### PR TITLE
Step Highlight

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1828,6 +1828,8 @@ PRIMARY KEY  (id)
 		/**
 		* Prepare the step_highlight composite settings to be accessible for every field in the composite
 		*
+		* @since 1.9.2
+		*
 		* @param array $field The step_highlight field
 		*
 		* @return array
@@ -1872,6 +1874,8 @@ PRIMARY KEY  (id)
 		* Generate the step_highlight composite setting container
 		*
 		* The container will be displayed or hidden depending on the value of the step_highlight checkbox field.
+		*
+		* @since 1.9.2
 		*
 		* @param array $field The step_highlight field
 		*/

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1810,23 +1810,39 @@ PRIMARY KEY  (id)
 			<?php
 		}
 
-		public function settings_step_highlight( $field, $echo = true ) {
+		/**
+		 * Prepare and render markup for the step_highlight composite setting.
+		 *
+		 * The container will be displayed or hidden depending on the value of the step_highlight checkbox field.
+		 *
+		 * @since 1.9.2
+		 *
+		 * @param array $field
+		 */
+		public function settings_step_highlight( $field ) {
 			$field = $this->prepare_settings_step_highlight( $field );
 
-			return $this->settings_step_highlight_container( $field, $echo );
+			return $this->settings_step_highlight_container( $field );
 		}
 
+		/**
+		* Prepare the step_highlight composite settings to be accessible for every field in the composite
+		*
+		* @param array $field The step_highlight field
+		*
+		* @return array
+		*/
 		public function prepare_settings_step_highlight( $field ) {
 			unset( $field['settings'] );
 
 			$step_highlight = array(
 				'name'     => 'step_highlight',
 				'type'     => 'checkbox',
-				'required' => false,
 				'choices'  => array(
 					array(
-						'label' => esc_html__( 'Highlight this step', 'gravityflow' ),
-						'name'  => 'step_highlight',
+						'label'         => esc_html__( 'Highlight this step', 'gravityflow' ),
+						'name'          => 'step_highlight',
+						'default_value' => true,
 					),
 				),
 			);
@@ -1846,7 +1862,6 @@ PRIMARY KEY  (id)
 				'class'               => 'small-text',
 				'label'               => esc_html__( 'Color', 'gravityflow' ),
 				'type'                => 'text',
-				'required'            => true,
 				'default_value'       => '#dd3333',
 			);
 			$field['settings']['step_highlight_color'] = $step_highlight_color;
@@ -1854,7 +1869,14 @@ PRIMARY KEY  (id)
 			return $field;
 		}
 
