### PR TITLE
fixed ui step section field logic

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -6,3 +6,4 @@
 - Fixed the HubSpot step for the "HubSpot for Gravity Forms" plugin versions 3.0+.
 - Fixed a fatal error which could occur when processing the shortcode with the form attribute and the specified entry can't be retrieved.
 - Fixed an issue with the timeline notes for Approval and User Input steps where the step icon is used instead of the user avatar.
+- Fixed an issue with the conditional logic for Section fields on the User Input step.

--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -583,7 +583,7 @@ class Gravity_Flow_Entry_Editor {
 				$display_field = false;
 			}
 		} else {
-			if ( GFFormsModel::is_field_hidden( $this->form, $field, array(), $this->entry ) ) {
+			if ( $field->type !== 'section' && GFFormsModel::is_field_hidden( $this->form, $field, array(), $this->entry ) ) {
 				$display_field = false;
 			}
 			$display_field = (bool) apply_filters( 'gravityflow_workflow_detail_display_field', $display_field, $field, $this->form, $this->entry, $this->step );


### PR DESCRIPTION
re: [HS#4878](https://secure.helpscout.net/conversation/472255809/4878?folderId=793490)

GFFormsModel::is_field_hidden() was returning true for the section field as the two rules for display were not met. This caused Gravity_Flow_Entry_Editor::is_display_field() to return false which resulted in the section fields conditionalLogicFields and conditionalLogic properties being set to null so the section was displayed.

This change prevents GFFormsModel::is_field_hidden() being used for section fields in Gravity_Flow_Entry_Editor::is_display_field(). The section logic will be evaluated when the gform_field_container filter runs later.