### PR TITLE
Fix redirect bug when incorrect HTTP_HOST is passed / set (this is user supplied)

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4773,14 +4773,13 @@ AND m.meta_value='queued'";
 
 				if ( ! empty( $token ) && ! isset( $token['scopes']['action'] )&& ! is_user_logged_in() ) {
 					// Remove the token from the URL to avoid accidental sharing.
-					$secure = ( 'https' === parse_url( site_url(), PHP_URL_SCHEME ) );
+					$secure = ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) );
 					$sanitized_cookie = sanitize_text_field( $_GET['gflow_access_token'] );
 					setcookie( 'gflow_access_token', $sanitized_cookie, null, SITECOOKIEPATH, null, $secure, true );
-					$protocol = ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443 ) ? 'https://' : 'http://';
 
 					$request_uri = remove_query_arg( 'gflow_access_token' );
 
-					$redirect_url = $protocol . $_SERVER['HTTP_HOST'] . $request_uri;
+					$redirect_url = home_url() . $request_uri;
 
 					$this->log_debug( __METHOD__ . '(): redirect url: ' . $redirect_url );
 


### PR DESCRIPTION
Remove reliance on `$_SERVER` variables to determine protocol and site URL and use WordPress' in-built `home_url()` method instead (`home_url()` will point to the front end WordPress site, rather than where the WordPress files are located - `site_url()`)