### PR TITLE
Fix gravityview single entry view

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 
+- Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5290,6 +5290,7 @@ AND m.meta_value='queued'";
 			$steps = $api->get_steps();
 
 			if ( ! empty( $steps ) ) {
+				gform_add_meta( $entry['id'], 'workflow_final_status', 'pending', $form['id'] );
 				$this->log_debug( __METHOD__ . '(): triggering workflow for entry ID: ' . $entry['id'] );
 				gravity_flow()->maybe_process_feed( $entry, $form );
 				$api->process_workflow( $entry['id'] );
@@ -5869,7 +5870,9 @@ AND m.meta_value='queued'";
 
 			$keys = array();
 
-			if ( isset( $search_criteria['search_criteria']['field_filters'] ) && is_array( $search_criteria['search_criteria']['field_filters'] ) ) {
+			// Add the workflow assignee entry meta to the entry.
+			// This is necessary because assignee meta keys are not registered so they're not added automatically to the entry.
+			if ( isset( $criteria['search_criteria']['field_filters'] ) && is_array( $criteria['search_criteria']['field_filters'] ) ) {
 				foreach ( $criteria['search_criteria']['field_filters'] as $filter ) {
 					if ( is_array( $filter ) && strpos( $filter['key'], 'workflow_' ) !== false && ! isset( $entry[ $filter['key'] ] ) ) {
 						$meta_value              = gform_get_meta( $entry['id'], $filter['key'] );

--- a/includes/steps/class-common-step-settings.php
+++ b/includes/steps/class-common-step-settings.php
@@ -293,7 +293,7 @@ class Gravity_Flow_Common_Step_Settings {
 			'name_prefix'            => 'assignee',
 			'label'                  => '',
 			'tooltip'                => '',
-			'checkbox_label'         => __( 'Assignee Email', 'gravityflow' ),
+			'checkbox_label'         => __( 'Send an email to the assignee', 'gravityflow' ),
 			'checkbox_tooltip'       => __( 'Enable this setting to send email to each of the assignees as soon as the entry has been assigned. If a role is configured to receive emails then all the users with that role will receive the email.', 'gravityflow' ),
 			'checkbox_default_value' => false,
 			'default_message'        => '',


### PR DESCRIPTION
- Fixes authentication for single views when an assignee is defined in the Advanced Filter criteria. 
- Fix an issue where entries added by GFAPI don't have a final status set
- Fix the default text for the email assignee checkbox label