### PR TITLE
Add a unique GravityFlow class to the update notice is it can be targeted via CSS

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3709,7 +3709,7 @@ PRIMARY KEY  (id)
 					$entry = GFAPI::get_entry( $entry_id ); // refresh entry
 
 					?>
-					<div class="updated notice notice-success is-dismissible" style="padding:6px;">
+					<div class="gravityflow_workflow_notice updated notice notice-success is-dismissible" style="padding:6px;">
 						<?php echo $feedback; ?>
 					</div>
 					<?php


### PR DESCRIPTION
When the inbox shortcode is used, the success notice HTML markup isn't wrapped in any GravityFlow identifying markup (like `gravityflow_workflow_wrap` which occurs after the notice). This PR makes it easier to target the GravityFlow success notice directly.

The error notice wasn't modified because it has a unique GravityFlow class (`gravityflow_validation_error`) already.