### PR TITLE
Add new filter gravityflow_step_schedule_timestamp

### DIFF
--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -659,13 +659,13 @@ abstract class Gravity_Flow_Step extends stdClass {
 			 *
 			 * @since 2.0.2-dev
 			 *
-			 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+			 * @param int                  $schedule_timestamp The current scheduled timestamp (UTC)
 			 * @param string               $schedule_type      The type of schedule defined in step settings.
 			 * @param Gravity_Flow_Step    $this               The current step.
 			 *
-			 * @return timestamp
+			 * @return int
 			 */
-			$schedule_datetime = apply_filters( 'gravityflow_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
+			$schedule_datetime = apply_filters( 'gravityflow_step_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
 			return $schedule_datetime;
 		}
 
@@ -711,13 +711,13 @@ abstract class Gravity_Flow_Step extends stdClass {
 			 *
 			 * @since 2.0.2-dev
 			 *
-			 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+			 * @param int                  $schedule_timestamp The current scheduled timestamp (UTC)
 			 * @param string               $schedule_type      The type of schedule defined in step settings.
 			 * @param Gravity_Flow_Step    $this               The current step.
 			 *
-			 * @return timestamp
+			 * @return int
 			 */
-			$schedule_datetime = apply_filters( 'gravityflow_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
+			$schedule_datetime = apply_filters( 'gravityflow_step_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
 			return $schedule_datetime;
 		}
 
@@ -745,13 +745,13 @@ abstract class Gravity_Flow_Step extends stdClass {
 		 *
 		 * @since 2.0.2-dev
 		 *
-		 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+		 * @param int                  $schedule_timestamp The current scheduled timestamp (UTC)
 		 * @param string               $schedule_type      The type of schedule defined in step settings.
 		 * @param Gravity_Flow_Step    $this               The current step.
 		 *
-		 * @return timestamp
+		 * @return int
 		 */
-		$schedule_timestamp = apply_filters( 'gravityflow_schedule_timestamp', $schedule_timestamp, $this->schedule_type, $this );
+		$schedule_timestamp = apply_filters( 'gravityflow_step_schedule_timestamp', $schedule_timestamp, $this->schedule_type, $this );
 		return $schedule_timestamp;
 	}
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -654,6 +654,18 @@ abstract class Gravity_Flow_Step extends stdClass {
 			$schedule_date_gmt = get_gmt_from_date( $schedule_date );
 			$schedule_datetime = strtotime( $schedule_date_gmt );
 
+			/**
+			 * Allows the scheduled date/timestamp to be custom defined.
+			 *
+			 * @since 2.0.2-dev
+			 *
+			 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+			 * @param string               $schedule_type      The type of schedule defined in step settings.
+			 * @param Gravity_Flow_Step    $this               The current step.
+			 *
+			 * @return timestamp
+			 */
+			$schedule_datetime = apply_filters( 'gravityflow_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
 			return $schedule_datetime;
 		}
 
@@ -694,6 +706,18 @@ abstract class Gravity_Flow_Step extends stdClass {
 				}
 			}
 
+			/**
+			 * Allows the scheduled date/timestamp to be custom defined.
+			 *
+			 * @since 2.0.2-dev
+			 *
+			 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+			 * @param string               $schedule_type      The type of schedule defined in step settings.
+			 * @param Gravity_Flow_Step    $this               The current step.
+			 *
+			 * @return timestamp
+			 */
+			$schedule_datetime = apply_filters( 'gravityflow_schedule_timestamp', $schedule_datetime, $this->schedule_type, $this );
 			return $schedule_datetime;
 		}
 
@@ -716,6 +740,18 @@ abstract class Gravity_Flow_Step extends stdClass {
 				break;
 		}
 
+		/**
+		 * Allows the scheduled date/timestamp to be custom defined.
+		 *
+		 * @since 2.0.2-dev
+		 *
+		 * @param timestamp            $schedule_timestamp The current scheduled timestamp.
+		 * @param string               $schedule_type      The type of schedule defined in step settings.
+		 * @param Gravity_Flow_Step    $this               The current step.
+		 *
+		 * @return timestamp
+		 */
+		$schedule_timestamp = apply_filters( 'gravityflow_schedule_timestamp', $schedule_timestamp, $this->schedule_type, $this );
 		return $schedule_timestamp;
 	}
 


### PR DESCRIPTION
This gist -  https://gist.github.com/Idealien/55cd37f96936637f5838f7267d7bde4a - would delay a non-business-hours step by 4 hours. 
**To Test:**
- Create a step that is scheduled in any format, easiest to test is 1 minute delay
- Add the gist above with appropriate check for step / form involved.
- Test at various times, or change server settings to cover appropriate cycles

Relates to HS#5309
