### PR TITLE
Revise export  to output pending status with duration

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Added the filter gravityflow_step_status_evaluation_approval to allow the status evaluation of approval step to check custom logic (X of Y approvals)
+- Fixed an issue with status export .csv to include duration as a separate column so it is consistent with status export table info

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1987,6 +1987,15 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 								$col_val = $step_id;
 							}
 						break;
+						case 'workflow_final_status':
+							if( $item[ $column_key ] == 'pending' ) {
+								$duration     = time() - strtotime( $item['date_created'] );
+								$duration_str = ' ' . $this->format_duration( $duration );
+								$col_val = $item[ $column_key ] . $duration_str;
+							} else {
+								$col_val = $item[ $column_key ];
+							}
+						break;
 						default :
 							$col_val = $item[ $column_key ];
 					}

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1827,6 +1827,11 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 */
 	public function export_column_names( $echo = true ) {
 		$columns    = $this->get_columns();
+
+		if ( isset( $columns['workflow_final_status'] ) ) {
+			$columns['duration'] = esc_html__( 'Duration', 'gravityflow' );
+		}
+
 		$export_arr = array();
 
 		foreach ( $columns as $key => $column_title ) {
@@ -1948,6 +1953,9 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$export      = '';
 		$rows        = array();
 		$columns     = $this->get_columns();
+		if ( isset( $columns['workflow_final_status'] ) ) {
+			$columns['duration'] = esc_html__( 'Duration', 'gravityflow' );
+		}
 		$column_keys = array_keys( $columns );
 
 		if ( ( $cb = array_search( 'cb', $column_keys ) ) !== false ) {
@@ -1987,18 +1995,21 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 								$col_val = $step_id;
 							}
 						break;
-						case 'workflow_final_status':
-							if( $item[ $column_key ] == 'pending' ) {
-								$duration     = time() - strtotime( $item['date_created'] );
-								$duration_str = ' ' . $this->format_duration( $duration );
-								$col_val = $item[ $column_key ] . $duration_str;
-							} else {
-								$col_val = $item[ $column_key ];
-							}
-						break;
 						default :
 							$col_val = $item[ $column_key ];
 					}
+				} else {
+					switch ( $column_key ) {
+						case 'duration':
+							if( $item[ 'workflow_final_status' ] == 'pending' ) {
+								$duration     = time() - strtotime( $item['date_created'] );
+								$duration_str = $this->format_duration( $duration );
+								$col_val = $item[ $column_key ] . $duration_str;
+							} else {
+								$col_val = "";
+							}
+						break;
+					}	
 				}
 
 				/**

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1829,7 +1829,8 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$columns    = $this->get_columns();
 
 		if ( isset( $columns['workflow_final_status'] ) ) {
-			$columns['duration'] = esc_html__( 'Duration', 'gravityflow' );
+			$final_status_offset = array_search('workflow_final_status',array_keys($columns)) + 1;
+			$columns = array_slice($columns, 0, $final_status_offset, true) + array('duration' => esc_html__( 'Duration', 'gravityflow' )) + array_slice($columns, $final_status_offset, NULL, true);
 		}
 
 		$export_arr = array();
@@ -1954,7 +1955,8 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$rows        = array();
 		$columns     = $this->get_columns();
 		if ( isset( $columns['workflow_final_status'] ) ) {
-			$columns['duration'] = esc_html__( 'Duration', 'gravityflow' );
+			$final_status_offset = array_search('workflow_final_status',array_keys($columns)) + 1;
+			$columns = array_slice($columns, 0, $final_status_offset, true) + array('duration' => esc_html__( 'Duration', 'gravityflow' )) + array_slice($columns, $final_status_offset, NULL, true);
 		}
 		$column_keys = array_keys( $columns );
 
@@ -2004,7 +2006,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 							if( $item[ 'workflow_final_status' ] == 'pending' ) {
 								$duration     = time() - strtotime( $item['date_created'] );
 								$duration_str = $this->format_duration( $duration );
-								$col_val = $item[ $column_key ] . $duration_str;
+								$col_val = $duration_str;
 							} else {
 								$col_val = '';
 							}

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1990,7 +1990,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 							$step_id = rgar( $item, 'workflow_step' );
 							if ( $step_id > 0 ) {
 								$step      = gravity_flow()->get_step( $step_id );
-								$col_val = $step->get_name();
+								$col_val = $step ? $step->get_name() : $step_id;
 							} else {
 								$col_val = $step_id;
 							}
@@ -2006,7 +2006,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 								$duration_str = $this->format_duration( $duration );
 								$col_val = $item[ $column_key ] . $duration_str;
 							} else {
-								$col_val = "";
+								$col_val = '';
 							}
 						break;
 					}	


### PR DESCRIPTION
***Test Instructions***
- Use master branch and go to status page
- Note that status column for pending entries includes the duration since step was started
- Perform export and note that status column for pending entries only includes the status.
- Switch to branch 5436-status-export-pending
- Note that both status table and export contain the duration (export has it as separate column)
