### PR TITLE
Added gravityflow_step_status_evaluation_approval

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Added the filter gravityflow_step_status_evaluation_approval to allow the status evaluation of approval step to check custom logic (X of Y approvals)

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -384,9 +384,9 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		 *
 		 * @since 2.1-dev 
 		 *
-		 * @param string                $step_status   The status of the step
-		 * @param array                 $assignees     Array of Gravity_Flow_Assignee objects
-		 * @param Gravity_Flow_Step     $step          The current step
+		 * @param string                     $step_status   The status of the step
+		 * @param Gravity_Flow_Assignee[]    $approvers     The array of Gravity_Flow_Assignee objects
+		 * @param Gravity_Flow_Step          $step          The current step
 		 */
 		$step_status = apply_filters( 'gravityflow_step_status_evaluation_approval', $step_status, $approvers, $this );
 

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -388,7 +388,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		 * @param array                 $assignees     Array of Gravity_Flow_Assignee objects
 		 * @param Gravity_Flow_Step     $step          The current step
 		 */
-		$step_status = apply_filters( 'gravityflow_step_status_approval_evaluation', $step_status, $approvers, $this );
+		$step_status = apply_filters( 'gravityflow_step_status_evaluation_approval', $step_status, $approvers, $this );
 
 		return $step_status;
 	}

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -379,6 +379,17 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 			}
 		}
 
+		/**
+		 * Allows the step status for the approval to be customized
+		 *
+		 * @since 2.1-dev 
+		 *
+		 * @param string                $step_status   The status of the step
+		 * @param array                 $assignees     Array of Gravity_Flow_Assignee objects
+		 * @param Gravity_Flow_Step     $step          The current step
+		 */
+		$step_status = apply_filters( 'gravityflow_step_status_approval_evaluation', $step_status, $approvers, $this );
+
 		return $step_status;
 	}
 


### PR DESCRIPTION
***Test  Instructions***

* Create an approval step with more than 2 assignees and approval policy set to 'all'
* Add [this gist](https://gist.github.com/Idealien/8c97b322370b0252ded58d5932f6b050) to your functions.php
* Update the step ID in filter to match your test step
* Test various approval scenarios

The gist is set so that any 2 approvals will complete the step, with any rejection continuing to reject the entire step. Other use cases could apply much different logic such as % of approve/reject with minimum number of non-pending responses.