### PR TITLE
Swap `return` to `continue` so all assignee's in the loop can be processed

### DIFF
--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1875,7 +1875,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 				$notification['message'] = $this->replace_variables( $message, $assignee );
 				$this->send_notification( $notification );
 
-				return;
+				continue;
 			}
 
 


### PR DESCRIPTION
Noticed this issue when using the Notification step with multiple assignees and only one email was going out.