### PR TITLE
Add modifier to limit user notes to most recent occurrence of the specified step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,7 +3,7 @@ Added the gravityflow_step_assignees filter.
 Added PATCH to the list of request methods in the request method setting of the Outgoing Webhook step settings.
 Added Headers to the Outgoing Webhook step settings.
 Added the Raw body setting to the OUtgoing webhook step settings.
-Updated the {workflow_note} merge tag to support the all_occurrences modifier when using the step_id modifier e.g. {workflow_note:step_id=5 all_occurrences=false}.
+Updated the {workflow_note} merge tag to support the history modifier to control if notes from previous occurrences of the step are output e.g. {workflow_note:step_id=5 history=true}.
 Fixed an issue populating multi-select fields with the existing entry value on the user input step when the field uses the new json storageType.
 Fixed the $original_entry parameter not being passed when the gform_after_update_entry hook is triggered on entry update by the user input step.
 Fixed empty fields being displayed on the user input step when 'show empty fields' was not enabled.

--- a/change_log.txt
+++ b/change_log.txt
@@ -3,6 +3,7 @@ Added the gravityflow_step_assignees filter.
 Added PATCH to the list of request methods in the request method setting of the Outgoing Webhook step settings.
 Added Headers to the Outgoing Webhook step settings.
 Added the Raw body setting to the OUtgoing webhook step settings.
+Updated the {workflow_note} merge tag to support the all_occurrences modifier when using the step_id modifier e.g. {workflow_note:step_id=5 all_occurrences=false}.
 Fixed an issue populating multi-select fields with the existing entry value on the user input step when the field uses the new json storageType.
 Fixed the $original_entry parameter not being passed when the gform_after_update_entry hook is triggered on entry update by the user input step.
 Fixed empty fields being displayed on the user input step when 'show empty fields' was not enabled.

--- a/includes/merge-tags/class-merge-tag-workflow-note.php
+++ b/includes/merge-tags/class-merge-tag-workflow-note.php
@@ -49,14 +49,14 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 				$modifiers = rgar( $match, 2 );
 
 				$a = $this->get_attributes( $modifiers, array(
-					'step_id'         => null,
-					'display_name'    => false,
-					'display_date'    => false,
-					'all_occurrences' => true,
+					'step_id'      => null,
+					'display_name' => false,
+					'display_date' => false,
+					'history'      => false,
 				) );
 
 				$replacement = '';
