### PR TITLE
Refresh the entry before getting the next step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue where, in some situations, getting the next step was not using the latest version of the entry.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4689,10 +4689,13 @@ PRIMARY KEY  (id)
 
 					$this->log_debug( __METHOD__ . '() - getting next step.' );
 
-					$step = $this->get_next_step( $step, $entry, $form );
+					// Refresh the entry before getting the next step.
+					$entry         = GFAPI::get_entry( $entry_id );
+					$step          = $this->get_next_step( $step, $entry, $form );
 					$step_complete = false;
+
 					if ( $step ) {
-						$step_id = $step->get_id();
+						$step_id       = $step->get_id();
 						$step_complete = $step->start();
 						if ( $step_complete ) {
 							$step->end();


### PR DESCRIPTION
re: [HS#5186](https://secure.helpscout.net/conversation/506497512/5186?folderId=1113535)

Fixes an issue where conditional logic evaluation whilst getting the next step was using the old entry from before the update entry step had run.