### PR TITLE
Fix feed IDs (step IDs) in feed condition

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -7,3 +7,4 @@
 - Fixed a fatal error which could occur when processing the shortcode with the form attribute and the specified entry can't be retrieved.
 - Fixed an issue with the timeline notes for Approval and User Input steps where the step icon is used instead of the user avatar.
 - Fixed an issue with the conditional logic for Section fields on the User Input step.
+- Fixed an issue that feed IDs (step IDs) in feed condition weren't updated after forms imported.

--- a/change_log.txt
+++ b/change_log.txt
@@ -7,4 +7,4 @@
 - Fixed a fatal error which could occur when processing the shortcode with the form attribute and the specified entry can't be retrieved.
 - Fixed an issue with the timeline notes for Approval and User Input steps where the step icon is used instead of the user avatar.
 - Fixed an issue with the conditional logic for Section fields on the User Input step.
-- Fixed an issue that feed IDs (step IDs) in feed condition weren't updated after forms imported.
+- Fixed an issue that feed IDs (step IDs) in feed condition weren't updated after forms duplicated or imported.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4844,14 +4844,14 @@ AND m.meta_value='queued'";
 				$is_condition_enabled = rgar( $new_step_meta, 'feed_condition_conditional_logic' ) == true;
 				$logic                = rgars( $new_step_meta, 'feed_condition_conditional_logic_object/conditionalLogic' );
 				if ( $is_condition_enabled && ! empty( $logic ) ) {
-				    foreach ( $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'] as $key => $rule ) {
-				        if ( strstr( $rule['fieldId'], 'workflow_step_status_' ) ) {
-					        $old_feed_id = explode( '_', $rule['fieldId'] ); // fieldId is in the format of "workflow_step_status_30"
-					        $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'][$key]['fieldId'] = 'workflow_step_status_' . $feed_id_mappings[$old_feed_id[3]];
-					        $step_ids_updated = true;
-                        }
-                    }
-                }
+					foreach ( $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'] as $key => $rule ) {
+						if ( strstr( $rule['fieldId'], 'workflow_step_status_' ) ) {
+							$old_feed_id = explode( '_', $rule['fieldId'] ); // fieldId is in the format of "workflow_step_status_30"
+							$new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'][$key]['fieldId'] = 'workflow_step_status_' . $feed_id_mappings[$old_feed_id[3]];
+							$step_ids_updated = true;
+						}
+					}
+				}
 
 				if ( $step_ids_updated ) {
 					$this->update_feed_meta( $new_step->get_id(), $new_step_meta );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -986,7 +986,7 @@ PRIMARY KEY  (id)
 				}
 				$step_settings['dependency'] = array( 'field' => 'step_type', 'values' => array( $type ) );
 				$settings[] = $step_settings;
-				
+
 			}
 
 			$list_url         = remove_query_arg( 'fid' );
@@ -4840,6 +4840,19 @@ AND m.meta_value='queued'";
 						$step_ids_updated = true;
 					}
 				}
