### PR TITLE
Fix User Step default_value for field conditional logic

### DIFF
--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -85,7 +85,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 					'checkbox' => array(
 						'label'          => esc_html__( 'Enable field conditional logic', 'gravityflow' ),
 						'name'           => 'conditional_logic_editable_fields_enabled',
-						'defeault_value' => '0',
+						'default_value' => '1',
 					),
 					'select'   => array(
 						'name'    => 'conditional_logic_editable_fields_mode',
@@ -111,7 +111,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 						array(
 							'label'          => esc_html__( 'Enable field conditional logic', 'gravityflow' ),
 							'name'           => 'conditional_logic_editable_fields_enabled',
-							'defeault_value' => '0',
+							'default_value' => '1',
 						),
 					),
 				);


### PR DESCRIPTION
This ensures new user input steps for forms with conditional logic fields or pages have the 'Enable field conditional logic' checkbox active by default. Does not impact existing user input steps that had already stored value on / off.