### PR TITLE
Fixed inactive feeds being processed

### DIFF
--- a/includes/steps/class-step-feed-add-on.php
+++ b/includes/steps/class-step-feed-add-on.php
@@ -158,7 +158,7 @@ abstract class Gravity_Flow_Step_Feed_Add_On extends Gravity_Flow_Step {
 
 					$this->add_note( $note );
 				} else {
-					$this->log_debug( __METHOD__ . '() - Feed condition not met' );
+					$this->log_debug( __METHOD__ . '() - Feed inactive or condition not met' );
 				}
 			}
 		}
@@ -237,7 +237,7 @@ abstract class Gravity_Flow_Step_Feed_Add_On extends Gravity_Flow_Step {
 	 */
 	public function is_feed_condition_met( $feed, $form, $entry ) {
 
-		return gravity_flow()->is_feed_condition_met( $feed, $form, $entry );
+		return $feed['is_active'] && gravity_flow()->is_feed_condition_met( $feed, $form, $entry );
 	}
 
 	/**
@@ -410,9 +410,12 @@ abstract class Gravity_Flow_Step_Feed_Add_On extends Gravity_Flow_Step {
 		$add_on_feeds = $this->get_processed_add_on_feeds();
 		$feeds        = $this->get_feeds();
 
+		$form  = $this->get_form();
+		$entry = $this->get_entry();
+
 		foreach ( $feeds as $feed ) {
 			$setting_key = 'feed_' . $feed['id'];
-			if ( $this->{$setting_key} && ! in_array( $feed['id'], $add_on_feeds ) ) {
+			if ( $this->{$setting_key} && ! in_array( $feed['id'], $add_on_feeds ) && $this->is_feed_condition_met( $feed, $form, $entry ) ) {
 				return 'pending';
 			}
 		}

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -122,7 +122,7 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 	 */
 	public function is_feed_condition_met( $feed, $form, $entry ) {
 
-		return GFZapier::conditions_met( $form, $feed, $entry );
+		return $feed['is_active'] && GFZapier::conditions_met( $form, $feed, $entry );
 	}
 }
 


### PR DESCRIPTION
re: [HS#5506](https://secure.helpscout.net/conversation/532879465/5506?folderId=1113535)

Fixes an issue where inactive add-on feeds are still processed.

**Testing instructions**

Configure a form with a feed for a feed based add-on such as MailChimp.

Configure a workflow with a feed based step followed by an approval step. After configuring the steps set the add-on feed to inactive.

Testing with the master branch you'll find the add-on step starts with a status of pending, processes the inactive feed, the step completes, and then the approval step starts.

Testing with this branch you should find the add-on step starts with a status of pending and completes without processing the inactive feed, and then the approval step starts.