### PR TITLE
fixed empty fields being displayed

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+Fixed empty fields being displayed on the user input step when 'show empty fields' was not enabled.

--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -490,7 +490,9 @@ class Gravity_Flow_Entry_Editor {
 			return $html;
 		}
 
-		$html = '<div style="display:none;">' . $html . '</div>';
+		if ( $html ) {
+			$html = '<div style="display:none;">' . $html . '</div>';
+		}
 
 		$value = $this->maybe_get_product_calculation_value( $value, $field );
 


### PR DESCRIPTION
re: [HS#4202](https://secure.helpscout.net/conversation/402995135/4202/?folderId=793490)

Fixes empty fields being displayed on the user input step when 'show empty fields' is not checked.