### PR TITLE
Add support for GP Nested Forms

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
+- Added support for the Gravity Perks Nested Forms add-on.
 - Added the current step as parameters to the gravityflow_feedback_approval_token and gravityflow_feedback_approval filters.
 - Added the gravityflow_feedback_cancel_workflow filter to allow the user feedback to be modified when the workflow is cancelled using the cancel workflow link.
 - Added the gravityflow_inbox_search_criteria filter to allow the search criteria to be modify.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4640,13 +4640,25 @@ PRIMARY KEY  (id)
 				$feed = gf_paypal()->get_single_submission_feed( $entry, $form );
 
 				if ( ! empty( $feed ) && $this->is_delayed( $feed ) && $this->has_paypal_payment( $feed, $form, $entry ) ) {
-					$this->log_debug( __METHOD__ . '() - processing delayed pending PayPal payment for entry id ' . $entry['id'] );
-					remove_action( 'gform_after_submission', array( $this, 'after_submission' ), 9 );
 					$is_delayed = true;
 				}
 			}
 
-			if ( ! $is_delayed ) {
+			/**
+			 * Allow processing of the workflow to be delayed.
+			 *
+			 * @since 2.0.2-dev
+			 *
+			 * @param bool  $is_delayed Indicates if processing of the workflow should be delayed.
+			 * @param array $entry      The current entry.
+			 * @param array $form       The current form.
+			 */
+			$is_delayed = apply_filters( 'gravityflow_is_delayed_pre_process_workflow', $is_delayed, $entry, $form );
+
+			if ( $is_delayed ) {
+				$this->log_debug( __METHOD__ . '() - processing delayed for entry id ' . $entry['id'] );
+				remove_action( 'gform_after_submission', array( $this, 'after_submission' ), 9 );
+			} else {
 				gform_update_meta( $entry['id'], "{$this->_slug}_is_fulfilled", true );
 			}
 		}

