### PR TITLE
Fixed incomplete step when feed logic not met

### DIFF
--- a/includes/steps/class-step-feed-add-on.php
+++ b/includes/steps/class-step-feed-add-on.php
@@ -410,9 +410,12 @@ abstract class Gravity_Flow_Step_Feed_Add_On extends Gravity_Flow_Step {
 		$add_on_feeds = $this->get_processed_add_on_feeds();
 		$feeds        = $this->get_feeds();
 
+		$form  = $this->get_form();
+		$entry = $this->get_entry();
+
 		foreach ( $feeds as $feed ) {
 			$setting_key = 'feed_' . $feed['id'];
-			if ( $this->{$setting_key} && ! in_array( $feed['id'], $add_on_feeds ) ) {
+			if ( $this->{$setting_key} && ! in_array( $feed['id'], $add_on_feeds ) && $this->is_feed_condition_met( $feed, $form, $entry ) ) {
 				return 'pending';
 			}
 		}


### PR DESCRIPTION
Fixes an issue with the status evaluation of feed add-on based steps with feeds using conditional logic.

**Testing Instructions**

Configure a form with two feeds for a feed based add-on such as MailChimp. The second feed should have a conditional logic rule which will not be met.

Configure a workflow with a feed based step, with both feeds selected, followed by an approval step.

Testing with the master branch you'll find the following:
 - the feed add-on step starts with a status of pending
 - the first feed is processed
 - the second feed is not processed as the logic is not met
 - the step status remains pending
 - the approval step does not start

Testing with this branch you'll find the following:
 - the feed add-on step starts with a status of pending
 - the first feed is processed
 - the second feed is not processed as the logic is not met
 - the step status changes to complete
 - the approval step starts