### PR TITLE
5406 discussion display more

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -6,3 +6,4 @@
 - Updated the Sliced Invoices integration.
 - Added the gravityflow_step_schedule_timestamp filter to allow the scheduled start of steps to apply custom logic (business hours, delay specific entries, etc)
 - Updated discussion field to support use of view more / less on non-edit field scenarios (display only field on user input or any other step type) including status page
+- Added filter gravityflow_discussion_items_display_toggle to allow view more / less to be active or inactive per discussion field

--- a/change_log.txt
+++ b/change_log.txt
@@ -5,3 +5,4 @@
 - Fixed an issue where calculated product fields hidden by conditional logic could appear in order summary when the entry is updated on the User Input step.
 - Updated the Sliced Invoices integration.
 - Added the gravityflow_step_schedule_timestamp filter to allow the scheduled start of steps to apply custom logic (business hours, delay specific entries, etc)
+- Updated discussion field to support use of view more / less on non-edit field scenarios (display only field on user input or any other step type) including status page

--- a/css/discussion-field.css
+++ b/css/discussion-field.css
@@ -24,3 +24,13 @@
 .rtl .gravityflow-dicussion-item-toggle-display {
     float: left;
 }
+
+@media print {
+    .gravityflow-dicussion-item-hidden { 
+        display:block !important;
+    }
+
+    .gravityflow-dicussion-item-toggle-display { 
+        display: none;
+    }
+}

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -411,3 +411,13 @@ table#gravityflow-inbox tbody tr{
     border-right-width: 3px;
     border-right-style: solid;
 }
+
+@media print {
+    .gravityflow-dicussion-item-hidden { 
+        display:block !important;
+    }
+
+    .gravityflow-dicussion-item-toggle-display { 
+        display: none;
+    }
+}

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -305,10 +305,6 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 				} else {
 					$return .= $display_items;
 				}
-				$return .= '<style type="text/css" media="print">';
-				$return .= '.gravityflow-dicussion-item-hidden { display:block !important; }';
-				$return .= '.gravityflow-dicussion-item-toggle-display { display: none; }';
-				$return .= '</style>';
 			} else {
 				$return .= $hidden_items . $display_items;
 			}

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -8,7 +8,7 @@
  */
 
 if ( ! class_exists( 'GFForms' ) ) {
-    die();
+	die();
 }
 
 /**
@@ -177,7 +177,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 						'assignee_key' => 'example|John Doe',
 						'timestamp'    => time(),
 						'value'        => esc_attr__( 'Example comment.', 'gravityflow' ),
-					)
+					),
 				) );
 			} else {
 				$entry_value = rgar( $entry, $this->id );
@@ -252,7 +252,9 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			$display_items         = '';
 			$hidden_items          = '';
 
-			if ( $entry_id && ! $this->is_form_editor() ) {
+			$display_toggle = apply_filters( 'gravityflow_discussion_items_display_toggle', false, $this );
+
+			if ( ( $entry_id && ! $this->is_form_editor() ) || $display_toggle ) {
 
 				/**
 				 * Set the amount of discussion items to be shown on active user input step without toggle.
@@ -271,7 +273,9 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 					$view_more_label = esc_attr__( 'View More', 'gravityflow' );
 					$view_less_label = esc_attr__( 'View Less', 'gravityflow' );
 
-					$return .= sprintf( "<a href='javascript:void(0);' title='%s' data-title='%s' onclick='GravityFlowEntryDetail.displayDiscussionItemToggle(%d, %d, %d);'  class='gravityflow-dicussion-item-toggle-display'>%s</a>", $view_more_label, $view_less_label, $this['formId'], $this['id'], $recent_display_limit, __( 'View More', 'gravityflow' ) );
+					if ( $format === 'html' ) {
+						$return .= sprintf( "<a href='javascript:void(0);' title='%s' data-title='%s' onclick='GravityFlowEntryDetail.displayDiscussionItemToggle(%d, %d, %d);'  class='gravityflow-dicussion-item-toggle-display'>%s</a>", $view_more_label, $view_less_label, $this['formId'], $this['id'], $recent_display_limit, __( 'View More', 'gravityflow' ) );
+					}
 
 				}
 			}
@@ -301,6 +305,10 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 				} else {
 					$return .= $display_items;
 				}
+				$return .= '<style type="text/css" media="print">';
+				$return .= '.gravityflow-dicussion-item-hidden { display:block !important; }';
+				$return .= '.gravityflow-dicussion-item-toggle-display { display: none; }';
+				$return .= '</style>';
 			} else {
 				$return .= $hidden_items . $display_items;
 			}
@@ -432,10 +440,11 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			$previous_value_json = rgar( $entry, $this->id );
 			$assignee_key        = gravity_flow()->get_current_user_assignee_key();
 
-			$new_comment = array( 'id'           => uniqid( '', true ),
-			                      'assignee_key' => $assignee_key,
-			                      'timestamp'    => time(),
-			                      'value'        => $value
+			$new_comment = array(
+				'id'             => uniqid( '', true ),
+				'assignee_key' => $assignee_key,
+				'timestamp'    => time(),
+				'value'        => $value,
 			);
 			if ( empty( $previous_value_json ) ) {
 				if ( ! empty( $value ) ) {
@@ -568,7 +577,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 						field_id: fieldId,
 						item_id: itemId,
 						action: 'gravityflow_delete_discussion_item',
-						gravityflow_delete_discussion_item: '<?php echo wp_create_nonce( 'gravityflow_delete_discussion_item' ) ?>'
+						gravityflow_delete_discussion_item: '<?php echo wp_create_nonce( 'gravityflow_delete_discussion_item' ); ?>'
 					}, function (response) {
 						if (response) {
 							jQuery('#gravityflow-discussion-item-' + response).remove();

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -252,12 +252,19 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			$display_items         = '';
 			$hidden_items          = '';
 
-			$display_toggle = apply_filters( 'gravityflow_discussion_items_display_toggle', false, $this );
+			/**
+			 * Whether to show / hide the toggle to display more discussion items.
+			 *
+			 * @param boolean                       $hide_toggle Whether to prevent the display more toggle from displaying.
+			 * @param Gravity_Flow_Field_Discussion $this        The field currently being processed.
+			 *
+			 * @since 2.0.2.dev
+			 */
+			$display_toggle = apply_filters( 'gravityflow_discussion_items_display_toggle', true, $this );
 
