### PR TITLE
Allow filtering of most columns in the status table

### DIFF
--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -668,6 +668,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$final_status = rgar( $item, 'workflow_final_status' );
 		$label = empty( $final_status ) ? '' : gravity_flow()->translate_status_label( $final_status );
 		$label = esc_html( $label );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'final_status', $item );
 		$url_entry = esc_url( $url_entry );
 		$link = "<a href='{$url_entry}'>$label</a>";
 

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -636,6 +636,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
 		$url_entry = esc_url( $url_entry );
 		$label = absint( $item['id'] );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'id', $item );
 
 		$link = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -656,6 +657,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		}
 
 		$label = esc_html( $value );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], $column_name, $item );
 
 		$link = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -786,6 +788,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		 * @param array $form The form object for the current entry.
 		 */
 		$label = apply_filters( 'gravityflow_status_submitter_name', $label, $item, $form );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'created_by', $item );
 
 		$url_entry = esc_url( $url_entry );
 
@@ -800,6 +803,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$form    = $this->get_form( $form_id );
 
 		$label = esc_html( $form['title'] );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'form_id', $item );
 
 		$url_entry = esc_url( $url_entry );
 
@@ -816,6 +820,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$url_entry = esc_url( $url_entry );
 
 			$label = $step ? esc_html( $step->get_name() ) : '';
+			$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'workflow_step', $item );
 			$link  = "<a href='{$url_entry}'>$label</a>";
 			$output = $link;
 		} else {
@@ -836,6 +841,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
 		$url_entry = esc_url( $url_entry );
 		$label = GFCommon::format_date( $item['date_created'] );
+		$label = apply_filters( 'gravityflow_status_field_value', $label, $item['form_id'], 'date_created', $item );
 		$link  = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
 	}
@@ -847,6 +853,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$last_updated = date( 'Y-m-d H:i:s', $item['workflow_timestamp'] );
 			$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
 			$last_updated = esc_html( GFCommon::format_date( $last_updated, true, 'Y/m/d' ) );
+			$last_updated = apply_filters( 'gravityflow_status_field_value', $last_updated, $item['form_id'], 'workflow_timestamp', $item );
 			$url_entry = esc_url( $url_entry );
 			$label  = "<a href='{$url_entry}'>$last_updated</a>";
 		}


### PR DESCRIPTION
This allows more extensibility by developers who want to give more form-specific information for each row. The name and filter structure were borrowed from the 'gform_entries_field_value' filter in the Inbox table.