### PR TITLE
Sliced Invoices enhancements

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,13 +2,14 @@
 - Added the ability to configure emails to be sent when a User Input step updates the entry and remains in progress and when the step is completed.
 - Added the date field option to the step expiration setting.
 - Added new functionality to the Sliced Invoices step:
-	- Setting enabling the entry order summary to be used as the invoice/quote line items.
-	- Settings for the default status of the created invoices and quotes.
-	- The Assign To, Assignee Email, Instructions, and Display Fields settings.
+	- The Assign To, Assignee Email, Instructions, Display Fields, and Expiration settings.
 	- The Step Completion setting allowing completion of the step to be delayed until the invoice is paid.
 	- When the step is pending invoice payment the invoice details will be displayed in the workflow detail box on the inbox detail page.
 - Fixed an issue with the notification message when the Discussion field merge tag content exceeded the max line length.
 - Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.
 - Updated the "no assignees" note from "not required" which could have been confusing in some situations.
+- Updated the feed configuration page for the Sliced Invoices & Gravity Forms Add-On:
+	- Added settings for the default status of the invoice/quote.
+	- Updated the choices for the Line Items map field to only include List type fields and the option to use the entry order summary.
 - Renamed the User Input step 'Default Status Option' setting to 'Save Progress Option' and changed the setting type from radio buttons to drop down.
 

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,8 +1,12 @@
 - Added support for unfiltered HTML in the instructions setting for users with the unfiltered_html capability.
 - Added the ability to configure emails to be sent when a User Input step updates the entry and remains in progress and when the step is completed.
 - Added the date field option to the step expiration setting.
-- Added the Step Completion setting to the Sliced Invoices step allowing the step to remain pending until the created invoices have been paid.
-- Added the invoice details and preview button to the workflow detail box for the Sliced Invoices step.
+- Added new functionality to the Sliced Invoices step:
+	- Setting enabling the entry order summary to be used as the invoice/quote line items.
+	- Settings for the default status of the created invoices and quotes.
+	- The Assign To, Assignee Email, Instructions, and Display Fields settings.
+	- The Step Completion setting allowing completion of the step to be delayed until the invoice is paid.
+	- When the step is pending invoice payment the invoice details will be displayed in the workflow detail box on the inbox detail page.
 - Fixed an issue with the notification message when the Discussion field merge tag content exceeded the max line length.
 - Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.
 - Updated the "no assignees" note from "not required" which could have been confusing in some situations.

--- a/change_log.txt
+++ b/change_log.txt
@@ -5,5 +5,6 @@
 - Added the invoice details and preview button to the workflow detail box for the Sliced Invoices step.
 - Fixed an issue with the notification message when the Discussion field merge tag content exceeded the max line length.
 - Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.
+- Updated the "no assignees" note from "not required" which could have been confusing in some situations.
 - Renamed the User Input step 'Default Status Option' setting to 'Save Progress Option' and changed the setting type from radio buttons to drop down.
 

--- a/change_log.txt
+++ b/change_log.txt
@@ -4,4 +4,5 @@
 - Fixed an issue with the notification message when the Discussion field merge tag content exceeded the max line length.
 - Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.
 - Renamed the User Input step 'Default Status Option' setting to 'Save Progress Option' and changed the setting type from radio buttons to drop down.
+- Updated the Sliced Invoices step to remain pending when the processed feed creates an invoice, until the invoice is paid.
 

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,8 +1,9 @@
 - Added support for unfiltered HTML in the instructions setting for users with the unfiltered_html capability.
 - Added the ability to configure emails to be sent when a User Input step updates the entry and remains in progress and when the step is completed.
 - Added the date field option to the step expiration setting.
+- Added the Step Completion setting to the Sliced Invoices step allowing the step to remain pending until the created invoices have been paid.
+- Added the invoice details and preview button to the workflow detail box for the Sliced Invoices step.
 - Fixed an issue with the notification message when the Discussion field merge tag content exceeded the max line length.
 - Fixed an issue with the GravityView integration where the single view doesn't display if an assignee is defined the Advanced Filter criteria.
 - Renamed the User Input step 'Default Status Option' setting to 'Save Progress Option' and changed the setting type from radio buttons to drop down.