-			if ( ( $entry_id && ! $this->is_form_editor() ) || $display_toggle ) {
-
+			if ( ( $entry_id && ! $this->is_form_editor() && $display_toggle ) ) {
 				/**
-				 * Set the amount of discussion items to be shown on active user input step without toggle.
+				 * Set the amount of discussion items to be shown in non-print inbox / status view when toggle is active.
 				 *
 				 * @param int                           $max_display_limit Amount of comments to be shown. Default is 10.
 				 * @param Gravity_Flow_Field_Discussion $this              The field currently being processed.
@@ -276,7 +283,6 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 					if ( $format === 'html' ) {
 						$return .= sprintf( "<a href='javascript:void(0);' title='%s' data-title='%s' onclick='GravityFlowEntryDetail.displayDiscussionItemToggle(%d, %d, %d);'  class='gravityflow-dicussion-item-toggle-display'>%s</a>", $view_more_label, $view_less_label, $this['formId'], $this['id'], $recent_display_limit, __( 'View More', 'gravityflow' ) );
 					}
-
 				}
 			}
 

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -258,7 +258,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			 * @param boolean                       $hide_toggle Whether to prevent the display more toggle from displaying.
 			 * @param Gravity_Flow_Field_Discussion $this        The field currently being processed.
 			 *
-			 * @since 2.0.2.dev
+			 * @since 2.0.2
 			 */
 			$display_toggle = apply_filters( 'gravityflow_discussion_items_display_toggle', true, $this );
 

--- a/includes/pages/class-print-entries.php
+++ b/includes/pages/class-print-entries.php
@@ -190,6 +190,7 @@ class Gravity_Flow_Print_Entries {
 			</title>
 			<link rel='stylesheet' href='<?php echo GFCommon::get_base_url() ?>/css/print<?php echo $min; ?>.css' type='text/css'/>
 			<link rel='stylesheet' href='<?php echo gravity_flow()->get_base_url() ?>/css/entry-detail<?php echo $min; ?>.css' type='text/css'/>
+			<link rel='stylesheet' href='<?php echo gravity_flow()->get_base_url() ?>/css/discussion-field<?php echo $min; ?>.css' type='text/css'/>
 			<?php
 			$styles = apply_filters( 'gravityflow_print_styles', false );
 			if ( ! empty( $styles ) ) {

--- a/js/entry-detail.js
+++ b/js/entry-detail.js
@@ -5,19 +5,16 @@
 
     GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
 
-        var $toggle = $( '#field_' + formId + '_' + fieldId );
-
-        if ( $toggle ) {
-
-            $toggle.children( '.gravityflow-dicussion-item-hidden' ).slideToggle( 'fast' );
+            $toggle = $(':focus').parent();
+            
+            $toggle.find( '.gravityflow-dicussion-item-hidden' ).slideToggle( 'fast' );
 
             var oldText = $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).attr( 'title' );
             var newText = $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).data( 'title' );
 
             $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).attr( 'title', newText ).text( newText );
-            $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).data( 'title', oldText );
+            $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).data( 'title', oldText );    
 
-        }
     }
 
 }(window.GravityFlowEntryDetail = window.GravityFlowEntryDetail || {}, jQuery));

--- a/js/entry-detail.js
+++ b/js/entry-detail.js
@@ -6,14 +6,14 @@
     GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
 
             $toggle = $(':focus').parent();
-            
             $toggle.find( '.gravityflow-dicussion-item-hidden' ).slideToggle( 'fast' );
 
-            var oldText = $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).attr( 'title' );
-            var newText = $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).data( 'title' );
+            var $viewMore = $toggle.children( '.gravityflow-dicussion-item-toggle-display' );
+            var oldText = $viewMore.attr( 'title' );
+            var newText = $viewMore.data( 'title' );
 
-            $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).attr( 'title', newText ).text( newText );
-            $toggle.children( '.gravityflow-dicussion-item-toggle-display' ).data( 'title', oldText );    
+            $viewMore.attr( 'title', newText ).text( newText );
+            $viewMore.data( 'title', oldText );    
 
     }
 


### PR DESCRIPTION
Display more now applies by default on inbox (both edit and display felds) as well as status page.

**Form configuration:**

Add two Discussion type fields
Configure a Workflow user input step with save progress active
Configure an Approval step with the discussion field displayed

**Testing:**

Submit the form.
Access the inbox and save several discussion comments to trigger view more.
(Alternatively consider gravityflow_discussion_items_display_limit to set lower display)
Access the status page and note that view more is now accessible
Access print by browser File menu and GFlow button and note the full list still displays