-		public function settings_step_highlight_container( $field, $echo = true ) {
+		/**
+		* Generate the step_highlight composite setting container
+		*
+		* The container will be displayed or hidden depending on the value of the step_highlight checkbox field.
+		*
+		* @param array $field The step_highlight field
+		*/
+		public function settings_step_highlight_container( $field ) {
 			$form = $this->get_current_form();
 			$step_settings = rgar( $field, 'settings' );
 
@@ -1864,7 +1886,7 @@ PRIMARY KEY  (id)
 
 			$this->settings_checkbox( $step_settings['step_highlight'] );
 
-			$enabled = $this->get_setting( 'step_highlight', false );
+			$enabled = $this->get_setting( 'step_highlight', true );
 			$step_highlight_style = $enabled ? '' : 'style="display:none;"';
 			$step_highlight_type_setting = $this->get_setting( 'step_highlight_type', 'color' );
 			$step_highlight_color_style = ( $step_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';
@@ -1883,7 +1905,6 @@ PRIMARY KEY  (id)
 				(function($) {
 					$( '#step_highlight' ).click(function(){
 						$('.gravityflow-step-highlight-settings').slideToggle();
-						$('.gravityflow-step-highlight-color-container').slideToggle();
 					});
 					$(document).ready(function () {
 						$("#step_highlight_color").wpColorPicker();
@@ -2113,14 +2134,21 @@ PRIMARY KEY  (id)
 			$this->validate_textarea_settings( $textarea_field, $settings );
 		}
 
+		/**
+		 * Validate step_highlight composite setting
+		 *
+		 * Validate the sub-settings are of appropriate type and required status
+		 * 
+		 * @since 1.9.2
+		 *
+		 * @param array $field The field properties.
+		 * @param array $settings The settings to be potentially saved.
+		 */
 		public function validate_step_highlight_settings( $field, $settings ) {
 			$field = $this->prepare_settings_step_highlight( $field );
 
 			$checkbox_field = $field['settings']['step_highlight'];
 			$this->validate_checkbox_settings( $checkbox_field, $settings );
-
-			$radio_field = $field['settings']['step_highlight_type'];
-			$this->validate_radio_settings( $radio_field, $settings );
 
 			$color_field = $field['settings']['step_highlight_color'];
 			$this->validate_text_settings( $color_field, $settings );
@@ -2128,10 +2156,18 @@ PRIMARY KEY  (id)
 
 		}
 
+		/**
+		 * Validate step_highlight_color is a hexadecimal code
+		 *
+		 * @since 1.9.2
+		 *
+		 * @param array $field The field properties.
+		 * @param array $settings The settings to be potentially saved.
+		 */
 		public function validate_step_highlight_color_settings( $field, $settings ) {
 
-			if ( ! preg_match( '/^#[a-f0-9]{6}$/i', $settings['step_highlight_color'] ) ) {
-				$this->set_field_error( $field, __( 'You must provide a color value for the highlight.', 'gravityflow' ) );
+			if( $settings['step_highlight'] && ! preg_match( '/^#[a-f0-9]{6}$/i', $settings['step_highlight_color'] ) ) {
+				$this->set_field_error( $field, __( 'You must provide a color value for the active highlight to apply.', 'gravityflow' ) );
 			}
 
 		}
@@ -2260,6 +2296,15 @@ PRIMARY KEY  (id)
 			return $link;
 		}
 
+		/**
+		 * Return value of step_highlight composite setting for display on feed list
+		 *
+		 * @since 1.9.2
+		 *
+		 * @param array $item Current workflow step
+		 *
+		 * @return string
+		 */
 		public function get_column_value_step_highlight( $item ) {
 			$step_highlight = '';
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -443,7 +443,7 @@ PRIMARY KEY  (id)
 				array(
 					'handle'  => 'gravityflow_feed_list',
 					'src'     => $this->get_base_url() . "/js/feed-list{$min}.js",
-					'deps'    => array( 'jquery', 'jquery-ui-sortable' ),
+					'deps'    => array( 'jquery', 'jquery-ui-sortable', 'wp-color-picker' ),
 					'version' => $this->_version,
 					'enqueue' => array(
 						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflow' ),
@@ -702,8 +702,11 @@ PRIMARY KEY  (id)
 					'handle'  => 'gravityflow_feed_list',
 					'src'     => $this->get_base_url() . "/css/feed-list{$min}.css",
 					'version' => $this->_version,
+					'deps' => array( 'wp-color-picker' ),
 					'enqueue' => array(
-						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflow' ),
+						array(
+							'query' => 'page=gf_edit_forms&view=settings&subview=gravityflow',
+						),
 					),
 				),
 				array(
@@ -874,7 +877,6 @@ PRIMARY KEY  (id)
 		 * @return array
 		 */
 		public function feed_settings_fields() {
-
 			$current_step_id = $this->get_current_feed_id();
 
 			$step_type_choices = array();
@@ -926,6 +928,13 @@ PRIMARY KEY  (id)
 						'type'  => 'textarea',
 					),
 					$step_type_setting,
+					array(
+						'name'                => 'step_highlight',
+						'label'               => esc_html__( 'Highlight', 'gravityflow' ),
+						'type'                => 'step_highlight',
+						'required'            => false,
+						'tooltip'             => esc_html__( 'Highlighting a step will help to differentiate it when editing Workflow Steps. It can also be enabled as a column (highlight) in the Inbox Shortcode to identify the step of each entry.', 'gravityflow' ),
+					),
 					array(
 						'name'           => 'condition',
 						'tooltip'        => esc_html__( "Build the conditional logic that should be applied to this step before it's allowed to be processed. If an entry does not meet the conditions of this step it will fall on to the next step in the list.", 'gravityflow' ),
@@ -1801,6 +1810,91 @@ PRIMARY KEY  (id)
 			<?php
 		}
 
+		public function settings_step_highlight( $field, $echo = true ) {
+			$field = $this->prepare_settings_step_highlight( $field );
+
+			return $this->settings_step_highlight_container( $field, $echo );
+		}
+
+		public function prepare_settings_step_highlight( $field ) {
+			unset( $field['settings'] );
+
+			$step_highlight = array(
+				'name'     => 'step_highlight',
+				'type'     => 'checkbox',
+				'required' => false,
+				'choices'  => array(
+					array(
+						'label' => esc_html__( 'Highlight this step', 'gravityflow' ),
+						'name'  => 'step_highlight',
+					),
+				),
+			);
+			$field['settings']['step_highlight'] = $step_highlight;
+
+			$step_highlight_type = array(
+				'name'           => 'step_highlight_type',
+				'type'           => 'hidden',
+				'default_value'  => 'color',
+				'required'       => true,
+			);
+			$field['settings']['step_highlight_type'] = $step_highlight_type;
+
+			$step_highlight_color = array(
+				'name'                => 'step_highlight_color',
+				'id'                  => 'step_highlight_color',
+				'class'               => 'small-text',
+				'label'               => esc_html__( 'Color', 'gravityflow' ),
+				'type'                => 'text',
+				'required'            => true,
+				'default_value'       => '#dd3333',
+			);
+			$field['settings']['step_highlight_color'] = $step_highlight_color;
+
+			return $field;
+		}
+
+		public function settings_step_highlight_container( $field, $echo = true ) {
+			$form = $this->get_current_form();
+			$step_settings = rgar( $field, 'settings' );
+
+			if ( empty( $step_settings ) ) {
+				return '';
+			}
+
+			$this->settings_checkbox( $step_settings['step_highlight'] );
+
+			$enabled = $this->get_setting( 'step_highlight', false );
+			$step_highlight_style = $enabled ? '' : 'style="display:none;"';
+			$step_highlight_type_setting = $this->get_setting( 'step_highlight_type', 'color' );
+			$step_highlight_color_style = ( $step_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';
+			?>
+			<div class="gravityflow-step-highlight-settings" <?php echo $step_highlight_style; ?> >
+				<div class="gravityflow-step-highlight-type-container">
+					<?php $this->settings_hidden( $step_settings['step_highlight_type'] ); ?>
+				</div>
+				<div class="gravityflow-step-highlight-color-container" <?php echo $step_highlight_color_style; ?> >
+					<?php
+					$this->settings_text( $step_settings['step_highlight_color'] );
+					?>
+				</div>
+			</div>
+			<script>
+				(function($) {
+					$( '#step_highlight' ).click(function(){
+						$('.gravityflow-step-highlight-settings').slideToggle();
+						$('.gravityflow-step-highlight-color-container').slideToggle();
+					});
+					$(document).ready(function () {
+						$("#step_highlight_color").wpColorPicker();
+					});
+				})(jQuery); 
+			</script>
+			<?php
+
+			return;
+		}
+
 		public function settings_tabs( $tabs_field ) {
 			printf( '<div id="tabs-%s">', $tabs_field['name'] );
 			echo '<ul>';
@@ -1852,7 +1946,6 @@ PRIMARY KEY  (id)
 		 * @return string
 		 */
 		public function settings_checkbox_and_container( $field, $echo = true ) {
-
 			$checkbox_field = rgar( $field, 'checkbox' );
 
 			if ( empty( $checkbox_field ) ) {
@@ -1950,7 +2043,6 @@ PRIMARY KEY  (id)
 		 * @return string
 		 */
 		public function settings_checkbox_and_text( $field, $echo = true ) {
-
 			$text_input = rgars( $field, 'text' );
 
 			$text_field = array(
@@ -1985,7 +2077,6 @@ PRIMARY KEY  (id)
 		 * @return string
 		 */
 		public function settings_checkbox_and_textarea( $field, $echo = true ) {
-
 			$field = $this->prepare_settings_checkbox_and_textarea( $field );
 
 			return $this->settings_checkbox_and_container( $field, $echo );
@@ -2008,6 +2099,7 @@ PRIMARY KEY  (id)
 			unset( $field['textarea'] );
 
 			$field['settings'] = array( 'textarea' => $textarea_field );
+
 			return $field;
 		}
 
@@ -2019,6 +2111,29 @@ PRIMARY KEY  (id)
 
 			$this->validate_checkbox_settings( $checkbox_field, $settings );
 			$this->validate_textarea_settings( $textarea_field, $settings );
+		}
+
+		public function validate_step_highlight_settings( $field, $settings ) {
+			$field = $this->prepare_settings_step_highlight( $field );
+
+			$checkbox_field = $field['settings']['step_highlight'];
+			$this->validate_checkbox_settings( $checkbox_field, $settings );
+
+			$radio_field = $field['settings']['step_highlight_type'];
+			$this->validate_radio_settings( $radio_field, $settings );
+
+			$color_field = $field['settings']['step_highlight_color'];
+			$this->validate_text_settings( $color_field, $settings );
+			$this->validate_step_highlight_color_settings( $color_field, $settings );
+
+		}
+
+		public function validate_step_highlight_color_settings( $field, $settings ) {
+
+			if ( ! preg_match( '/^#[a-f0-9]{6}$/i', $settings['step_highlight_color'] ) ) {
+				$this->set_field_error( $field, __( 'You must provide a color value for the highlight.', 'gravityflow' ) );
+			}
+
 		}
 
 		public function settings_visual_editor( $field ) {
@@ -2101,9 +2216,9 @@ PRIMARY KEY  (id)
 		 * @return array
 		 */
 		public function feed_list_columns() {
-
 			$columns = array(
 				'step_name' => __( 'Step name', 'gravityflow' ),
+				'step_highlight' => '',
 				'step_type' => esc_html__( 'Step Type', 'gravityflow' ),
 			);
 
@@ -2143,6 +2258,32 @@ PRIMARY KEY  (id)
 			$url = admin_url( 'admin.php?page=gf_entries&view=entries&id='. $form_id . '&field_id=workflow_step&operator=is&s=' . $step_id );
 			$link = sprintf( '<a href="%s">%d</a>', $url, $count );
 			return $link;
+		}
+
+		public function get_column_value_step_highlight( $item ) {
+			$step_highlight = '';
+
+			if ( ! empty( $item['meta']['step_highlight'] ) ) {
+				switch ( $item['meta']['step_highlight_type'] ) :
+
+					case 'color':
+						if ( preg_match( '/^#[a-f0-9]{6}$/i', $item['meta']['step_highlight_color'] ) ) {
+							$step_highlight = '<div class="step_highlight step_highlight_color" style="background-color: ' . $item['meta']['step_highlight_color'] . ';">&nbsp;</div>';
+						}
+						break;
+
+					case 'text':
+						$step_highlight = '<div class="step_highlight step_highlight_text">' . $item['meta']['step_highlight_text'] . '</div>';
+						break;
+
+					case 'icon':
+						$step_highlight = $item['meta']['step_highlight_icon'];
+						break;
+
+				endswitch;
+			}
+
+			return $step_highlight;
 		}
 
 		public function feed_list_no_item_message() {
@@ -3420,6 +3561,7 @@ PRIMARY KEY  (id)
 				'check_permissions'    => true,
 				'show_header'          => true,
 				'timeline'             => true,
+				'step_highlight'       => true,
 			);
 
 			$args = array_merge( $defaults, $args );
@@ -4126,6 +4268,7 @@ PRIMARY KEY  (id)
 				'step_status'      => true,
 				'workflow_info'    => true,
 				'sidebar'          => true,
+				'step_highlight'   => true,
 			);
 
 			return $defaults;
@@ -4162,7 +4305,6 @@ PRIMARY KEY  (id)
 		public function get_shortcode_inbox_page( $a ) {
 			wp_enqueue_script( 'gravityflow_entry_detail' );
 			wp_enqueue_script( 'gravityflow_status_list' );
-
 			$args = array(
 				'form_id'              => $a['form'],
 				'id_column'            => $a['id_column'],
@@ -4177,6 +4319,7 @@ PRIMARY KEY  (id)
 				'step_status'          => $a['step_status'],
 				'workflow_info'        => $a['workflow_info'],
 				'sidebar'              => $a['sidebar'],
+				'step_highlight'       => $a['step_highlight'],
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1842,7 +1842,6 @@ PRIMARY KEY  (id)
 					array(
 						'label'         => esc_html__( 'Highlight this step', 'gravityflow' ),
 						'name'          => 'step_highlight',
-						'default_value' => true,
 					),
 				),
 			);
@@ -1886,7 +1885,7 @@ PRIMARY KEY  (id)
 
 			$this->settings_checkbox( $step_settings['step_highlight'] );
 
-			$enabled = $this->get_setting( 'step_highlight', true );
+			$enabled = $this->get_setting( 'step_highlight', false );
 			$step_highlight_style = $enabled ? '' : 'style="display:none;"';
 			$step_highlight_type_setting = $this->get_setting( 'step_highlight_type', 'color' );
 			$step_highlight_color_style = ( $step_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -933,7 +933,7 @@ PRIMARY KEY  (id)
 						'label'               => esc_html__( 'Highlight', 'gravityflow' ),
 						'type'                => 'step_highlight',
 						'required'            => false,
-						'tooltip'             => esc_html__( 'Highlighting a step will help to differentiate it when editing Workflow Steps. It can also be enabled as a column (highlight) in the Inbox Shortcode to identify the step of each entry.', 'gravityflow' ),
+						'tooltip'             => esc_html__( 'Highlighted steps will stand out in both the workflow inbox and the step list. Use highlighting to bring attention to important tasks and to help organise complex workflows.', 'gravityflow' ),
 					),
 					array(
 						'name'           => 'condition',

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -306,3 +306,9 @@ span.gf_admin_page_formid {
     cursor:default;
     border-bottom: 1px solid #eee;
 }
+
+/* Step Highlight */
+table#gravityflow-inbox tbody tr{
+    border-left-width: 3px;
+    border-left-style: solid;
+}

--- a/css/feed-list.css
+++ b/css/feed-list.css
@@ -38,3 +38,12 @@ td.check-column,
 .tablenav.bottom{
     display: none;
 }
+
+td.column-step_highlight .step_highlight_color {
+    width: 0.25em;
+    height: 100%;
+}
+
+th.column-step_highlight, td.column-step_highlight {
+    display: none;
+}

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -167,6 +167,8 @@ tr#gaddon-setting-row-step_type label > span > i {
     color:#0074a2;
 }
 
+.gravityflow-step-highlight-type-container,
+.gravityflow-step-highlight-color-container,
 .gravityflow-schedule-type-container,
 .gravityflow-schedule-delay-container,
 .gravityflow-schedule-date-container,
@@ -174,6 +176,10 @@ tr#gaddon-setting-row-step_type label > span > i {
 .gravityflow-expiration-delay-container,
 .gravityflow-expiration-date-container{
     margin: 10px 0 10px 0;
+}
+
+.gravityflow-step-highlight-type-container {
+    display: none; 
 }
 
 .gravityflow_display_fields_selected_container{

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -186,6 +186,10 @@ tr#gaddon-setting-row-step_type label > span > i {
     margin-top:5px;
 }
 
+.gravityflow-step-highlight-color-container .wp-picker-container {
+    margin-top: 5px;
+}
+
 .settings-field-map-table .custom-value-reset {
     background: url( ../images/xit.gif ) no-repeat scroll 0 0 transparent;
     cursor:pointer;

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -334,7 +334,10 @@ table.entry-products col.entry-products-col4{
         width:100%!important;
         border-top:1px solid #ddd !important;
     }
-
+    
+    table#gravityflow-inbox td[data-label="Highlight"] {
+        display: none !important;
+    }
 }
 
 div.gf_entry_wrap {
@@ -353,6 +356,12 @@ table#gravityflow-inbox th{
 
 table#gravityflow-inbox{
     border-top:1px solid #ddd!important;
+}
+
+table#gravityflow-inbox tbody tr{
+    border-left-width: 3px;
+    border-left-style: solid;
+    border-left-color: transparent;
 }
 
 #gravityflow-admin-action{

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -335,9 +335,6 @@ table.entry-products col.entry-products-col4{
         border-top:1px solid #ddd !important;
     }
     
-    table#gravityflow-inbox td[data-label="Highlight"] {
-        display: none !important;
-    }
 }
 
 div.gf_entry_wrap {

--- a/css/inbox.css
+++ b/css/inbox.css
@@ -11,6 +11,12 @@ table#gravityflow-inbox tr:nth-child(odd) {
     background: #FFF
 }
 
+table#gravityflow-inbox tbody tr{
+    border-left-width: 5px;
+    border-left-style: solid;
+    border-left-color: transparent;
+}
+
 table#gravityflow-inbox {
     border-collapse: collapse;
     margin-top:10px;

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -293,16 +293,18 @@ class Gravity_Flow_Inbox {
 		 * @param string $highlight The highlight color (hex value) of the row currently being processed.
 		 * @param int $form['id'] The ID of form currently being processed.
 		 * @param array $entry The entry object for the row currently being processed.
+		 *
+		 * @return string
 		 */
-		$step_highlight = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
+		$step_highlight_color = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
 
 		if ( strlen( $step_highlight_color ) > 0 ) {
 			echo '<tr style="border-left-color: ' . $step_highlight_color . ';">';
-			unset( $columns['step_highlight'] );
 		} else {
 			echo '<tr>';
-			unset( $columns['step_highlight'] );
 		}
+
+		unset( $columns['step_highlight'] );
 
 		foreach ( $columns as $id => $label ) {
 			$value = self::get_column_value( $id, $form, $entry, $columns );

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -276,8 +276,8 @@ class Gravity_Flow_Inbox {
 			if ( $step ) {
 				$meta = $step->get_feed_meta();
 
-				if ( $meta && isset( $meta['step_highlight'] ) && $meta['step_highlight']) {
-					if( isset( $meta['step_highlight_type'] ) && $meta['step_highlight_type'] == 'color' ) {
+				if ( $meta && isset( $meta['step_highlight'] ) && $meta['step_highlight'] ) {
+					if ( isset( $meta['step_highlight_type'] ) && $meta['step_highlight_type'] == 'color' ) {
 						if ( isset( $meta['step_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['step_highlight_color'] ) ) {
 							$step_highlight_color = $meta['step_highlight_color'];
 						}

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -275,9 +275,12 @@ class Gravity_Flow_Inbox {
 			$step = gravity_flow()->get_step( $entry['workflow_step'] );
 			if ( $step ) {
 				$meta = $step->get_feed_meta();
-				if ( $meta && isset( $meta['step_highlight_type'] ) ) {
-					if ( isset( $meta['step_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['step_highlight_color'] ) ) {
-						$step_highlight_color = $meta['step_highlight_color'];
+
+				if ( $meta && isset( $meta['step_highlight'] ) && $meta['step_highlight']) {
+					if( isset( $meta['step_highlight_type'] ) && $meta['step_highlight_type'] == 'color' ) {
+						if ( isset( $meta['step_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['step_highlight_color'] ) ) {
+							$step_highlight_color = $meta['step_highlight_color'];
+						}
 					}
 				}
 			}
@@ -298,6 +301,7 @@ class Gravity_Flow_Inbox {
 			unset( $columns['step_highlight'] );
 		} else {
 			echo '<tr>';
+			unset( $columns['step_highlight'] );
 		}
 
 		foreach ( $columns as $id => $label ) {

--- a/js/feed-list.js
+++ b/js/feed-list.js
@@ -5,6 +5,11 @@
         if ( $('table.wp-list-table tbody tr').length == 1 ) {
             return;
         }
+
+        $.each( $('.wp-list-table tbody tr'), function() { 
+            $( this ).css( 'border-left', '5px solid ' + $(this).find('.step_highlight_color').css( 'background-color' ) );
+        });
+
         var sortHandleMarkup = '<td class="sort-column"><i class="fa fa-bars feed-sort-handle"></i></td>';
         $('.wp-list-table thead tr, .wp-list-table tfoot tr').append('<th class="sort-column"></th>');
         $('.wp-list-table tbody tr').append(sortHandleMarkup);

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -71,8 +71,9 @@
 
 					return false;
 				});
-		});
-
+		});		
 	});
+
+	
 
 }(window.GravityFlowFrontEnd = window.GravityFlowFrontEnd || {}, jQuery));


### PR DESCRIPTION
Ready for an initial code review for the Step Highlight - Color Setting.

- All step types get new setting 'Highlight - Highlight this step' that is not selected by default.
- Part 1 PR has step_highlight_type hidden / defaulted to color
- New JS dependency to wp-color-picker on step edit screen
- New filter - gravityflow_step_highlight_color_inbox - that could be used to change from a step-defined color to a field-derived status/priority. Passes $form['id'], $entry as additional parameters to the step_highlight_color to return (color hexcode)

Defined step highlight color can display in 3 locations:
1. Inbox Shortcode - new column step_highlight - off by default as true/false
1. Workflow inbox - on by default args, can be overridden through gravityflow_inbox_args
1. Workflow Step List

PR also includes small inactive plumbing for part 2 of text, icon and upload svg step highights which a future PR will complete and activate.
