### PR TITLE
Fix merge tags for approval step

### DIFF
--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -535,9 +535,11 @@ class Gravity_Flow_Assignee {
 			'step'     => $this->step,
 		);
 
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_url', $args )->replace( $text );
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_cancel', $args )->replace( $text );
+		$merge_tags = Gravity_Flow_Merge_Tags::get_all( $args );
 
+		foreach ( $merge_tags as $merge_tag ) {
+			$text = $merge_tag->replace( $text );
+		}
 		return $text;
 	}
 }

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1051,9 +1051,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 			'step'     => $this,
 		);
 
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_url', $args )->replace( $text );
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_cancel', $args )->replace( $text );
+		$merge_tags = Gravity_Flow_Merge_Tags::get_all( $args );
 
+		foreach ( $merge_tags as $merge_tag ) {
+			$text = $merge_tag->replace( $text );
+		}
 		return $text;
 	}
 


### PR DESCRIPTION
The assignee refactor knocked out the merge tags for the approval step. This PR ensures that all registered merge tags are replaced.

**Testing instructions**
- Create an approval step with an approve link merge tag in an assignee email
- Submit a form to trigger the step.
- Verify that the merge tag is replaced by an empty string.
- Apply this PR, repeat the submission and check the merge tag is replaced properly.

