### PR TITLE
Fix min requirements for GF2.3

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3549,6 +3549,8 @@ PRIMARY KEY  (id)
 						<span><?php esc_html_e( 'Workflow Status', 'gravityflow' ); ?></span>
 					</h2>
 
+					<?php GFCommon::display_admin_message(); ?>
+
 					<?php $this->toolbar(); ?>
 					<?php
 				endif;
@@ -3628,6 +3630,8 @@ PRIMARY KEY  (id)
 						<span><?php esc_html_e( 'Workflow Reports', 'gravityflow' ); ?></span>
 
 					</h2>
+
+					<?php GFCommon::display_admin_message(); ?>
 
 					<?php $this->toolbar(); ?>
 					<?php

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -254,6 +254,28 @@ table.entry-products col.entry-products-col4{
     padding-right: 38px;
     position: relative;
 }
+
+.gravityflow_workflow_wrap div.updated,
+.gravityflow_workflow_wrap div.error {
+    display: block;
+    background: #fff;
+    border-left: 4px solid #7ad03a;
+    -webkit-box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+    margin: 5px 15px 2px;
+    padding: 1px 12px;
+}
+
+.gravityflow_workflow_wrap div.error {
+    border-left-color: #dc3232;
+}
+
+.gravityflow_workflow_wrap div.updated p,
+.gravityflow_workflow_wrap div.error p {
+    margin: 0.5em 0;
+    padding: 2px;
+}
+
 .wrap .notice, .wrap div.updated, .wrap div.error, .media-upload-form .notice, .media-upload-form div.error {
     margin: 5px 0 15px;
 }

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -22,13 +22,26 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 	public function init() {
 		parent::init();
+
+		$meets_requirements = $this->meets_minimum_requirements();
+		if ( ! $meets_requirements['meets_requirements'] ) {
+			return;
+		}
+
 		add_filter( 'gravityflow_menu_items', array( $this, 'menu_items' ) );
 		add_filter( 'gravityflow_toolbar_menu_items', array( $this, 'toolbar_menu_items' ) );
 	}
 
 	public function init_admin() {
 		parent::init_admin();
+
+		$meets_requirements = $this->meets_minimum_requirements();
+		if ( ! $meets_requirements['meets_requirements'] ) {
+			return;
+		}
+
 		add_filter( 'gravityflow_settings_menu_tabs', array( $this, 'app_settings_tabs' ) );
+		add_filter( 'plugin_action_links', array( $this, 'plugin_settings_link' ), 10, 2 );
 
 		// Members 2.0+ Integration.
 		if ( function_exists( 'members_register_cap_group' ) ) {
@@ -58,20 +71,10 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 	public function app_settings_tabs( $settings_tabs ) {
 
-		$callback = 'app_settings_tab';
-
-		if ( is_callable( array( $this, 'meets_minimum_requirements' ) ) ) {
-			$meets_requirements = $this->meets_minimum_requirements();
-
-			if ( ! $meets_requirements['meets_requirements'] ) {
-				$callback = 'failed_requirements_page';
-			}
-		}
-
 		$settings_tabs[] = array(
 			'name'     => $this->_slug,
 			'label'    => $this->get_short_title(),
-			'callback' => array( $this, $callback ),
+			'callback' => array( $this, 'app_settings_tab' ),
 		);
 
 		return $settings_tabs;
@@ -242,7 +245,39 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 * @since 1.7.1-dev
 	 */
 	public function failed_requirements_init() {
-		add_filter( 'plugin_action_links', array( $this, 'plugin_settings_link' ), 10, 2 );
+		$failed_requirements = $this->meets_minimum_requirements();
+
+		// Prepare errors list.
+		$errors = '';
+		foreach ( $failed_requirements['errors'] as $error ) {
+			$errors .= sprintf( '<li>%s</li>', esc_html( $error ) );
+		}
+
+		// Prepare error message.
+		$error_message = sprintf(
+			'%s<br />%s<ol>%s</ol>',
+			sprintf( esc_html__( '%s is not able to run because your WordPress environment has not met the minimum requirements.', 'gravityflow' ), $this->_title ),
+			sprintf( esc_html__( 'Please resolve the following issues to use %s:', 'gravityflow' ), $this->get_short_title() ),
+			$errors
+		);
+
+		// Add error message.
+		GFCommon::add_error_message( $error_message );
+	}
+
+	/**
+	 * Determine if the add-ons minimum requirements have been met with Gravity Forms 2.2+.
+	 *
+	 * @since 1.8.1-dev
+	 *
+	 * @return array
+	 */
+	public function meets_minimum_requirements() {
+		if ( $this->is_gravityforms_supported( '2.2' ) ) {
+			return parent::meets_minimum_requirements();
+		}
+
+		return array( 'meets_requirements' => true, 'errors' => array() );
 	}
 
 	/**

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -388,7 +388,6 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$this->output_filter_scripts();
 		$this->output_print_modal();
 		$this->process_bulk_action();
-		GFCommon::display_admin_message();
 	}
 
 	/**
@@ -1644,9 +1643,9 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		if ( ! empty( $feedback ) ) {
 			if ( is_wp_error( $feedback ) ) {
-				GFCommon::add_message( $feedback->get_error_message(), true );
+				$this->display_message( $feedback->get_error_message(), true );
 			} else {
-				GFCommon::add_message( $feedback );
+				$this->display_message( $feedback );
 			}
 			return;
 		}
@@ -1680,9 +1679,23 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		}
 
 		$message = esc_html__( 'Workflows restarted.',  'gravityflow' );
-		GFCommon::add_message( $message );
+		$this->display_message( $message );
 
 		return;
+	}
+
+	/**
+	 * Displays an error or updated type message.
+	 *
+	 * @since 1.8.1-dev
+	 *
+	 * @param  string $message  The message to be displayed.
+	 * @param bool    $is_error Is this an error message? Default false.
+	 */
+	public function display_message( $message, $is_error = false ) {
+		$class = $is_error ? 'error' : 'updated';
+
+		echo '<div class="' . $class . ' below-h2"><p><strong>' . esc_html( $message ) . '</strong></p></div>';
 	}
 
 	public function export() {


### PR DESCRIPTION
- Updates min requirements to work with Gravity Forms 2.3 which uses admin messages instead of displaying the messages on the settings tab.
- Updates the status page to display admin messages above the toolbar like other pages whilst keeping the bulk action messages in their existing location below the filters. This change also fixes an issue where the bulk action message would not be displayed if an admin message is present.
- Fixes an issue where the status page bulk action messages are hidden on the front-end by the Twenty themes.