### PR TITLE
Fix Dropbox Steps for Dropbox 2.0+

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -9,3 +9,4 @@ Fixed an issue populating multi-select fields with the existing entry value on t
 Fixed the $original_entry parameter not being passed when the gform_after_update_entry hook is triggered on entry update by the user input step.
 Fixed empty fields being displayed on the user input step when 'show empty fields' was not enabled.
 Fixed an issue with the shortcode where the gravityflow_status_filter and gravityflow_permission_granted_entry_detail filters don't fire.
+Fixed the Dropbox step for Gravity Forms Dropbox Add-On versions 2.0+.

--- a/includes/steps/class-step-feed-dropbox.php
+++ b/includes/steps/class-step-feed-dropbox.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'GFForms' ) ) {
 class Gravity_Flow_Step_Feed_Dropbox extends Gravity_Flow_Step_Feed_Add_On {
 	public $_step_type = 'dropbox';
 
-	protected $_class_name = 'GFDropbox';
+	protected $_class_name = 'GF_Dropbox';
 
 	public function get_label() {
 		return 'Dropbox';
@@ -25,6 +25,14 @@ class Gravity_Flow_Step_Feed_Dropbox extends Gravity_Flow_Step_Feed_Add_On {
 
 	public function get_icon_url() {
 		return $this->get_base_url() . '/images/dropbox-icon.svg';
+	}
+
+	public function get_feed_add_on_class_name() {
+		if ( class_exists( 'GFDropbox' ) ) {
+			$this->_class_name = 'GFDropbox';
+		}
+
+		return $this->_class_name;
 	}
 
 	/**


### PR DESCRIPTION
In Dropbox 2.0 the class name changed from GFDropbox to GF_Dropbox. This change has caused Dropbox steps to fail the `class_exits()` check in `Gravity_Flow_Step_Feed_Add_On::is_supported()` so existing steps would not run during the workflow and new steps could not be created.