### PR TITLE
Adding filter gravityflow_limit_activity_events

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -5,3 +5,4 @@
 - Fixed an issue where calculated product fields hidden by conditional logic could appear in order summary when the entry is updated on the User Input step.
 - Updated the Sliced Invoices integration.
 - Added the gravityflow_step_schedule_timestamp filter to allow the scheduled start of steps to apply custom logic (business hours, delay specific entries, etc)
+- Add gravityflow_limit_activity_events filter to enable the activity page to display more than default 400 events

--- a/includes/models/class-activity.php
+++ b/includes/models/class-activity.php
@@ -59,6 +59,13 @@ class Gravity_Flow_Activity {
 		$log_objects_placeholders = array_fill( 0, count( $objects ), '%s' );
 		$log_objects_in_list = $wpdb->prepare( implode( ', ', $log_objects_placeholders ), $objects );
 
+		/**
+		* Allows the limit for activity events to be modified before events are retrieved.
+		*
+		* @param int $limit The limit of events.
+		*/
+		$limit = (int) apply_filters( 'gravityflow_limit_activity_events', $limit );
+
 		$activity_table = self::get_activity_log_table_name();
 		$entry_table = self::get_entry_table_name();
 		$sql     = $wpdb->prepare( "

--- a/includes/models/class-activity.php
+++ b/includes/models/class-activity.php
@@ -59,13 +59,6 @@ class Gravity_Flow_Activity {
 		$log_objects_placeholders = array_fill( 0, count( $objects ), '%s' );
 		$log_objects_in_list = $wpdb->prepare( implode( ', ', $log_objects_placeholders ), $objects );
 
-		/**
-		* Allows the limit for activity events to be modified before events are retrieved.
-		*
-		* @param int $limit The limit of events.
-		*/
-		$limit = (int) apply_filters( 'gravityflow_limit_activity_events', $limit );
-
 		$activity_table = self::get_activity_log_table_name();
 		$entry_table = self::get_entry_table_name();
 		$sql     = $wpdb->prepare( "

--- a/includes/pages/class-activity.php
+++ b/includes/pages/class-activity.php
@@ -38,7 +38,17 @@ class Gravity_Flow_Activity_List {
 			return;
 		}
 
-		$events = Gravity_Flow_Activity::get_events();
+		/**
+		*
+		* @since 2.0.2
+		*
+		* Allows the limit for activity events to be modified before events are displayed.
+		*
+		* @param int $limit The limit of events.
+		*/
+		$limit = (int) apply_filters( 'gravityflow_limit_activity_events', 400 );
+
+		$events = Gravity_Flow_Activity::get_events( $limit );
 
 		if ( sizeof( $events ) > 0 ) {
 			?>

--- a/includes/pages/class-activity.php
+++ b/includes/pages/class-activity.php
@@ -42,11 +42,11 @@ class Gravity_Flow_Activity_List {
 		*
 		* @since 2.0.2
 		*
-		* Allows the limit for activity events to be modified before events are displayed.
+		* Allows the limit for events to be modified before events are displayed on the activity page.
 		*
 		* @param int $limit The limit of events.
 		*/
-		$limit = (int) apply_filters( 'gravityflow_limit_activity_events', 400 );
+		$limit = (int) apply_filters( 'gravitylow_event_limit_activity_page', 400 );
 
 		$events = Gravity_Flow_Activity::get_events( $limit );
 


### PR DESCRIPTION
**To Test:**
Add filter to gravityflow_limit_activity_events which returns int value 25
Notice that the Activity page (wp-admin/admin.php?page=gravityflow-activity) returns 25 results.