### PR TITLE
add user to assignee

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4891,6 +4891,12 @@ AND m.meta_value='queued'";
 				);
 			}
 
+			$user = $assignee->get_user();
+
+			if ( ! empty( $user ) ) {
+				$scopes['user_id'] = $user->ID;
+			}
+
 			if ( empty( $expiration_timestamp ) ) {
 				$expiration_timestamp = strtotime( '+30 days' );
 			}

--- a/includes/class-assignee.php
+++ b/includes/class-assignee.php
@@ -141,7 +141,7 @@ class Gravity_Flow_Assignee {
 	 *
 	 * @since 1.7.1
 	 */
-	public function maybe_set_user() {
+	private function maybe_set_user() {
 		if ( ! $this->get_user() ) {
 			if ( $this->get_type() === 'user_id' ) {
 				$user = get_user_by( 'ID', $this->get_id() );

--- a/includes/class-assignee.php
+++ b/includes/class-assignee.php
@@ -111,6 +111,9 @@ class Gravity_Flow_Assignee {
 				$entry      = $this->step->get_entry();
 				$this->id   = absint( rgar( $entry, $id ) );
 				$this->type = 'user_id';
+				if ( ! isset( $this->user ) ) {
+					$this->user = get_user_by( 'ID', $this->id );
+				}
 				break;
 			case  'assignee_role_field' :
 				$entry      = $this->step->get_entry();
@@ -121,6 +124,12 @@ class Gravity_Flow_Assignee {
 				$entry      = $this->step->get_entry();
 				$this->id   = sanitize_email( rgar( $entry, $id ) );
 				$this->type = 'email';
+				if ( ! isset( $this->user ) ) {
+					$user = get_user_by( 'email', $this->id );
+					if ( $user ) {
+						$this->user = $user;
+					}
+				}
 				break;
 			case 'entry' :
 				$entry      = $this->step->get_entry();
@@ -130,6 +139,10 @@ class Gravity_Flow_Assignee {
 			default :
 				$this->type = $type;
 				$this->id   = $id;
+		}
+
+		if ( $this->type == 'user_id' && ! isset( $this->user ) ) {
+			$this->user = get_user_by( 'ID', $this->id );
 		}
 
 		$this->key = $this->type . '|' . $this->id;

--- a/includes/class-assignee.php
+++ b/includes/class-assignee.php
@@ -16,12 +16,61 @@ if ( ! class_exists( 'GFForms' ) ) {
 }
 
 class Gravity_Flow_Assignee {
+
+	/**
+	 * The ID of this assignee.
+	 *
+	 * @since 1.0
+	 *
+	 * @var string
+	 */
 	protected $id;
+
+	/* @var string The Type of this assignee */
+
+	/**
+	 * The Type of this assignee.
+	 *
+	 * @since 1.0
+	 *
+	 * @var string
+	 */
 	protected $type;
+
+	/**
+	 * The Assignee key.
+	 *
+	 * @since 1.0
+	 *
+	 * @var string
+	 */
 	protected $key;
+
+	/**
+	 * The editable fields for this assignee.
+	 *
+	 * @since 1.0
+	 *
+	 * @var array
+	 */
 	protected $editable_fields = array();
 
-	/* @var Gravity_Flow_Step|bool */
+	/**
+	 * The WordPress user account for this assignee
+	 *
+	 * @since 1.7.1
+	 *
+	 * @var WP_User
+	 */
+	protected $user = null;
+
+	/**
+	 * The step.
+	 *
+	 * @since 1.0
+	 *
+	 * @var Gravity_Flow_Step|bool
+	 */
 	protected $step;
 
 	/**
@@ -44,6 +93,9 @@ class Gravity_Flow_Assignee {
 			$type = $args['type'];
 			if ( isset( $args['editable_fields'] ) ) {
 				$this->editable_fields = $args['editable_fields'];
+			}
+			if ( isset( $args['user'] ) && $args['user'] instanceof WP_User ) {
+				$this->user = $args['user'];
 			}
 		} else {
 			throw new Exception( 'Assignees must be instantiated with either a string or an array' );
@@ -99,6 +151,16 @@ class Gravity_Flow_Assignee {
 		return $this->editable_fields;
 	}
 
+	/**
+	 * Returns the user account for this assignee.
+	 *
+	 * @since 1.7.1
+	 *
+	 * @return WP_User
+	 */
+	public function get_user() {
+		return $this->user;
+	}
 
 	/**
 	 * Returns the status.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -990,15 +990,15 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 		$user_assignee_args = array(
 			'type' => $assignee_type,
-			'id' => $assignee_id,
+			'id'   => $assignee_id,
 		);
 		foreach ( $users as $user ) {
 			$user_assignee_args['user'] = $user;
-			$user_assignee = new Gravity_Flow_Assignee( $user_assignee_args, $this );
-			$notification['id']      = 'workflow_step_' . $this->get_id() . '_user_' . $user->ID;
-			$notification['name']    = $notification['id'];
-			$notification['to']      = $user->user_email;
-			$notification['message'] = $this->replace_variables( $message, $user_assignee );
+			$user_assignee              = $this->get_assignee( $user_assignee_args );
+			$notification['id']         = 'workflow_step_' . $this->get_id() . '_user_' . $user->ID;
+			$notification['name']       = $notification['id'];
+			$notification['to']         = $user->user_email;
+			$notification['message']    = $this->replace_variables( $message, $user_assignee );
 			$this->send_notification( $notification );
 		}
 	}

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -988,11 +988,17 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 		$this->log_debug( __METHOD__ . sprintf( '() sending assignee notifications to %d users', count( $users ) ) );
 
+		$user_assignee_args = array(
+			'type' => $assignee_type,
+			'id' => $assignee_id,
+		);
 		foreach ( $users as $user ) {
+			$user_assignee_args['user'] = $user;
+			$user_assignee = new Gravity_Flow_Assignee( $user_assignee_args, $this );
 			$notification['id']      = 'workflow_step_' . $this->get_id() . '_user_' . $user->ID;
 			$notification['name']    = $notification['id'];
 			$notification['to']      = $user->user_email;
-			$notification['message'] = $this->replace_variables( $message, $assignee );
+			$notification['message'] = $this->replace_variables( $message, $user_assignee );
 			$this->send_notification( $notification );
 		}
 	}


### PR DESCRIPTION
Currently, the one-click tokens for roles don't include the ID of the user. This PR allows the tokens for role assignee to include the user ID. See [HS#4131](https://secure.helpscout.net/conversation/397448673/4131/?folderId=516732). It also opens the way for a {assignee:[meta_key]} merge tag like the {created_by} merge tag.