### PR TITLE
4933 translation filter

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2611,20 +2611,14 @@ PRIMARY KEY  (id)
 			*
 			* @param string $date_format A date format string - defaults to 'Y/m/d'
 			*/
-			$date_created_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
-			printf( '%s: %s', esc_html__( 'Submitted', 'gravityflow' ), esc_html( GFCommon::format_date( $entry['date_created'], true, $date_created_format ) ) );
+			$date_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
+			printf( '%s: %s', esc_html__( 'Submitted', 'gravityflow' ), esc_html( GFCommon::format_date( $entry['date_created'], true, $date_format ) ) );
 
 			if ( ! empty( $entry['workflow_timestamp'] ) ) {
 				$last_updated = date( 'Y-m-d H:i:s', $entry['workflow_timestamp'] );
 				if ( $entry['date_created'] != $last_updated ) {
 					echo '<br /><br />';
-					/**
-					* Allows the format for dates within the entry detail workflow info box to be modified.
-					*
-					* @param string $date_format A date format string - defaults to 'Y/m/d'
-					*/
-					$date_updated_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
-					esc_html_e( 'Last updated', 'gravityflow' ); ?>: <?php echo esc_html( GFCommon::format_date( $last_updated, true, $date_updated_format ) );
+					esc_html_e( 'Last updated', 'gravityflow' ); ?>: <?php echo esc_html( GFCommon::format_date( $last_updated, true, $date_format ) );
 				}
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2604,13 +2604,16 @@ PRIMARY KEY  (id)
 				$entry_id_link = '<a href="' . admin_url( 'admin.php?page=gf_entries&view=entry&id=' . absint( $form['id'] ) . '&lid=' . absint( $entry['id'] ) ) . '">' . $entry_id . '</a>';
 			}
 
-			printf( '%s: %s<br/><br/>%s: %s', esc_html__( 'Entry ID', 'gravityflow' ), $entry_id_link, esc_html__( 'Submitted', 'gravityflow' ), esc_html( GFCommon::format_date( $entry['date_created'], true, 'Y/m/d' ) ) );
+			printf( '%s: %s<br/><br/>', esc_html__( 'Entry ID', 'gravityflow' ), $entry_id_link );
+			$date_created_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
+			printf( '%s: %s', esc_html__( 'Submitted', 'gravityflow' ), esc_html( GFCommon::format_date( $entry['date_created'], true, $date_created_format ) ) );
 
 			if ( ! empty( $entry['workflow_timestamp'] ) ) {
 				$last_updated = date( 'Y-m-d H:i:s', $entry['workflow_timestamp'] );
 				if ( $entry['date_created'] != $last_updated ) {
 					echo '<br /><br />';
-					esc_html_e( 'Last updated', 'gravityflow' ); ?>: <?php echo esc_html( GFCommon::format_date( $last_updated, true, 'Y/m/d' ) );
+					$date_updated_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
+					esc_html_e( 'Last updated', 'gravityflow' ); ?>: <?php echo esc_html( GFCommon::format_date( $last_updated, true, $date_updated_format ) );
 				}
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2605,6 +2605,12 @@ PRIMARY KEY  (id)
 			}
 
 			printf( '%s: %s<br/><br/>', esc_html__( 'Entry ID', 'gravityflow' ), $entry_id_link );
+
+			/**
+			 * Allows the format for dates within the entry detail workflow info box to be modified.
+			*
+			* @param string $date_format A date format string - defaults to 'Y/m/d'
+			*/
 			$date_created_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
 			printf( '%s: %s', esc_html__( 'Submitted', 'gravityflow' ), esc_html( GFCommon::format_date( $entry['date_created'], true, $date_created_format ) ) );
 
@@ -2612,6 +2618,11 @@ PRIMARY KEY  (id)
 				$last_updated = date( 'Y-m-d H:i:s', $entry['workflow_timestamp'] );
 				if ( $entry['date_created'] != $last_updated ) {
 					echo '<br /><br />';
+					/**
+					* Allows the format for dates within the entry detail workflow info box to be modified.
+					*
+					* @param string $date_format A date format string - defaults to 'Y/m/d'
+					*/
 					$date_updated_format = apply_filters( 'gravityflow_date_format_entry_detail', 'Y/m/d' );
 					esc_html_e( 'Last updated', 'gravityflow' ); ?>: <?php echo esc_html( GFCommon::format_date( $last_updated, true, $date_updated_format ) );
 				}


### PR DESCRIPTION
On the Entry Detail screen workflow info box, the Last Updated and Submitted dates were being passed through GFCommon::format_date with a hard-coded 'Y/m/d' date_format parameter. This PR adds a new filter - gravityflow_date_format_entry_detail - to that parameter.

Note for translation / review...The impact is only displayed out of GFCommon::format_date for timestamps older than 24 hours (getting escaped through '%1$s at %2$s') instead of '%s ago'