--- a/gravityflow.php
+++ b/gravityflow.php
@@ -87,6 +87,8 @@ class Gravity_Flow_Bootstrap {
 		require_once( 'class-gravity-flow.php' );
 		require_once( 'includes/models/class-activity.php' );
 
+		require_once( 'includes/integrations/class-gp-nested-forms.php' );
+
 		self::include_steps();
 		self::include_fields();
 		self::include_merge_tags();

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -170,12 +170,16 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @since 2.0.2-dev
 	 */
 	private function maybe_delete_cookie() {
-		if ( ! $this->is_current_step_submission() || empty( GFAPI::get_fields_by_type( $this->get_form(), 'form' ) ) ) {
+		if ( ! $this->is_current_step_submission() ) {
 			return;
 		}
 
-		$session = new GPNF_Session( $this->get_form_id() );
-		$session->delete_cookie();
+		$nested_fields = GFAPI::get_fields_by_type( $this->get_form(), 'form' );
+
+		if ( ! empty( $nested_fields ) ) {
+			$session = new GPNF_Session( $this->get_form_id() );
+			$session->delete_cookie();
+		}
 	}
 
 	/**

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -48,6 +48,15 @@ class Gravity_Flow_GP_Nested_Forms {
 	private $_current_step = false;
 
 	/**
+	 * The Nested Form IDs.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @var array
+	 */
+	private $_nested_forms = array();
+
+	/**
 	 * Gravity_Flow_GP_Nested_Forms constructor.
 	 *
 	 * Adds the hooks on the init action, after the GP Nested Form add-on has been loaded.
@@ -362,9 +371,10 @@ class Gravity_Flow_GP_Nested_Forms {
 	 */
 	public function filter_gravityflow_field_value_entry_editor( $value, $field, $form, $entry, $current_step ) {
 		if ( $field->type === 'form' ) {
-			$this->_form         = $form;
-			$this->_entry        = $entry;
-			$this->_current_step = $current_step;
+			$this->_form           = $form;
+			$this->_entry          = $entry;
+			$this->_current_step   = $current_step;
+			$this->_nested_forms[] = $field->gpnfForm;
 			$this->add_late_hooks( $form['id'], $field->id );
 		}
 
@@ -403,7 +413,14 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @since 2.0.2-dev
 	 */
 	public function output_nested_forms_markup() {
+		unset( $_GET['view'] );
 		echo gp_nested_forms()->get_nested_forms_markup( $this->get_form() );
+
+		if ( is_admin() ) {
+			foreach ( $this->_nested_forms as $nested_form_id ) {
+				GFFormDisplay::footer_init_scripts( $nested_form_id );
+			}
+		}
 	}
 
 	/**

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -345,7 +345,7 @@ class Gravity_Flow_GP_Nested_Forms {
 	 */
 	private function maybe_process_nested_form_workflows( $entry, $form ) {
 		foreach ( $form['fields'] as $field ) {
-			if ( $field->type !== 'form' ) {
+			if ( $field->type !== 'form' || $field->gpnfFeedProcessing === 'child' ) {
 				continue;
 			}
 

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -57,13 +57,37 @@ class Gravity_Flow_GP_Nested_Forms {
 	private $_nested_forms = array();
 
 	/**
+	 * The instance of this class.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @var null|Gravity_Flow_GP_Nested_Forms
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Returns an instance of this class, and stores it in the $_instance property.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return null|Gravity_Flow_GP_Nested_Forms
+	 */
+	public static function get_instance() {
+		if ( self::$_instance === null ) {
+			self::$_instance = new self();
+		}
+
+		return self::$_instance;
+	}
+
+	/**
 	 * Gravity_Flow_GP_Nested_Forms constructor.
 	 *
 	 * Adds the hooks on the init action, after the GP Nested Form add-on has been loaded.
 	 *
 	 * @since 2.0.2-dev
 	 */
-	public function __construct() {
+	private function __construct() {
 		add_action( 'init', array( $this, 'maybe_add_hooks' ) );
 	}
 
@@ -577,4 +601,4 @@ class Gravity_Flow_GP_Nested_Forms {
 
 }
 
-new Gravity_Flow_GP_Nested_Forms();
+Gravity_Flow_GP_Nested_Forms::get_instance();

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Gravity Flow GP Nested Forms
+ *
+ * @package     GravityFlow
+ * @copyright   Copyright (c) 2015-2018, Steven Henty S.L.
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+if ( ! class_exists( 'GFForms' ) ) {
+	die();
+}
+
+/**
+ * Class Gravity_Flow_GP_Nested_Forms
+ *
+ * Enables the Nested Form field to function on the workflow detail page.
+ *
+ * @since 2.0.2-dev
+ */
+class Gravity_Flow_GP_Nested_Forms {
+
+	/**
+	 * The current form array.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @var array
+	 */
+	private $_form = array();
+
+	/**
+	 * The current entry array.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @var array
+	 */
+	private $_entry = array();
+
+	/**
+	 * The current step.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @var bool|Gravity_Flow_Step
+	 */
+	private $_current_step = false;
+
+	/**
+	 * Gravity_Flow_GP_Nested_Forms constructor.
+	 *
+	 * Adds the hooks on the init action, after the GP Nested Form add-on has been loaded.
+	 *
+	 * @since 2.0.2-dev
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'maybe_add_hooks' ) );
+	}
+
+	/**
+	 * Returns the parent entry step ID.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return int
+	 */
+	private function get_step_id() {
+		return absint( rgpost( 'step_id' ) );
+	}
+
+	/**
+	 * Returns the parent entry ID.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return int
+	 */
+	private function get_entry_id() {
+		return absint( rgget( 'lid' ) );
+	}
+
+	/**
+	 * Returns the parent form ID.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return int
+	 */
+	private function get_form_id() {
+		return absint( rgget( 'id' ) );
+	}
+
+	/**
+	 * Returns the parent entry.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return array
+	 */
+	private function get_entry() {
+		if ( empty( $this->_entry ) ) {
+			$this->_entry = GFAPI::get_entry( $this->get_entry_id() );
+		}
+
+		return $this->_entry;
+	}
+
+	/**
+	 * Returns the parent form.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return array
+	 */
+	private function get_form() {
+		if ( empty( $this->_form ) ) {
+			$this->_form = GFAPI::get_form( $this->get_form_id() );
+		}
+
+		return $this->_form;
+	}
+
+	/**
+	 * Returns the current step or false.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return bool|Gravity_Flow_Step
+	 */
+	private function get_current_step() {
+		if ( empty( $this->_current_step ) ) {
+			$this->_current_step = gravity_flow()->get_current_step( $this->get_form(), $this->get_entry() );
+		}
+
+		return $this->_current_step;
+	}
+
+	/**
+	 * Returns the key to be used for the entry meta item.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param bool|int $step_id False or the parent forms current step ID.
+	 *
+	 * @return string
+	 */
+	private function get_meta_key( $step_id = false ) {
+		if ( empty( $step_id ) ) {
+			$step_id = $this->get_step_id();
+		}
+
+		return 'workflow_step_' . $step_id . '_process_nested_form';
+	}
+
+	/**
+	 * Determines if this is a workflow detail page submission for the current step.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @return bool
+	 */
+	private function is_current_step_submission() {
+		return rgpost( 'gravityflow_submit' ) == $this->get_form()['id'] && $this->get_step_id() == $this->get_current_step()->get_id();
+	}
+
+	/**
+	 * If the GP Nested Forms add-on is available and this is the workflow detail page add the hooks which need loading first.
+	 *
+	 * @since 2.0.2-dev
+	 */
+	public function maybe_add_hooks() {
+		if ( ! function_exists( 'gp_nested_forms' ) || ! gravity_flow()->is_workflow_detail_page() ) {
+			return;
+		}
+
+		add_action( 'gform_after_update_entry', array( $this, 'action_gform_after_update_entry' ), 10, 3 );
+		add_action( 'gravityflow_step_complete', array( $this, 'action_gravityflow_step_complete' ), 10, 5 );
+
+		add_filter( 'gravityflow_field_value_entry_editor', array( $this, 'filter_gravityflow_field_value_entry_editor' ), 10, 5 );
+		add_filter( 'gravityflow_is_delayed_pre_process_workflow', array( $this, 'filter_gravityflow_is_delayed_pre_process_workflow' ) );
+	}
+
+	/**
+	 * Delays processing of the workflow for the child form entries.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param bool $is_delayed Indicates if workflow processing is delayed.
+	 *
+	 * @return bool
+	 */
+	public function filter_gravityflow_is_delayed_pre_process_workflow( $is_delayed ) {
+		if ( gp_nested_forms()->is_nested_form_submission() ) {
+			$parent_form       = GFAPI::get_form( gp_nested_forms()->get_parent_form_id() );
+			$nested_form_field = gp_nested_forms()->get_posted_nested_form_field( $parent_form );
+			$is_delayed        = $nested_form_field->gpnfFeedProcessing !== 'child';
+		}
+
+		return $is_delayed;
+	}
+
+	/**
+	 * Determines if the current field is an editable Nested Form field so the required functionality can be included.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param mixed             $value        The current field value.
+	 * @param GF_Field          $field        The current field.
+	 * @param array             $form         The parent form.
+	 * @param array             $entry        The parent entry.
+	 * @param Gravity_Flow_Step $current_step The current step for the parent entry.
+	 *
+	 * @return mixed
+	 */
+	public function filter_gravityflow_field_value_entry_editor( $value, $field, $form, $entry, $current_step ) {
+		if ( $field->type === 'form' ) {
+			$this->_form         = $form;
+			$this->_entry        = $entry;
+			$this->_current_step = $current_step;
+			$this->add_late_hooks( $form['id'], $field->id );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Includes the hooks which will enable the Nested Form field to function on the entry editor.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param int $form_id  The parent form ID.
+	 * @param int $field_id The current Nested Form field ID.
+	 */
+	private function add_late_hooks( $form_id, $field_id ) {
+		// Removing to prevent the child form markup being generated before the entry editor filters are removed.
+		remove_action( 'gform_get_form_filter', array( gp_nested_forms(), 'handle_nested_forms_markup' ) );
+
+		add_filter( "gpnf_init_script_args_{$form_id}_{$field_id}", array( $this, 'filter_gpnf_init_script_args' ), 10, 2 );
+
+		if ( ! has_action( 'admin_footer', array( $this, 'output_nested_forms_markup' ) ) ) {
+			add_action( 'admin_footer', array( $this, 'output_nested_forms_markup' ) );
+		}
+
+		if ( ! has_action( 'wp_footer', array( $this, 'output_nested_forms_markup' ) ) ) {
+			add_action( 'wp_footer', array( $this, 'output_nested_forms_markup' ) );
+		}
+	}
+
+	/**
+	 * Generate and output the child form and modal markup for the Nested Form field in the page footer.
+	 *
+	 * @since 2.0.2-dev
+	 */
+	public function output_nested_forms_markup() {
+		echo gp_nested_forms()->get_nested_forms_markup( $this->get_form() );
+	}
+
+	/**
+	 * If the child form has entries for this parent entry add them to the fields init script arguments so they will be listed in the table on field render.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param array    $args  The arguments that will be used to initialize the nested forms frontend script.
+	 * @param GF_Field $field The Nested Form field object.
+	 *
+	 * @return array
+	 */
+	public function filter_gpnf_init_script_args( $args, $field ) {
+		if ( empty( $args['entries'] ) && ! $this->is_current_step_submission() ) {
+			$value   = GFFormsModel::get_lead_field_value( $this->get_entry(), $field );
+			$entries = gp_nested_forms()->get_entries( $value );
+
+			if ( ! empty( $entries ) ) {
+				$nested_form = GFAPI::get_form( $field->gpnfForm );
+				foreach ( $entries as $entry ) {
+					$args['entries'][] = gp_nested_forms()->get_entry_display_values( $entry, $nested_form, $field->gpnfFields );
+				}
+			}
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Determines if the parent entry values of any Nested Form fields have changed so an entry meta item can be set to flag them for processing on step completion.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param array $form           The parent form.
+	 * @param int   $entry_id       The parent entry ID.
+	 * @param array $original_entry The parent entry before it was updated.
+	 */
+	public function action_gform_after_update_entry( $form, $entry_id, $original_entry ) {
+		if ( ! $this->is_current_step_submission() ) {
+			return;
+		}
+
+		foreach ( $form['fields'] as $field ) {
+			if ( $field->type !== 'form' ) {
+				continue;
+			}
+
+			$entry = GFAPI::get_entry( $entry_id );
+
+			if ( rgar( $entry, $field->id ) !== rgar( $original_entry, $field->id ) ) {
+				gform_update_meta( $entry_id, $this->get_meta_key(), true, $form['id'] );
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Triggers processing of the delayed notifications, feeds, and workflows for the Nested Form fields, if the entry meta item indicates processing is required.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param int               $step_id      The parent step ID.
+	 * @param int               $entry_id     The parent entry ID.
+	 * @param int               $form_id      The parent form ID.
+	 * @param string            $status       The step status.
+	 * @param Gravity_Flow_Step $current_step The step being completed by the parent form.
+	 */
+	public function action_gravityflow_step_complete( $step_id, $entry_id, $form_id, $status, $current_step ) {
+		$meta_key            = $this->get_meta_key( $step_id );
+		$requires_processing = gform_get_meta( $entry_id, $meta_key );
+		if ( $requires_processing ) {
+			$current_step->log_debug( __METHOD__ . '(): triggering processing of delayed nested form notifications and feeds.' );
+			$entry = $current_step->get_entry();
+			$form  = $current_step->get_form();
+			gpnf_notification_processing()->maybe_send_child_notifications( $entry, $form );
+			gpnf_feed_processing()->process_feeds( $entry, $form );
+			$this->maybe_process_nested_form_workflows( $entry, $form );
+			gform_delete_meta( $entry_id, $meta_key );
+		}
+	}
+
+	/**
+	 * Triggers processing of the child form workflows.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param array $entry The parent entry.
+	 * @param array $form  The parent form.
+	 */
+	private function maybe_process_nested_form_workflows( $entry, $form ) {
+		foreach ( $form['fields'] as $field ) {
+			if ( $field->type !== 'form' ) {
+				continue;
+			}
+
+			$entry_ids = array_map( 'trim', explode( ',', rgar( $entry, $field->id, '' ) ) );
+			if ( empty( $entry_ids ) ) {
+				continue;
+			}
+
+			$nested_form = GFAPI::get_form( $field->gpnfForm );
+
+			foreach ( $entry_ids as $entry_id ) {
+				gravity_flow()->process_workflow( $nested_form, $entry_id );
+			}
+		}
+	}
+
+}
+
+new Gravity_Flow_GP_Nested_Forms();

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -413,10 +413,13 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @since 2.0.2-dev
 	 */
 	public function output_nested_forms_markup() {
+		// Prevent GFCommon::get_field_input() displaying the "Product fields are not editable" message.
 		unset( $_GET['view'] );
 		echo gp_nested_forms()->get_nested_forms_markup( $this->get_form() );
 
 		if ( is_admin() ) {
+			// GP Nested Forms forces the child form init scripts into the footer and uses gform_footer_init_scripts_filter to modify them.
+			// GFForms::get_form() does not call GFFormDisplay::footer_init_scripts() in the admin.
 			foreach ( $this->_nested_forms as $nested_form_id ) {
 				GFFormDisplay::footer_init_scripts( $nested_form_id );
 			}

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -179,6 +179,7 @@ class Gravity_Flow_GP_Nested_Forms {
 
 		add_filter( 'gravityflow_field_value_entry_editor', array( $this, 'filter_gravityflow_field_value_entry_editor' ), 10, 5 );
 		add_filter( 'gravityflow_is_delayed_pre_process_workflow', array( $this, 'filter_gravityflow_is_delayed_pre_process_workflow' ) );
+		add_filter( 'gpnf_entry_url', array( $this, 'filter_gpnf_entry_url' ), 10, 3 );
 	}
 
 	/**
@@ -198,6 +199,21 @@ class Gravity_Flow_GP_Nested_Forms {
 		}
 
 		return $is_delayed;
+	}
+
+	/**
+	 * Replaces the entry detail page URL with the workflow detail page URL for the child entry.
+	 *
+	 * @since 2.0.2-dev
+	 *
+	 * @param string $url      The entry detail page URL.
+	 * @param int    $entry_id The child entry ID.
+	 * @param int    $form_id  The Nested Form form ID.
+	 *
+	 * @return string
+	 */
+	public function filter_gpnf_entry_url( $url, $entry_id, $form_id ) {
+		return add_query_arg( array( 'id' => $form_id, 'lid' => $entry_id ) );
 	}
 
 	/**

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -301,8 +301,10 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @return array
 	 */
 	public function filter_gpnf_template_args( $args, $field ) {
-		$url                          = $this->get_related_entries_url( $field );
-		$args['related_entries_link'] = $url ? preg_replace( '~href=".+"~', 'href="' . $url . '"', $args['related_entries_link'] ) : '';
+		if ( isset( $args['related_entries_link'] ) ) {
+			$url                          = $this->get_related_entries_url( $field );
+			$args['related_entries_link'] = $url ? preg_replace( '~href=".+"~', 'href="' . $url . '"', $args['related_entries_link'] ) : '';
+		}
 
 		return $args;
 	}

--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -161,7 +161,7 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @return bool
 	 */
 	private function is_current_step_submission() {
-		return rgpost( 'gravityflow_submit' ) == $this->get_form()['id'] && $this->get_step_id() == $this->get_current_step()->get_id();
+		return rgpost( 'gravityflow_submit' ) == rgar( $this->get_form(), 'id' ) && $this->get_step_id() == $this->get_current_step()->get_id();
 	}
 
 	/**

--- a/includes/integrations/index.php
+++ b/includes/integrations/index.php
@@ -1,0 +1,2 @@
+<?php
+//Nothing to see here


### PR DESCRIPTION
cc @spivurno

This enables the Nested Form field to function on the workflow detail page when selected as an editable field on the user input step.

**Child form configuration:**
- Add an Email type field.
- Configure a feed for an add-on such as MailChimp or User Registration.
- Configure a Workflow with two steps: approval step and then a step for the feed based add-on.

**Parent form configuration:**
- Add a Nested Form field selecting the above child form.
- Add one or more additional fields of any type.
- Configure a Workflow with two user input steps. The Nested Form field should be selected as editable on the first step. On the second step select one of the other fields as the editable field and the Nested form field as the display field.

**Testing:**
- Ensure logging is enabled for core and all add-ons.
- Preview the Parent form.
- Add one child entry to the Nested Form field.
- Submit the form.
- Access the inbox and view the parent form entry.
- Check the child entry is displayed in the Nested Form field.
- Check the child entry edit and delete links function.
- Add a new child entry.
- Check the logs to ensure the workflow and feed have not been processed for the child entry.
- Submit the step.
- Check the Nested Form field is using the non-editable entry detail page content and includes the child entry.
- Check the browser console to confirm there are no js errors related to the Nested Form field.
- Check the logs to ensure the child entry workflow has started and that the feed has not been processed.
- Access the inbox and view the child form entry.
- Approve the child form entry.
- Check the logs to ensure the feed has now been processed for the child entry.