-				$notes       = $this->get_step_notes( $entry['id'], $a['step_id'], $a['all_occurrences'] );
+				$notes       = $this->get_step_notes( $entry['id'], $a['step_id'], $a['history'] );
 
 				if ( ! empty( $notes ) ) {
 					$replacement_array = array();
@@ -83,29 +83,25 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 	 *
 	 * @since 1.7.1-dev
 	 *
-	 * @param int      $entry_id        The current entry ID.
-	 * @param int|null $step_id         The step ID or null to return the most recent note.
-	 * @param bool     $all_occurrences Include notes from all occurrences of the specified step.
+	 * @param int      $entry_id The current entry ID.
+	 * @param int|null $step_id  The step ID or null to return the most recent note.
+	 * @param bool     $history  Include notes from previous occurrences of the specified step.
 	 *
 	 * @return array
 	 */
-	protected function get_step_notes( $entry_id, $step_id, $all_occurrences ) {
+	protected function get_step_notes( $entry_id, $step_id, $history ) {
 		$notes      = Gravity_Flow_Common::get_workflow_notes( $entry_id, true );
 		$step_notes = array();
 
 		$step_found            = false;
-		$step_timestamp        = $step_id && ! $all_occurrences ? gform_get_meta( $entry_id, 'workflow_step_' . $step_id . '_timestamp' ) : 0;
-		$step_status_timestamp = $step_id && ! $all_occurrences ? gform_get_meta( $entry_id, 'workflow_step_status_' . $step_id . '_timestamp' ) : 0;
+		$step_timestamp        = $step_id && ! $history ? gform_get_meta( $entry_id, 'workflow_step_' . $step_id . '_timestamp' ) : 0;
+		$step_status_timestamp = $step_id && ! $history ? gform_get_meta( $entry_id, 'workflow_step_status_' . $step_id . '_timestamp' ) : 0;
 
 		foreach ( $notes as $note ) {
-			if ( $step_found && ! $all_occurrences ) {
-				if ( $step_id != $note['step_id'] ) {
-					break;
-				}
-
-				if ( $note['timestamp'] < $step_timestamp || $note['timestamp'] > $step_status_timestamp ) {
-					break;
-				}
+			if ( $step_found && ! $history &&
+			     ( $step_id != $note['step_id'] || $note['timestamp'] < $step_timestamp || $note['timestamp'] > $step_status_timestamp )
+			) {
+				break;
 			}
 
 			if ( $step_id && $step_id != $note['step_id'] ) {

--- a/includes/merge-tags/class-merge-tag-workflow-note.php
+++ b/includes/merge-tags/class-merge-tag-workflow-note.php
@@ -49,13 +49,14 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 				$modifiers = rgar( $match, 2 );
 
 				$a = $this->get_attributes( $modifiers, array(
-					'step_id'      => null,
-					'display_name' => false,
-					'display_date' => false,
+					'step_id'         => null,
+					'display_name'    => false,
+					'display_date'    => false,
+					'all_occurrences' => true,
 				) );
 
 				$replacement = '';
-				$notes       = $this->get_step_notes( $entry['id'], $a['step_id'] );
+				$notes       = $this->get_step_notes( $entry['id'], $a['step_id'], $a['all_occurrences'] );
 
 				if ( ! empty( $notes ) ) {
 					$replacement_array = array();
@@ -82,21 +83,37 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 	 *
 	 * @since 1.7.1-dev
 	 *
-	 * @param int      $entry_id The current entry ID.
-	 * @param int|null $step_id  The step ID or null to return the most recent note.
+	 * @param int      $entry_id        The current entry ID.
+	 * @param int|null $step_id         The step ID or null to return the most recent note.
+	 * @param bool     $all_occurrences Include notes from all occurrences of the specified step.
 	 *
 	 * @return array
 	 */
-	protected function get_step_notes( $entry_id, $step_id ) {
+	protected function get_step_notes( $entry_id, $step_id, $all_occurrences ) {
 		$notes      = Gravity_Flow_Common::get_workflow_notes( $entry_id, true );
 		$step_notes = array();
 
+		$step_found            = false;
+		$step_timestamp        = $step_id && ! $all_occurrences ? gform_get_meta( $entry_id, 'workflow_step_' . $step_id . '_timestamp' ) : 0;
+		$step_status_timestamp = $step_id && ! $all_occurrences ? gform_get_meta( $entry_id, 'workflow_step_status_' . $step_id . '_timestamp' ) : 0;
+
 		foreach ( $notes as $note ) {
+			if ( $step_found && ! $all_occurrences ) {
+				if ( $step_id != $note['step_id'] ) {
+					break;
+				}
+
+				if ( $note['timestamp'] < $step_timestamp || $note['timestamp'] > $step_status_timestamp ) {
+					break;
+				}
+			}
+
 			if ( $step_id && $step_id != $note['step_id'] ) {
 				continue;
 			}
 
 			$step_notes[] = $note;
+			$step_found   = true;
 
 			if ( is_null( $step_id ) ) {
 				break;


### PR DESCRIPTION
re: [HS#4305](https://secure.helpscout.net/conversation/412406037/4305/?folderId=516726)

When using the step_id modifier with the workflow_note merge tag all the user submitted notes with the specified step id will be returned. For the average workflow that is fine, however, if the workflow includes loops so a step can occur multiple times the notes from all occurrences are currently output.

The all_occurrences modifier when set to false will return only those notes belonging to the most recent occurrence of the specified step.