### PR TITLE
Fix assignee notes

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Added the gravityflow_timeline_step_icon filter.
 - Fixed the HubSpot step for the "HubSpot for Gravity Forms" plugin versions 3.0+.
 - Fixed a fatal error which could occur when processing the shortcode with the form attribute and the specified entry can't be retrieved.
+- Fixed an issue with the timeline notes for Approval and User Input steps where the step icon is used instead of the user avatar.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1795,7 +1795,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 			$assignee_key = $this->get_current_assignee_key();
 			if ( $assignee_key ) {
 				$assignee = $this->get_assignee( $assignee_key );
-				if ( $assignee_key instanceof Gravity_Flow_Assignee && $assignee->get_type() === 'user_id' ) {
+				if ( $assignee instanceof Gravity_Flow_Assignee && $assignee->get_type() === 'user_id' ) {
 					$user_id   = $assignee->get_id();
 					$user_name = $assignee->get_display_name();
 				}


### PR DESCRIPTION
Fixes an issue with the timeline notes for Approval and User Input steps where the step icon is used instead of the user avatar.