### PR TITLE
Fix conditional logic issue with section breaks when the Selected Fields display mode is enabled

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -579,7 +579,7 @@ class Gravity_Flow_Entry_Editor {
 		$display_fields_selected = is_array( $this->step->display_fields_selected ) ? $this->step->display_fields_selected : array();
 
 		if ( $display_fields_mode == 'selected_fields' ) {
-			if ( ! in_array( $field->id, $display_fields_selected ) ) {
+			if ( $field->type !== 'section' && ! in_array( $field->id, $display_fields_selected ) ) {
 				$display_field = false;
 			}
 		} else {


### PR DESCRIPTION
Section Breaks show during the User Input step regardless of being selected in the UI. This change adds to ce3e767f937f02dfb0648269a02b2caea12c7805 to account for the Selected Fields option being enabled.