### PR TITLE
Fixed undefined property notice on status page

### DIFF
--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1029,6 +1029,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 			if ( empty( $form_ids ) ) {
 				$results            = new stdClass();
+				$results->total     = 0;
 				$results->pending   = 0;
 				$results->complete  = 0;
 				$results->cancelled = 0;


### PR DESCRIPTION
When retrieving the counts for the workflow status page, if no workflow form IDs are found, a new standard results class is created setting the result counts to 0. However, the total result count is not set and throws a PHP undefined property notice on the workflow status page.