### PR TITLE
check current step before processing status update

### DIFF
--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -303,7 +303,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 
 		$form_id = $form['id'];
 
-		if ( isset( $_POST['gforms_save_entry'] ) && check_admin_referer( 'gforms_save_entry', 'gforms_save_entry' ) ) {
+		if ( isset( $_POST['gforms_save_entry'] ) && rgpost( 'step_id' ) == $this->get_id() && check_admin_referer( 'gforms_save_entry', 'gforms_save_entry' ) ) {
 
 			$new_status = rgpost( 'gravityflow_status' );
 


### PR DESCRIPTION
Reloading the page after submitting a User Input step can complete the next User Input step. I couldn't reproduce the issue on any browser in OSX but I reproduced the issue in Microsoft Edge on Windows 10. This PR adds a check for the current step ID just before processing the status update. [HS#4218](https://secure.helpscout.net/conversation/404986229/4218/?folderId=516731)