### PR TITLE
Enabling Form Title column for Inbox with multiple forms set via the gravityflow_inbox_args filter

### DIFF
--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -201,7 +201,7 @@ class Gravity_Flow_Inbox {
 			$columns['actions'] = '';
 		}
 
-		if ( empty( $args['form_id'] ) ) {
+		if ( empty( $args['form_id'] ) || is_array( $args['form_id']) ) {
 			$columns['form_title'] = __( 'Form', 'gravityflow' );
 		}
 


### PR DESCRIPTION
The filter gravityflow_inbox_args provides method to limit the shortcode to an array of forms. But the check whether to display Form Name as column in the inbox assumes the form_id argument is empty. This PR expands it to also check/allow array values to trigger Form Name column display.

https://gist.github.com/Idealien/aaeb8538adcf28d16f721ca4c44f249b is example of filter use that would not  display Form Name column without the PR.