-- Updated the Sliced Invoices step to remain pending when the processed feed creates an invoice, until the invoice is paid.
 

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -24,6 +24,92 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 		return esc_html__( 'Sliced Invoices', 'gravityflow' );
 	}
 
+	/**
+	 * Processes the given feed for the add-on.
+	 *
+	 * @since 1.6.1-dev-2
+	 *
+	 * @param array $feed The feed to be processed.
+	 *
+	 * @return bool Returning false if the feed created an invoice to ensure the next step is not processed until after the invoice is paid.
+	 */
+	public function process_feed( $feed ) {
+		if ( rgars( $feed, 'meta/post_type' ) !== 'invoice' ) {
+			return parent::process_feed( $feed );
+		}
+
+		add_action( 'sliced_gravityforms_feed_processed', array( $this, 'sliced_gravityforms_feed_processed' ), 10, 3 );
+		parent::process_feed( $feed );
+		remove_action( 'sliced_gravityforms_feed_processed', array( $this, 'sliced_gravityforms_feed_processed' ) );
+
+		return false;
+	}
+
+	/**
+	 * Store the entry, feed, and step IDs in the invoice (post) meta.
+	 *
+	 * @since 1.6.1-dev-2
+	 *
+	 * @param int   $id    The invoice (post) ID.
+	 * @param array $feed  The feed which created the invoice.
+	 * @param array $entry The entry which created the invoice.
+	 */
+	public function sliced_gravityforms_feed_processed( $id, $feed, $entry ) {
+		update_post_meta( $id, '_gform-entry-id', rgar( $entry, 'id' ) );
+		update_post_meta( $id, '_gform-feed-id', rgar( $feed, 'id' ) );
+		update_post_meta( $id, '_gravityflow-step-id', $this->get_id() );
+	}
+
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Sliced_Invoices() );
+
+/**
+ * Resume the workflow if the invoice is paid and originated from a feed processed by one of our steps.
+ *
+ * @since 1.6.1-dev-2
+ *
+ * @param string $id     The invoice (post) ID.
+ * @param string $status The invoice status.
+ */
+function gravity_flow_step_sliced_invoice_status_update( $id, $status ) {
+	if ( $status !== 'paid' ) {
+		return;
+	}
+
+	$entry_id = get_post_meta( $id, '_gform-entry-id', true );
+	$feed_id  = get_post_meta( $id, '_gform-feed-id', true );
+	$step_id  = get_post_meta( $id, '_gravityflow-step-id', true );
+
+	if ( ! $entry_id || ! $feed_id || ! $step_id ) {
+		return;
+	}
+
+	$entry = GFAPI::get_entry( $entry_id );
+
+	if ( ! is_wp_error( $entry ) && rgar( $entry, 'workflow_final_status' ) === 'pending' ) {
+		$api = new Gravity_Flow_API( $entry['form_id'] );
+
+		/* @var Gravity_Flow_Step_Feed_Sliced_Invoices $step */
+		$step = $api->get_current_step( $entry );
+
+		if ( $step && $step->get_id() == $step_id ) {
+			$feed  = gravity_flow()->get_feed( $feed_id );
+			$label = $step->get_feed_label( $feed );
+			$note  = sprintf( esc_html__( 'Invoice paid: %s', 'gravityflow' ), $label );
+			$step->log_debug( __METHOD__ . '() - Feed processing complete: ' . $label );
+			$step->add_note( $note, 0, $step->get_type() );
+
+			$add_on_feeds = $step->get_processed_add_on_feeds( $entry_id );
+			if ( ! in_array( $feed_id, $add_on_feeds ) ) {
+				$add_on_feeds[] = $feed_id;
+				$step->update_processed_feeds( $add_on_feeds, $entry_id );
+				$form = GFAPI::get_form( $entry['form_id'] );
+				gravity_flow()->process_workflow( $form, $entry_id );
+			}
+		}
+	}
+
+}
+
+add_action( 'sliced_invoice_status_update', 'gravity_flow_step_sliced_invoice_status_update', 10, 2 );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -25,6 +25,33 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 	}
 
 	/**
+	 * Returns the settings for this step.
+	 *
+	 * @since 1.6.1-dev-2 Added the Step Completion setting.
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+		$settings = parent::get_settings();
+
+		if ( ! $this->is_supported() ) {
+			return $settings;
+		}
+
+		$settings['fields'][] = array(
+			'name'    => 'post_feed_completion',
+			'type'    => 'select',
+			'label'   => __( 'Step Completion', 'gravityflow' ),
+			'choices' => array(
+				array( 'label' => __( 'Immediately following feed processing', 'gravityflow' ), 'value' => '' ),
+				array( 'label' => __( 'Delay until invoices are paid', 'gravityflow' ), 'value' => 'delayed' ),
+			),
+		);
+
+		return $settings;
+	}
+
+	/**
 	 * Processes the given feed for the add-on.
 	 *
 	 * @since 1.6.1-dev-2
@@ -34,7 +61,7 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 	 * @return bool Returning false if the feed created an invoice to ensure the next step is not processed until after the invoice is paid.
 	 */
 	public function process_feed( $feed ) {
-		if ( rgars( $feed, 'meta/post_type' ) !== 'invoice' ) {
+		if ( rgars( $feed, 'meta/post_type' ) !== 'invoice' || $this->post_feed_completion !== 'delayed' ) {
 			return parent::process_feed( $feed );
 		}
 

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -106,6 +106,10 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 	 * @return bool Returning false if the feed created an invoice to ensure the next step is not processed until after the invoice is paid.
 	 */
 	public function process_feed( $feed ) {
+		if ( $this->product_line_items_enabled ) {
+			$feed['meta']['mappedFields_line_items'] = '';
+		}
+
 		add_action( 'sliced_gravityforms_feed_processed', array( $this, 'sliced_gravityforms_feed_processed' ), 1, 3 );
 		parent::process_feed( $feed );
 		remove_action( 'sliced_gravityforms_feed_processed', array( $this, 'sliced_gravityforms_feed_processed' ), 1 );
@@ -205,6 +209,9 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 		if ( ! empty( $invoices ) ) {
 			echo sprintf( '<h4 style="margin-bottom:10px;">%s</h4>', $this->get_label() );
 
+			$assignee_key = gravity_flow()->get_current_user_assignee_key();
+			$is_assignee  = $this->is_assignee( $assignee_key );
+
 			/* @var WP_Post $invoice */
 			foreach ( $invoices as $invoice ) {
 				$title = $invoice->post_title;
@@ -227,6 +234,9 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 				}
 
 				echo '<div class="gravityflow-action-buttons">';
+				if ( $is_assignee ) {
+					echo sprintf( '<a href="%s" target="_blank" class="button button-large button-primary">%s</a> ', get_edit_post_link( $invoice->ID ), esc_html__( 'Edit', 'gravityflow' ) );
+				}
 				echo sprintf( '<a href="%s" target="_blank" class="button button-large button-primary">%s</a><br><br>', get_permalink( $invoice ), esc_html__( 'Preview', 'gravityflow' ) );
 				echo '</div>';
 

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -162,6 +162,10 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 				echo sprintf( '%s: %s<br><br>', esc_html__( 'Title', 'gravityflow' ), esc_html( $title ) );
 				echo sprintf( '%s: %s<br><br>', esc_html__( 'Number', 'gravityflow' ), esc_html( get_post_meta( $invoice->ID, '_sliced_invoice_number', true ) ) );
 
+				if ( function_exists( 'sliced_get_invoice_total' ) ) {
+					echo sprintf( '%s: %s<br><br>', esc_html__( 'Total', 'gravityflow' ), esc_html( sliced_get_invoice_total( $invoice->ID ) ) );
+				}
+
 				if ( class_exists( 'Sliced_Shared' ) ) {
 					echo sprintf( '%s: %s<br><br>', esc_html__( 'Status', 'gravityflow' ), esc_html( Sliced_Shared::get_status( $invoice->ID, 'invoice' ) ) );
 				}

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -87,6 +87,60 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 		update_post_meta( $id, '_gravityflow-step-id', $this->get_id() );
 	}
 
+	/**
+	 * Display the workflow detail box for this step.
+	 *
+	 * @since 1.6.1-dev-2
+	 *
+	 * @param array $form The current form.
+	 * @param array $args The page arguments.
+	 */
+	public function workflow_detail_box( $form, $args ) {
+		$args = array(
+			'post_type'  => 'sliced_invoice',
+			'meta_query' => array(
+				array(
+					'key'   => '_gform-entry-id',
+					'value' => $this->get_entry_id(),
+				),
+				array(
+					'key'   => '_gravityflow-step-id',
+					'value' => $this->get_id(),
+				),
+			),
+		);
+
+		$invoices = get_posts( $args );
+
+		if ( ! empty( $invoices ) ) {
+			echo sprintf( '<h4 style="margin-bottom:10px;">%s</h4>', $this->get_label() );
+
+			/* @var WP_Post $invoice */
+			foreach ( $invoices as $invoice ) {
+				$title = $invoice->post_title;
+
+				if ( ! $title ) {
+					$feed_id = $feed_id = get_post_meta( $invoice->ID, '_gform-feed-id', true );
+					$feed    = gravity_flow()->get_feed( $feed_id );
+					$title   = rgar( $feed['meta'], 'feedName' );
+				}
+
+				echo sprintf( '%s: %s<br><br>', esc_html__( 'Title', 'gravityflow' ), esc_html( $title ) );
+				echo sprintf( '%s: %s<br><br>', esc_html__( 'Number', 'gravityflow' ), esc_html( get_post_meta( $invoice->ID, '_sliced_invoice_number', true ) ) );
+
+				if ( class_exists( 'Sliced_Shared' ) ) {
+					echo sprintf( '%s: %s<br><br>', esc_html__( 'Status', 'gravityflow' ), esc_html( Sliced_Shared::get_status( $invoice->ID, 'invoice' ) ) );
+				}
+
+				echo '<div class="gravityflow-action-buttons">';
+				echo sprintf( '<a href="%s" target="_blank" class="button button-large button-primary">%s</a><br><br>', get_permalink( $invoice ), esc_html__( 'Preview', 'gravityflow' ) );
+				echo '</div>';
+
+			}
+
+		}
+	}
+
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Sliced_Invoices() );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -210,14 +210,14 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 			echo sprintf( '<h4 style="margin-bottom:10px;">%s</h4>', $this->get_label() );
 
 			$assignee_key = gravity_flow()->get_current_user_assignee_key();
-			$is_assignee  = $this->is_assignee( $assignee_key );
+			$can_edit     = $this->is_assignee( $assignee_key ) && current_user_can( 'edit_posts' );
 
 			/* @var WP_Post $invoice */
 			foreach ( $invoices as $invoice ) {
 				$title = $invoice->post_title;
 
 				if ( ! $title ) {
-					$feed_id = $feed_id = get_post_meta( $invoice->ID, '_gform-feed-id', true );
+					$feed_id = get_post_meta( $invoice->ID, '_gform-feed-id', true );
 					$feed    = gravity_flow()->get_feed( $feed_id );
 					$title   = rgar( $feed['meta'], 'feedName' );
 				}
@@ -234,7 +234,7 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 				}
 
 				echo '<div class="gravityflow-action-buttons">';
-				if ( $is_assignee ) {
+				if ( $can_edit ) {
 					echo sprintf( '<a href="%s" target="_blank" class="button button-large button-primary">%s</a> ', get_edit_post_link( $invoice->ID ), esc_html__( 'Edit', 'gravityflow' ) );
 				}
 				echo sprintf( '<a href="%s" target="_blank" class="button button-large button-primary">%s</a><br><br>', get_permalink( $invoice ), esc_html__( 'Preview', 'gravityflow' ) );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -278,6 +278,38 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 	}
 
 	/**
+	 * When restarting the workflow or step delete the step ID from the post meta of the invoices which already exist.
+	 *
+	 * @since 1.6.1-dev-2
+	 */
+	public function restart_action() {
+		$args = array(
+			'post_type'  => 'sliced_invoice',
+			'meta_query' => array(
+				array(
+					'key'   => '_gform-entry-id',
+					'value' => $this->get_entry_id(),
+				),
+				array(
+					'key'   => '_gravityflow-step-id',
+					'value' => $this->get_id(),
+				),
+			),
+		);
+
+		$invoices = get_posts( $args );
+
+		if ( empty( $invoices ) ) {
+			return;
+		}
+
+		/* @var WP_Post $invoice */
+		foreach ( $invoices as $invoice ) {
+			delete_post_meta( $invoice->ID, '_gravityflow-step-id' );
+		}
+	}
+
+	/**
 	 * Resume the workflow if the invoice is paid and originated from a feed processed by one of our steps.
 	 *
 	 * @since 1.6.1-dev-2

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -139,6 +139,9 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 				update_post_meta( $id, '_gform-entry-id', rgar( $entry, 'id' ) );
 				update_post_meta( $id, '_gform-feed-id', rgar( $feed, 'id' ) );
 				update_post_meta( $id, '_gravityflow-step-id', $this->get_id() );
+				if ( function_exists( 'sliced_get_accepted_payment_methods' ) ) {
+					update_post_meta( $id, '_sliced_payment_methods', array_keys( sliced_get_accepted_payment_methods() ) );
+				}
 			}
 
 			$invoice_status = rgars( $feed, 'meta/invoice_status' );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -38,17 +38,51 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 			return $settings;
 		}
 
-		$settings['fields'][] = array(
-			'name'    => 'post_feed_completion',
-			'type'    => 'select',
-			'label'   => __( 'Step Completion', 'gravityflow' ),
-			'choices' => array(
-				array( 'label' => __( 'Immediately following feed processing', 'gravityflow' ), 'value' => '' ),
-				array( 'label' => __( 'Delay until invoices are paid', 'gravityflow' ), 'value' => 'delayed' ),
-			),
+		$settings_api = $this->get_common_settings_api();
+
+		$fields = array(
+			$settings_api->get_setting_assignee_type(),
+			$settings_api->get_setting_assignees(),
+			$settings_api->get_setting_assignee_routing(),
+			$settings_api->get_setting_notification_tabs( array(
+				array(
+					'label'  => __( 'Assignee Email', 'gravityflow' ),
+					'id'     => 'tab_assignee_notification',
+					'fields' => $settings_api->get_setting_notification( array(
+						'type' => 'assignee',
+					) ),
+				)
+			) ),
+			$settings_api->get_setting_instructions(),
+			$settings_api->get_setting_display_fields(),
+			array(
+				'name'    => 'post_feed_completion',
+				'type'    => 'select',
+				'label'   => __( 'Step Completion', 'gravityflow' ),
+				'choices' => array(
+					array( 'label' => __( 'Immediately following feed processing', 'gravityflow' ), 'value' => '' ),
+					array( 'label' => __( 'Delay until invoices are paid', 'gravityflow' ), 'value' => 'delayed' ),
+				),
+			)
 		);
 
+		$settings['fields'] = array_merge( $settings['fields'], $fields );
+
 		return $settings;
+	}
+
+	/**
+	 * Processes this step.
+	 *
+	 * @since 1.6.1-dev-2
+	 *
+	 * @return bool Is the step complete?
+	 */
+	public function process() {
+		$complete = parent::process();
+		$this->assign();
+
+		return $complete;
 	}
 
 	/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -793,7 +793,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		$assignees = $this->get_assignees();
 
 		if ( empty( $assignees ) ) {
-			$note = sprintf( __( '%s: not required', 'gravityflow' ), $this->get_name() );
+			$note = sprintf( __( '%s: No assignees', 'gravityflow' ), $this->get_name() );
 			$this->add_note( $note, 0, 'gravityflow' );
 		} else {
 			foreach ( $assignees as $assignee ) {


### PR DESCRIPTION
- Added the Line Items setting

  When enabled the entry product fields will be used to set the line items on the created invoice/estimate.

- Added the Assign To, Assignee Email, Instructions, and Display Fields settings.
- Added the 'Step Completion' setting

  The step will complete immediately following feed processing unless the completion setting is set to delayed and the feeds created invoices. When set to delayed the step will have a status of pending until the invoices are paid.

- Added invoices to the workflow detail box

  When step completion is delayed pending invoice payment the invoices will be listed in the workflow detail box for the step. Details include the invoice title or the feed name, the invoice number, the invoice total, the invoice status, and a preview button.

- Changed the "not required" note to "no assignees" to prevent confusion when step completion is delayed pending invoice payment.