### PR TITLE
add assignee policy enhancements

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -175,6 +175,9 @@ if ( class_exists( 'GFForms' ) ) {
 		}
 
 		public function upgrade( $previous_version ) {
+
+			wp_cache_flush();
+
 			if ( empty( $previous_version ) ) {
 				// New installation
 				$settings = $this->get_app_settings();
@@ -191,7 +194,14 @@ if ( class_exists( 'GFForms' ) ) {
 				if ( version_compare( $previous_version,'1.5.1', '<' ) ) {
 					$this->fix_workflow_field_choices();
 				}
+
+				if ( version_compare( $previous_version,'1.7.1-dev', '<' ) ) {
+					$this->upgrade_171();
+				}
 			}
+
+			wp_cache_flush();
+
 			$this->setup_db();
 		}
 
@@ -267,6 +277,36 @@ PRIMARY KEY  (id)
 				}
 				if ( $form_dirty ) {
 					GFAPI::update_form( $form );
+				}
+			}
+		}
+
+		public function upgrade_171() {
+			$steps = $this->get_steps();
+
+			foreach( $steps as $step ) {
+				$step_id = $step->get_id();
+				$step_dirty = false;
+				$feed_meta = $step->get_feed_meta();
+				$step_type = $step->get_type();
+
+				if ( $step_type == 'approval' && $step->type == 'select' ) {
+					$unanimous_approval = $step->unanimous_approval;
+					if ( ! $unanimous_approval ) {
+						$step->assignee_policy = 'any';
+					} else {
+						$step->assignee_policy = 'all';
+					}
+					$step_dirty = true;
+				}
+
+				if ( in_array( $step_type, array( 'approval', 'user_input' ) ) && $step->type == 'routing' ) {
+					$step->assignee_policy = 'all';
+					$step_dirty            = true;
+				}
+
+				if ( $step_dirty ) {
+					$this->save_feed_settings( $step->get_id(), $step->get_form_id(), $step->get_feed_meta() );
 				}
 			}
 		}

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -165,7 +165,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	}
 
 	public function get_settings() {
-        $settings_api = $this->get_common_settings_api();
+		$settings_api = $this->get_common_settings_api();
 
 		$settings = array(
 			'title'  => esc_html__( 'Approval', 'gravityflow' ),
@@ -174,19 +174,19 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 				$settings_api->get_setting_assignees(),
 				$settings_api->get_setting_assignee_routing(),
 				array(
-					'name'          => 'unanimous_approval',
+					'name'          => 'assignee_policy',
 					'label'         => __( 'Approval Policy', 'gravityflow' ),
 					'tooltip'       => __( 'Define how approvals should be processed. If all assignees must approve then the entry will require unanimous approval before the step can be completed. If the step is assigned to a role only one user in that role needs to approve.', 'gravityflow' ),
 					'type'          => 'radio',
-					'default_value' => false,
+					'default_value' => 'all',
 					'choices'       => array(
 						array(
-							'label' => __( 'At least one assignee must approve', 'gravityflow' ),
-							'value' => false,
+							'label' => __( 'Only one assignee is required to approve', 'gravityflow' ),
+							'value' => 'any',
 						),
 						array(
 							'label' => __( 'All assignees must approve', 'gravityflow' ),
-							'value' => true,
+							'value' => 'all',
 						),
 					),
 				),
@@ -234,7 +234,10 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		$steps                   = gravity_flow()->get_steps( $form_id );
 		foreach ( $steps as $step ) {
 			if ( $step->get_type() === 'user_input' ) {
-				$user_input_step_choices[] = array( 'label' => $step->get_name(), 'value' => $step->get_id() );
+				$user_input_step_choices[] = array(
+					'label' => $step->get_name(),
+					'value' => $step->get_id(),
+				);
 			}
 		}
 
@@ -265,11 +268,11 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 				array( 'value' => 'required', 'label' => esc_html__( 'Always required', 'gravityflow' ) ),
 				array(
 					'value' => 'required_if_approved',
-					'label' => esc_html__( 'Required if approved', 'gravityflow' )
+					'label' => esc_html__( 'Required if approved', 'gravityflow' ),
 				),
 				array(
 					'value' => 'required_if_rejected',
-					'label' => esc_html__( 'Required if rejected', 'gravityflow' )
+					'label' => esc_html__( 'Required if rejected', 'gravityflow' ),
 				),
 			),
 		);

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -342,7 +342,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 				$step_status = 'rejected';
 				break;
 			}
