### PR TITLE
Fix filters when gravityflow_status_view_all cap is set

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -6,3 +6,4 @@ Added the Raw body setting to the OUtgoing webhook step settings.
 Fixed an issue populating multi-select fields with the existing entry value on the user input step when the field uses the new json storageType.
 Fixed the $original_entry parameter not being passed when the gform_after_update_entry hook is triggered on entry update by the user input step.
 Fixed empty fields being displayed on the user input step when 'show empty fields' was not enabled.
+Fixed an issue with the shortcode where the gravityflow_status_filter and gravityflow_permission_granted_entry_detail filters don't fire.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4215,9 +4215,6 @@ PRIMARY KEY  (id)
 				'detail_base_url'    => add_query_arg( array( 'page' => 'gravityflow-inbox', 'view' => 'entry' ) ),
 				'display_header'     => false,
 				'action_url'         => 'http' . ( isset( $_SERVER['HTTPS'] ) ? 's' : '' ) . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}?",
-				'constraint_filters' => array(
-					'form_id' => $a['form'],
-				),
 				'field_ids'          => $a['fields'] ? explode( ',', $a['fields'] ) : '',
 				'display_all'        => $a['display_all'],
 				'id_column'          => $a['id_column'],
@@ -4229,6 +4226,12 @@ PRIMARY KEY  (id)
 				'workflow_info'      => $a['workflow_info'],
 				'sidebar'            => $a['sidebar'],
 			);
+
+			if ( isset( $a['form'] ) ) {
+				$args['constraint_filters'] = array(
+					'form_id' => $a['form'],
+				);
+			}
 
 			if ( ! is_user_logged_in() && $a['allow_anonymous'] ) {
 				$args['bulk_actions'] = array();

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -48,16 +48,27 @@ class Gravity_Flow_Entry_Detail {
 			<?php
 			self::maybe_show_header( $form, $args );
 
-			if ( $check_view_entry_permissions ) {
-				$permission_granted = self::is_permission_granted( $entry, $form, $current_step );
+			$permission_granted = $check_view_entry_permissions ? self::is_permission_granted( $entry, $form, $current_step ) : true;
 
-				if ( ! $permission_granted ) {
-					$permission_denied_message = esc_attr__( "You don't have permission to view this entry.", 'gravityflow' );
-					$permission_denied_message = apply_filters( 'gravityflow_permission_denied_message_entry_detail', $permission_denied_message, $current_step );
-					echo $permission_denied_message;
+			/**
+			 * Allows the the permission check to be overridden for the workflow entry detail page.
+			 *
+			 * @param bool $permission_granted Whether permission is granted to open the entry.
+			 * @param array $entry
+			 * @param array $form
+			 * @param Gravity_Flow_Step $current_step
+			 */
+			$permission_granted = apply_filters( 'gravityflow_permission_granted_entry_detail', $permission_granted, $entry, $form, $current_step );
 
-					return;
-				}
+			gravity_flow()->log_debug( __METHOD__ . '() $permission_granted: ' . ( $permission_granted ? 'yes' : 'no' ) );
+
+
+			if ( ! $permission_granted ) {
+				$permission_denied_message = esc_attr__( "You don't have permission to view this entry.", 'gravityflow' );
+				$permission_denied_message = apply_filters( 'gravityflow_permission_denied_message_entry_detail', $permission_denied_message, $current_step );
+				echo $permission_denied_message;
+
+				return;
 			}
 
 			$url     = remove_query_arg( array( 'gworkflow_token', 'new_status' ) );
@@ -299,18 +310,6 @@ class Gravity_Flow_Entry_Detail {
 				$permission_granted = true;
 			}
 		}
-
-		/**
-		 * Allows the the permission check to be overridden for the workflow entry detail page.
-		 *
-		 * @param bool $permission_granted Whether permission is granted to open the entry.
-		 * @param array $entry
-		 * @param array $form
-		 * @param Gravity_Flow_Step $current_step
-		 */
-		$permission_granted = apply_filters( 'gravityflow_permission_granted_entry_detail', $permission_granted, $entry, $form, $current_step );
-
-		gravity_flow()->log_debug( __METHOD__ . '() $permission_granted: ' . ( $permission_granted ? 'yes' : 'no' ) );
 
 		return $permission_granted;
 	}

--- a/includes/pages/class-print-entries.php
+++ b/includes/pages/class-print-entries.php
@@ -53,7 +53,19 @@ class Gravity_Flow_Print_Entries {
 
 				require_once( $gravity_flow->get_base_path() . '/includes/pages/class-entry-detail.php' );
 
-				if ( ! Gravity_Flow_Entry_Detail::is_permission_granted( $entry, $form, $current_step ) ) {
+				$permission_granted = Gravity_Flow_Entry_Detail::is_permission_granted( $entry, $form, $current_step );
+
+				/**
+				 * Allows the the permission check to be overridden for the workflow entry detail page.
+				 *
+				 * @param bool $permission_granted Whether permission is granted to open the entry.
+				 * @param array $entry
+				 * @param array $form
+				 * @param Gravity_Flow_Step $current_step
+				 */
+				$permission_granted = apply_filters( 'gravityflow_permission_granted_entry_detail', $permission_granted, $entry, $form, $current_step );
+
+				if ( ! $permission_granted ) {
 					esc_attr_e( "You don't have permission to view this entry.", 'gravityflow' );
 					continue;
 				}

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -68,13 +68,17 @@ class Gravity_Flow_Status {
 	 * @return array
 	 */
 	public static function maybe_add_constraint_filters( $args ) {
+
 		if ( empty( $args['constraint_filters'] ) ) {
-			$args['constraint_filters'] = apply_filters( 'gravityflow_status_filter', array(
+			$args['constraint_filters'] = array(
 				'form_id'    => 0,
 				'start_date' => '',
 				'end_date'   => '',
-			) );
+			);
 		}
+
+		$args['constraint_filters'] = apply_filters( 'gravityflow_status_filter', $args['constraint_filters'] );
+
 		if ( ! isset( $args['constraint_filters']['form_id'] ) ) {
 			$args['constraint_filters']['form_id'] = 0;
 		}


### PR DESCRIPTION
The gravityflow_permission_granted_entry_detail and gravityflow_status_filter filters aren't firing for shortcodes and admin UI when the gravityflow_status_view_all cap is set.