### PR TITLE
Fixed editable post category field value

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -407,6 +407,8 @@ class Gravity_Flow_Entry_Editor {
 
 		$value = apply_filters( 'gravityflow_field_value_entry_editor', $value, $field, $this->form, $this->entry, $this->step );
 
+		$value = $this->get_post_category_value( $value, $field );
+
 		$html = $field->get_field_input( $this->form, $value, $this->entry );
 		$html .= $this->maybe_get_coupon_script( $field );
 
@@ -423,6 +425,51 @@ class Gravity_Flow_Entry_Editor {
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Ensures the post category field value is in the correct format for populating the field.
+	 *
+	 * @since 2.1.1-dev
+	 *
+	 * @param string|array $value The field value.
+	 * @param GF_Field     $field The current field object.
+	 *
+	 * @return string|array
+	 */
+	public function get_post_category_value( $value, $field ) {
+		if ( $field->type !== 'post_category' || empty( $value ) ) {
+			return $value;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				if ( ! empty( $item ) ) {
+					$value[ $key ] = $this->get_post_category_id( $item );
+				}
+			}
+		} else {
+			$value = $this->get_post_category_id( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Returns the post category id from the supplied value.
+	 *
+	 * The entry value will be in the format "category_name:category_id".
+	 *
+	 * @since 2.1.1-dev
+	 *
+	 * @param string $value The field value.
+	 *
+	 * @return string
+	 */
+	public function get_post_category_id( $value ) {
+		$parts = explode( ':', $value );
+
+		return isset( $parts[1] ) ? $parts[1] : $parts[0];
 	}
 
 	/**


### PR DESCRIPTION
re: [HS#5627](https://secure.helpscout.net/conversation/544754262/5627?folderId=1113535)

Fixes an issue where the post category field is not populated with the entry value on the user input step.

**Testing Instructions**

Import the form from [this note](https://secure.helpscout.net/conversation/544754262/5627?folderId=1113535#thread-1484907570) on the ticket.

Complete the form selecting one or more categories.
View the entry in the workflow inbox.

Testing with the master branch you will find the field is not populated with the entry value.
Testing with this branch you should find the field is now populated.