+				// Change feed id in conditional logic
+				$is_condition_enabled = rgar( $new_step_meta, 'feed_condition_conditional_logic' ) == true;
+				$logic                = rgars( $new_step_meta, 'feed_condition_conditional_logic_object/conditionalLogic' );
+				if ( $is_condition_enabled && ! empty( $logic ) ) {
+				    foreach ( $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'] as $key => $rule ) {
+				        if ( strstr( $rule['fieldId'], 'workflow_step_status_' ) ) {
+					        $old_feed_id = explode( '_', $rule['fieldId'] ); // fieldId is in the format of "workflow_step_status_30"
+					        $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'][$key]['fieldId'] = 'workflow_step_status_' . $feed_id_mappings[$old_feed_id[3]];
+					        $step_ids_updated = true;
+                        }
+                    }
+                }
+
 				if ( $step_ids_updated ) {
 					$this->update_feed_meta( $new_step->get_id(), $new_step_meta );
 				}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4845,7 +4845,7 @@ AND m.meta_value='queued'";
 				$logic                = rgars( $new_step_meta, 'feed_condition_conditional_logic_object/conditionalLogic' );
 				if ( $is_condition_enabled && ! empty( $logic ) ) {
 					foreach ( $new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'] as $key => $rule ) {
-						if ( strstr( $rule['fieldId'], 'workflow_step_status_' ) ) {
+						if ( 0 === strpos( $rule['fieldId'], 'workflow_step_status_' ) ) {
 							$old_feed_id = explode( '_', $rule['fieldId'] ); // fieldId is in the format of "workflow_step_status_30"
 							$new_step_meta['feed_condition_conditional_logic_object']['conditionalLogic']['rules'][$key]['fieldId'] = 'workflow_step_status_' . $feed_id_mappings[$old_feed_id[3]];
 							$step_ids_updated = true;

--- a/tests/acceptance-tests/_data/forms/0020-step-status-conditional-logic.json
+++ b/tests/acceptance-tests/_data/forms/0020-step-status-conditional-logic.json
@@ -1,0 +1,505 @@
+{
+  "0": {
+    "title": "Step Status Conditional Logic",
+    "description": "",
+    "labelPlacement": "top_label",
+    "descriptionPlacement": "below",
+    "button": {
+      "type": "text",
+      "text": "Submit",
+      "imageUrl": ""
+    },
+    "fields": [
+      {
+        "type": "text",
+        "id": 1,
+        "label": "Single Line",
+        "adminLabel": "",
+        "isRequired": false,
+        "size": "medium",
+        "errorMessage": "",
+        "inputs": null,
+        "formId": 11,
+        "description": "",
+        "allowsPrepopulate": false,
+        "inputMask": false,
+        "inputMaskValue": "",
+        "inputType": "",
+        "labelPlacement": "",
+        "descriptionPlacement": "",
+        "subLabelPlacement": "",
+        "placeholder": "",
+        "cssClass": "",
+        "inputName": "",
+        "visibility": "visible",
+        "noDuplicates": false,
+        "defaultValue": "",
+        "choices": "",
+        "conditionalLogic": "",
+        "productField": "",
+        "enablePasswordInput": "",
+        "maxLength": "",
+        "multipleFiles": false,
+        "maxFiles": "",
+        "calculationFormula": "",
+        "calculationRounding": "",
+        "enableCalculation": "",
+        "disableQuantity": false,
+        "displayAllCategories": false,
+        "useRichTextEditor": false
+      },
+      {
+        "type": "textarea",
+        "id": 2,
+        "label": "Paragraph",
+        "adminLabel": "",
+        "isRequired": false,
+        "size": "medium",
+        "errorMessage": "",
+        "inputs": null,
+        "formId": 11,
+        "description": "",
+        "allowsPrepopulate": false,
+        "inputMask": false,
+        "inputMaskValue": "",
+        "inputType": "",
+        "labelPlacement": "",
+        "descriptionPlacement": "",
+        "subLabelPlacement": "",
+        "placeholder": "",
+        "cssClass": "",
+        "inputName": "",
+        "visibility": "visible",
+        "noDuplicates": false,
+        "defaultValue": "",
+        "choices": "",
+        "conditionalLogic": "",
+        "productField": "",
+        "form_id": "",
+        "useRichTextEditor": false,
+        "multipleFiles": false,
+        "maxFiles": "",
+        "calculationFormula": "",
+        "calculationRounding": "",
+        "enableCalculation": "",
+        "disableQuantity": false,
+        "displayAllCategories": false
+      },
+      {
+        "type": "workflow_user",
+        "id": 3,
+        "label": "User",
+        "adminLabel": "",
+        "isRequired": false,
+        "size": "medium",
+        "errorMessage": "",
+        "inputs": null,
+        "choices": [
+          {
+            "value": 1,
+            "text": "admin"
+          },
+          {
+            "value": 2,
+            "text": "test"
+          }
+        ],
+        "formId": 11,
+        "description": "",
+        "allowsPrepopulate": false,
+        "inputMask": false,
+        "inputMaskValue": "",
+        "inputType": "",
+        "labelPlacement": "",
+        "descriptionPlacement": "",
+        "subLabelPlacement": "",
+        "placeholder": "",
+        "cssClass": "",
+        "inputName": "",
+        "visibility": "",
+        "noDuplicates": false,
+        "defaultValue": "",
+        "conditionalLogic": "",
+        "productField": "",
+        "gravityflowUsersRoleFilter": ""
+      }
+    ],
+    "version": "2.3-dev-1",
+    "id": 11,
+    "useCurrentUserAsAuthor": true,
+    "postContentTemplateEnabled": false,
+    "postTitleTemplateEnabled": false,
+    "postTitleTemplate": "",
+    "postContentTemplate": "",
+    "lastPageButton": null,
+    "pagination": null,
+    "firstPageCssClass": null,
+    "is_active": "1",
+    "date_created": "2017-11-24 12:36:35",
+    "is_trash": "0",
+    "confirmations": [
+      {
+        "id": "59329f0092288",
+        "name": "Default Confirmation",
+        "isDefault": true,
+        "type": "message",
+        "message": "Thanks for contacting us! We will get in touch with you shortly.",
+        "url": "",
+        "pageId": "",
+        "queryString": ""
+      }
+    ],
+    "notifications": [
+      {
+        "id": "59329f009139f",
+        "to": "{admin_email}",
+        "name": "Admin Notification",
+        "event": "form_submission",
+        "toType": "email",
+        "subject": "New submission from {form_title}",
+        "message": "{all_fields}"
+      }
+    ],
+    "feeds": {
+      "gravityflow": [
+        {
+          "id": "26",
+          "form_id": "11",
+          "is_active": "1",
+          "feed_order": "0",
+          "meta": {
+            "step_name": "Approval Step",
+            "description": "",
+            "step_type": "approval",
+            "feed_condition_conditional_logic": "0",
+            "feed_condition_conditional_logic_object": {
+              "conditionalLogic": {
+                "actionType": "show",
+                "logicType": "all",
+                "rules": [
+                  {
+                    "fieldId": "3",
+                    "operator": "is",
+                    "value": "1"
+                  }
+                ]
+              }
+            },
+            "scheduled": "0",
+            "schedule_type": "delay",
+            "schedule_date": "",
+            "schedule_delay_offset": "",
+            "schedule_delay_unit": "hours",
+            "schedule_date_field_offset": "0",
+            "schedule_date_field_offset_unit": "hours",
+            "schedule_date_field_before_after": "after",
+            "type": "select",
+            "assignees": [
+              "user_id|1"
+            ],
+            "routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "assignee_policy": "all",
+            "instructionsEnable": "0",
+            "instructionsValue": "Instructions: please review the values in the fields below and click on the Approve or Reject button",
+            "display_fields_mode": "all_fields",
+            "assignee_notification_enabled": "0",
+            "assignee_notification_from_name": "",
+            "assignee_notification_from_email": "{admin_email}",
+            "assignee_notification_reply_to": "",
+            "assignee_notification_bcc": "",
+            "assignee_notification_subject": "",
+            "assignee_notification_message": "A new entry is pending your approval. Please check your Workflow Inbox.",
+            "assignee_notification_disable_autoformat": "0",
+            "resend_assignee_emailEnable": "0",
+            "resend_assignee_emailValue": "7",
+            "resend_assignee_email_repeatEnable": "0",
+            "resend_assignee_email_repeatValue": "3",
+            "rejection_notification_enabled": "0",
+            "rejection_notification_type": "select",
+            "rejection_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "rejection_notification_from_name": "",
+            "rejection_notification_from_email": "{admin_email}",
+            "rejection_notification_reply_to": "",
+            "rejection_notification_bcc": "",
+            "rejection_notification_subject": "",
+            "rejection_notification_message": "Entry {entry_id} has been rejected",
+            "rejection_notification_disable_autoformat": "0",
+            "approval_notification_enabled": "0",
+            "approval_notification_type": "select",
+            "approval_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "approval_notification_from_name": "",
+            "approval_notification_from_email": "{admin_email}",
+            "approval_notification_reply_to": "",
+            "approval_notification_bcc": "",
+            "approval_notification_subject": "",
+            "approval_notification_message": "Entry {entry_id} has been approved",
+            "approval_notification_disable_autoformat": "0",
+            "note_mode": "not_required",
+            "expiration": "0",
+            "expiration_type": "delay",
+            "expiration_date": "",
+            "expiration_delay_offset": "",
+            "expiration_delay_unit": "hours",
+            "expiration_date_field_offset": "0",
+            "expiration_date_field_offset_unit": "hours",
+            "expiration_date_field_before_after": "after",
+            "status_expiration": "rejected",
+            "destination_expired": "next",
+            "destination_rejected": "next",
+            "destination_approved": "next"
+          },
+          "addon_slug": "gravityflow"
+        },
+        {
+          "id": "28",
+          "form_id": "11",
+          "is_active": "1",
+          "feed_order": "0",
+          "meta": {
+            "step_name": "Approval if Previous Approval Step Rejected",
+            "description": "",
+            "step_type": "approval",
+            "feed_condition_conditional_logic": "1",
+            "feed_condition_conditional_logic_object": {
+              "conditionalLogic": {
+                "actionType": "show",
+                "logicType": "all",
+                "rules": [
+                  {
+                    "fieldId": "workflow_step_status_26",
+                    "operator": "is",
+                    "value": "rejected"
+                  }
+                ]
+              }
+            },
+            "scheduled": "0",
+            "schedule_type": "delay",
+            "schedule_date": "",
+            "schedule_delay_offset": "",
+            "schedule_delay_unit": "hours",
+            "schedule_date_field_offset": "0",
+            "schedule_date_field_offset_unit": "hours",
+            "schedule_date_field_before_after": "after",
+            "type": "select",
+            "assignees": [
+              "user_id|1"
+            ],
+            "routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "assignee_policy": "all",
+            "instructionsEnable": "0",
+            "instructionsValue": "Instructions: please review the values in the fields below and click on the Approve or Reject button",
+            "display_fields_mode": "all_fields",
+            "assignee_notification_enabled": "0",
+            "assignee_notification_from_name": "",
+            "assignee_notification_from_email": "{admin_email}",
+            "assignee_notification_reply_to": "",
+            "assignee_notification_bcc": "",
+            "assignee_notification_subject": "",
+            "assignee_notification_message": "A new entry is pending your approval. Please check your Workflow Inbox.",
+            "assignee_notification_disable_autoformat": "0",
+            "resend_assignee_emailEnable": "0",
+            "resend_assignee_emailValue": "7",
+            "resend_assignee_email_repeatEnable": "0",
+            "resend_assignee_email_repeatValue": "3",
+            "rejection_notification_enabled": "0",
+            "rejection_notification_type": "select",
+            "rejection_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "rejection_notification_from_name": "",
+            "rejection_notification_from_email": "{admin_email}",
+            "rejection_notification_reply_to": "",
+            "rejection_notification_bcc": "",
+            "rejection_notification_subject": "",
+            "rejection_notification_message": "Entry {entry_id} has been rejected",
+            "rejection_notification_disable_autoformat": "0",
+            "approval_notification_enabled": "0",
+            "approval_notification_type": "select",
+            "approval_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "approval_notification_from_name": "",
+            "approval_notification_from_email": "{admin_email}",
+            "approval_notification_reply_to": "",
+            "approval_notification_bcc": "",
+            "approval_notification_subject": "",
+            "approval_notification_message": "Entry {entry_id} has been approved",
+            "approval_notification_disable_autoformat": "0",
+            "note_mode": "not_required",
+            "expiration": "0",
+            "expiration_type": "delay",
+            "expiration_date": "",
+            "expiration_delay_offset": "",
+            "expiration_delay_unit": "hours",
+            "expiration_date_field_offset": "0",
+            "expiration_date_field_offset_unit": "hours",
+            "expiration_date_field_before_after": "after",
+            "status_expiration": "rejected",
+            "destination_expired": "next",
+            "destination_rejected": "complete",
+            "destination_approved": "next"
+          },
+          "addon_slug": "gravityflow"
+        },
+        {
+          "id": "27",
+          "form_id": "11",
+          "is_active": "1",
+          "feed_order": "0",
+          "meta": {
+            "step_name": "Approval if Previous Approval Step Approved",
+            "description": "",
+            "step_type": "approval",
+            "feed_condition_conditional_logic": "1",
+            "feed_condition_conditional_logic_object": {
+              "conditionalLogic": {
+                "actionType": "show",
+                "logicType": "all",
+                "rules": [
+                  {
+                    "fieldId": "workflow_step_status_26",
+                    "operator": "is",
+                    "value": "approved"
+                  }
+                ]
+              }
+            },
+            "scheduled": "0",
+            "schedule_type": "delay",
+            "schedule_date": "",
+            "schedule_delay_offset": "",
+            "schedule_delay_unit": "hours",
+            "schedule_date_field_offset": "0",
+            "schedule_date_field_offset_unit": "hours",
+            "schedule_date_field_before_after": "after",
+            "type": "select",
+            "assignees": [
+              "user_id|1"
+            ],
+            "routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "assignee_policy": "all",
+            "instructionsEnable": "0",
+            "instructionsValue": "Instructions: please review the values in the fields below and click on the Approve or Reject button",
+            "display_fields_mode": "all_fields",
+            "assignee_notification_enabled": "0",
+            "assignee_notification_from_name": "",
+            "assignee_notification_from_email": "{admin_email}",
+            "assignee_notification_reply_to": "",
+            "assignee_notification_bcc": "",
+            "assignee_notification_subject": "",
+            "assignee_notification_message": "A new entry is pending your approval. Please check your Workflow Inbox.",
+            "assignee_notification_disable_autoformat": "0",
+            "resend_assignee_emailEnable": "0",
+            "resend_assignee_emailValue": "7",
+            "resend_assignee_email_repeatEnable": "0",
+            "resend_assignee_email_repeatValue": "3",
+            "rejection_notification_enabled": "0",
+            "rejection_notification_type": "select",
+            "rejection_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "rejection_notification_from_name": "",
+            "rejection_notification_from_email": "{admin_email}",
+            "rejection_notification_reply_to": "",
+            "rejection_notification_bcc": "",
+            "rejection_notification_subject": "",
+            "rejection_notification_message": "Entry {entry_id} has been rejected",
+            "rejection_notification_disable_autoformat": "0",
+            "approval_notification_enabled": "0",
+            "approval_notification_type": "select",
+            "approval_notification_routing": [
+              {
+                "assignee": "user_id|1",
+                "fieldId": "0",
+                "operator": "is",
+                "value": "",
+                "type": ""
+              }
+            ],
+            "approval_notification_from_name": "",
+            "approval_notification_from_email": "{admin_email}",
+            "approval_notification_reply_to": "",
+            "approval_notification_bcc": "",
+            "approval_notification_subject": "",
+            "approval_notification_message": "Entry {entry_id} has been approved",
+            "approval_notification_disable_autoformat": "0",
+            "note_mode": "not_required",
+            "expiration": "0",
+            "expiration_type": "delay",
+            "expiration_date": "",
+            "expiration_delay_offset": "",
+            "expiration_delay_unit": "hours",
+            "expiration_date_field_offset": "0",
+            "expiration_date_field_offset_unit": "hours",
+            "expiration_date_field_before_after": "after",
+            "status_expiration": "rejected",
+            "destination_expired": "next",
+            "destination_rejected": "complete",
+            "destination_approved": "next"
+          },
+          "addon_slug": "gravityflow"
+        }
+      ]
+    }
+  },
+  "version": "2.2.5.5"
+}

--- a/tests/acceptance-tests/acceptance/0020StepStatusConditionalLogicCept.php
+++ b/tests/acceptance-tests/acceptance/0020StepStatusConditionalLogicCept.php
@@ -1,0 +1,35 @@
+<?php
+//$scenario->skip();
+/*
+ * Test summary: perform step if previous step status is rejected
+ *
+ * Test details:
+ * - Fill in the form fields.
+ * - Login to back-end, go to Inbox
+ * - Click on the 'Step Status Conditional Logic' Workflow
+ * - Click on the 'Reject' button
+ * - Go to 'Approval if Previous Approval Step Rejected' step
+ * - Click on the 'Approve' button
+ */
+
+$I = new AcceptanceTester( $scenario );
+
+$I->loginAsAdmin();
+
+$I->amOnPage( '/step-status-conditional-logic' );
+$I->fillField( 'Single Line', 'test' );
+$I->fillField( 'Paragraph', 'test' );
+$I->selectOption( 'User', '1' );
+$I->click( 'Submit' );
+
+
+$I->amOnWorkflowPage( 'Inbox' );
+$I->click( 'Step Status Conditional Logic' );
+
+$I->waitforText( 'Approval Step' );
+$I->see( 'Approval Step', '.gravityflow-status-box' );
+$I->click( 'Reject' );
+
+$I->waitforText( 'Approval if Previous Approval Step Rejected' );
+$I->see( 'Approval if Previous Approval Step Rejected', '.gravityflow-status-box' );
+$I->dontSee( 'Approval if Previous Approval Step Approved', '.gravityflow-status-box' );


### PR DESCRIPTION
When using "step status" as feed condition, Gravity Flow doesn't update the feed IDs after importing the form. That makes all steps with such conditions skipped.

To reproduce this issue, create two steps and set the "Feed Condition" for the second step to depend on "if Status: First Step is Approved." Export the form and import it again. Should see the field ID (Status: First Step) missing.

These commits come with an acceptance test to validate it has been fixed.