### PR TITLE
Fix the Hubspot step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,1 @@
-
+- Fixed the HubSpot step for the "HubSpot for Gravity Forms" plugin versions 3.0+.

--- a/includes/steps/class-step-feed-hubspot.php
+++ b/includes/steps/class-step-feed-hubspot.php
@@ -17,11 +17,19 @@ if ( ! class_exists( 'GFForms' ) ) {
 class Gravity_Flow_Step_Feed_HubSpot extends Gravity_Flow_Step_Feed_Add_On {
 	public $_step_type = 'hubspot';
 
-	protected $_class_name = 'GF_HubSpot';
+	protected $_class_name = '\BigSea\GFHubSpot\GF_HubSpot';
 	protected $_slug = 'gravityforms-hubspot';
 
 	public function get_label() {
 		return 'HubSpot';
+	}
+
+	public function get_feed_add_on_class_name() {
+		if ( ! class_exists( '\BigSea\GFHubSpot\GF_HubSpot' ) ) {
+			$this->_class_name = 'GF_HubSpot';
+		}
+
+		return $this->_class_name;
 	}
 
 }


### PR DESCRIPTION
This updates the step to support the namespaced class name introduced in version 3.0 of the HubSpot for Gravity Form plugin.