-			if ( $this->type == 'select' && ! $this->unanimous_approval ) {
+			if ( $this->assignee_policy == 'any' ) {
 				if ( $approver_status == 'approved' ) {
 					$step_status = 'approved';
 					break;

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -54,6 +54,24 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 					'type'     => 'editable_fields',
 				),
 				$settings_api->get_setting_assignee_routing(),
+				array(
+					'id'            => 'assignee_policy',
+					'name'          => 'assignee_policy',
+					'label'         => __( 'Assignee Policy', 'gravityflow' ),
+					'tooltip'       => __( 'Define how this step should be processed. If all assignees must complete this step then the entry will require input from every assignee before the step can be completed. If the step is assigned to a role only one user in that role needs to complete the step.', 'gravityflow' ),
+					'type'          => 'radio',
+					'default_value' => 'all',
+					'choices'       => array(
+						array(
+							'label' => __( 'Only one assignee is required to complete the step', 'gravityflow' ),
+							'value' => 'any',
+						),
+						array(
+							'label' => __( 'All assignees must complete this step', 'gravityflow' ),
+							'value' => 'all',
+						),
+					),
+				),
 			),
 		);
 
@@ -123,24 +141,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 						),
 					),
 					'tooltip' => esc_html__( 'Fields and Sections support dynamic conditional logic. Pages do not support dynamic conditional logic so they will only be shown or hidden when the page loads.', 'gravityflow' ),
-				),
-			),
-			array(
-				'id'            => 'assignee_policy',
-				'name'          => 'assignee_policy',
-				'label'         => __( 'Assignee Policy', 'gravityflow' ),
-				'tooltip'       => __( 'Define how this step should be processed. If all assignees must complete this step then the entry will require input from every assignee before the step can be completed. If the step is assigned to a role only one user in that role needs to complete the step.', 'gravityflow' ),
-				'type'          => 'radio',
-				'default_value' => 'all',
-				'choices'       => array(
-					array(
-						'label' => __( 'At least one assignee must complete this step', 'gravityflow' ),
-						'value' => 'any',
-					),
-					array(
-						'label' => __( 'All assignees must complete this step', 'gravityflow' ),
-						'value' => 'all',
-					),
 				),
 			),
 			$settings_api->get_setting_instructions(),
@@ -238,7 +238,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 		foreach ( $assignee_details as $assignee ) {
 			$user_status = $assignee->get_status();
 
-			if ( $this->type == 'select' && $this->assignee_policy == 'any' ) {
+			if ( $this->assignee_policy == 'any' ) {
 				if ( $user_status == 'complete' ) {
 					$step_status = 'complete';
 					break;

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -340,7 +340,7 @@
 
 	function toggleType(showType) {
 		var fields = {
-			select: ['assignees\\[\\]', 'editable_fields\\[\\]', 'conditional_logic_editable_fields_enabled', 'unanimous_approval', 'assignee_policy'],
+			select: ['assignees\\[\\]', 'editable_fields\\[\\]', 'conditional_logic_editable_fields_enabled'],
 			routing: ['routing', 'conditional_logic_editable_fields_enabled']
 		};
 
@@ -379,7 +379,6 @@
 		var subSettings = [
 			'routing',
 			'assignees\\[\\]',
-			'unanimous_approval',
 			'assignee_notification_from_name',
 			'assignee_notification_from_email',
 			'assignee_notification_reply_to',
@@ -416,10 +415,7 @@
 
 			'assignees\\[\\]',
 			'editable_fields\\[\\]',
-			'conditional_logic_editable_fields_enabled',
-			'highlight_editable_fields',
 			'routing',
-			'assignee_policy',
 			'assignee_notification_message',
 
 		];


### PR DESCRIPTION
- add support for the assignee policy when conditional assignee routing is enabled.
- upgrade settings to ensure the default value is correct
- replace the unanimous_approval setting with the assignee_policy setting for consistency
