### PR TITLE
Added `Time` Field to the Scheduling feature

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1809,6 +1809,28 @@ PRIMARY KEY  (id)
 				'choices' => $date_field_choices,
 			);
 
+			$time_fields = GFFormsModel::get_fields_by_type( $form, 'time' );
+
+			$time_field_choices = array();
+
+			if ( ! empty($time_fields ) ) {
+				$schedule_type['choices'][] = array(
+					'label' => esc_html__( 'Time Field', 'gravityflow' ),
+					'value' => 'time_field',
+				);
+
+
+				foreach ( $time_fields  as $time_field ) {
+						$time_field_choices[] = array( 'value' => $time_field->id, 'label' => GFFormsModel::get_label( $time_field ) );
+					}
+			}
+
+			$schedule_time_fields = array(
+				'name' => 'schedule_time_field',
+				'label' => esc_html__( 'Schedule Time Field', 'gravityflow' ),
+				'choices' => $time_field_choices,
+			);
+
 			$schedule_date = array(
 				'id' => 'schedule_date',
 				'name' => 'schedule_date',
@@ -1857,6 +1879,7 @@ PRIMARY KEY  (id)
 			$schedule_date_style = ( $schedule_type_setting == 'date' ) ? '' : 'style="display:none;"';
 			$schedule_delay_style = ( $schedule_type_setting == 'delay' ) ? '' : 'style="display:none;"';
 			$schedule_date_fields_style = ( $schedule_type_setting == 'date_field' ) ? '' : 'style="display:none;"';
+			$schedule_time_fields_style = ( $schedule_type_setting == 'time_field' ) ? '' : 'style="display:none;"';
 			?>
 			<div class="gravityflow-schedule-settings" <?php echo $schedule_style ?> >
 				<div class="gravityflow-schedule-type-container">
@@ -1910,6 +1933,38 @@ PRIMARY KEY  (id)
 					$this->settings_select( $schedule_date_fields );
 					?>
 				</div>
+				<div class="gravityflow-schedule-time-field-container" <?php echo $schedule_time_fields_style ?>>
+					<?php
+					esc_html_e( 'Start this step', 'gravityflow' );
+					echo '&nbsp;';
+					$delay_offset_field['name'] = 'schedule_time_field_offset';
+					$delay_offset_field['default_value'] = '0';
+					$this->settings_text( $delay_offset_field );
+					$unit_field['name'] = 'schedule_time_field_offset_unit';
+					$this->settings_select( $unit_field );
+					echo '&nbsp;';
+					$before_after_field = array(
+						'name' => 'schedule_time_field_before_after',
+						'label' => esc_html__( 'Schedule', 'gravityflow' ),
+						'default_value' => 'after',
+						'choices' => array(
+							array(
+								'label' => esc_html__( 'after', 'gravityflow' ),
+								'value' => 'after',
+							),
+							array(
+								'label' => esc_html__( 'before', 'gravityflow' ),
+								'value' => 'before',
+							),
+						),
+					);
+					$this->settings_select( $before_after_field );
+					echo '&nbsp; date &nbsp;';
+					$this->settings_select( $schedule_date_fields );
+					echo '&nbsp; at time &nbsp;';
+					$this->settings_select( $schedule_time_fields );
+					?>
+				</div>
 			</div>
 			<script>
 				(function($) {
@@ -1920,16 +1975,25 @@ PRIMARY KEY  (id)
 						$('.gravityflow-schedule-delay-container').show();
 						$('.gravityflow-schedule-date-container').hide();
 						$('.gravityflow-schedule-date-field-container').hide();
+						$('.gravityflow-schedule-time-field-container').hide();
 					});
 					$( '#schedule_type1' ).click(function(){
 						$('.gravityflow-schedule-delay-container').hide();
 						$('.gravityflow-schedule-date-container').show();
 						$('.gravityflow-schedule-date-field-container').hide();
+						$('.gravityflow-schedule-time-field-container').hide();
 					});
 					$( '#schedule_type2' ).click(function(){
 						$('.gravityflow-schedule-delay-container').hide();
 						$('.gravityflow-schedule-date-container').hide();
 						$('.gravityflow-schedule-date-field-container').show();
+						$('.gravityflow-schedule-time-field-container').hide();
+					});
+					$( '#schedule_type3' ).click(function(){
+						$('.gravityflow-schedule-delay-container').hide();
+						$('.gravityflow-schedule-date-container').hide();
+						$('.gravityflow-schedule-date-field-container').hide();
+						$('.gravityflow-schedule-time-field-container').show();
 					});
 				})(jQuery);
 			</script>
@@ -1972,6 +2036,28 @@ PRIMARY KEY  (id)
 						'value' => 'date',
 					),
 				),
+			);
+
+			$time_fields = GFFormsModel::get_fields_by_type( $form, 'time' );
+
+			$time_field_choices = array();
+
+			if ( ! empty( $time_fields ) ) {
+				$expiration_type['choices'][] = array(
+					'label' => esc_html__( 'time Field', 'gravityflow' ),
+					'value' => 'time_field',
+				);
+
+
+				foreach ( $time_fields  as $time_field ) {
+					$time_field_choices[] = array( 'value' => $time_field->id, 'label' => GFFormsModel::get_label( $time_field ) );
+				}
+			}
+
+			$expiration_time_fields = array(
+				'name' => 'expiration_time_field',
+				'label' => esc_html__( 'Expiration time Field', 'gravityflow' ),
+				'choices' => $time_field_choices,
 			);
 
 			$date_fields = GFFormsModel::get_fields_by_type( $form, 'date' );
@@ -2044,7 +2130,7 @@ PRIMARY KEY  (id)
 			$expiration_date_style = ( $expiration_type_setting == 'date' ) ? '' : 'style="display:none;"';
 			$expiration_delay_style = ( $expiration_type_setting == 'delay' ) ? '' : 'style="display:none;"';
 			$expiration_date_fields_style = ( $expiration_type_setting == 'date_field' ) ? '' : 'style="display:none;"';
-
+			$expiration_time_fields_style = ( $expiration_type_setting == 'time_field' ) ? '' : 'style="display:none;"';
 			?>
 			<div class="gravityflow-expiration-settings" <?php echo $expiration_style ?> >
 				<div class="gravityflow-expiration-type-container" class="gravityflow-sub-setting">
@@ -2098,6 +2184,36 @@ PRIMARY KEY  (id)
 					$this->settings_select( $expiration_date_fields );
 					?>
 				</div>
+				<div class="gravityflow-expiration-time-field-container" <?php echo $expiration_time_fields_style ?>>
+					<?php
+					esc_html_e( 'Expire this step', 'gravityflow' );
+					echo '&nbsp;';
+					$delay_offset_field['name'] = 'expiration_time_field_offset';
+					$delay_offset_field['default_value'] = '0';
+					$this->settings_text( $delay_offset_field );
+					$unit_field['name'] = 'expiration_time_field_offset_unit';
+					$this->settings_select( $unit_field );
+					echo '&nbsp;';
+					$before_after_field = array(
+						'name' => 'expiration_date_field_before_after',
+						'label' => esc_html__( 'Expiration', 'gravityflow' ),
+						'default_value' => 'after',
+						'choices' => array(
+							array(
+								'label' => esc_html__( 'after', 'gravityflow' ),
+								'value' => 'after',
+							),
+							array(
+								'label' => esc_html__( 'before', 'gravityflow' ),
+								'value' => 'before',
+							),
+						),
+					);
+					$this->settings_select( $before_after_field );
+
+					$this->settings_select( $expiration_time_fields );
+					?>
+				</div>				
 				<div class="gravityflow-sub-setting">
 					<?php
 					$status_choices = rgar( $field, 'status_choices' );
@@ -2137,16 +2253,25 @@ PRIMARY KEY  (id)
 						$('.gravityflow-expiration-date-container').hide();
 						$('.gravityflow-expiration-delay-container').show();
 						$('.gravityflow-expiration-date-field-container').hide();
+						$('.gravityflow-expiration-time-field-container').hide();
 					});
 					$( '#expiration_type1' ).click(function(){
 						$('.gravityflow-expiration-date-container').show();
 						$('.gravityflow-expiration-delay-container').hide();
 						$('.gravityflow-expiration-date-field-container').hide();
+						$('.gravityflow-expiration-time-field-container').hide();
 					});
 					$( '#expiration_type2' ).click(function(){
 						$('.gravityflow-expiration-delay-container').hide();
 						$('.gravityflow-expiration-date-container').hide();
 						$('.gravityflow-expiration-date-field-container').show();
+						$('.gravityflow-expiration-time-field-container').hide();
+					});
+					$( '#expiration_type3' ).click(function(){
+						$('.gravityflow-expiration-delay-container').hide();
+						$('.gravityflow-expiration-date-container').hide();
+						$('.gravityflow-expiration-date-field-container').hide();
+						$('.gravityflow-expiration-time-field-container').show();
 					});
 				})(jQuery);
 			</script>
@@ -3122,6 +3247,10 @@ PRIMARY KEY  (id)
 					$scheduled_date = $current_step->schedule_date;
 					break;
 				case 'date_field' :
+					$scheduled_date_str = date( 'Y-m-d H:i:s', $scheduled_timestamp );
+					$scheduled_date     = get_date_from_gmt( $scheduled_date_str );
+					break;
+				case 'time_field' :
 					$scheduled_date_str = date( 'Y-m-d H:i:s', $scheduled_timestamp );
 					$scheduled_date     = get_date_from_gmt( $scheduled_date_str );
 					break;

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -721,6 +721,57 @@ abstract class Gravity_Flow_Step extends stdClass {
 			return $schedule_datetime;
 		}
 
+		if ( $this->schedule_type == 'time_field' ) {
+
+			$this->log_debug( __METHOD__ . '() schedule_time_field: ' . $this->schedule_time_field );
+			$schedule_time = $entry[ (string) $this->schedule_time_field ];
+			$this->log_debug( __METHOD__ . '() schedule_time: ' . $schedule_time );
+
+			$this->log_debug( __METHOD__ . '() schedule_date_field: ' . $this->schedule_date_field );
+			$schedule_date = $entry[ (string) $this->schedule_date_field ];
+			$this->log_debug( __METHOD__ . '() schedule_date: ' . $schedule_date );
+
+			// @source Gravity Wiz // Gravity Forms // Schedule a Post by Date Field
+			if( $schedule_time ) {
+		        list( $schedule_time_hour, $schedule_time_min, $schedule_time_am_pm ) = array_pad( preg_split( '/[: ]/', $time ), 3, false );
+		        if( strtolower( $schedule_time_am_pm ) == 'pm' ) {
+		        	$schedule_time_hour += 12;
+		        }
+			    } else {
+			    	$schedule_time_hour = $schedule_time_min = '00';
+			    }
+			$schedule_datetime = strtotime( sprintf( '%s %s:%s:00', $schedule_date, $schedule_time_hour, $schedule_time_min ) );
+			$schedule_time     = date( 'Y-m-d H:i:s', $schedule_datetime );
+			$schedule_time_gmt = get_gmt_from_date( $schedule_time );
+			$schedule_datetime = strtotime( $schedule_date_gmt );
+
+			// Calculate offset
+			if ( $this->schedule_time_field_offset ) {
+				$offset = 0;
+				switch ( $this->schedule_time_field_offset_unit ) {
+					case 'minutes' :
+						$offset = ( MINUTE_IN_SECONDS * $this->schedule_time_field_offset );
+						break;
+					case 'hours' :
+						$offset = ( HOUR_IN_SECONDS * $this->schedule_time_field_offset );
+						break;
+					case 'days' :
+						$offset = ( DAY_IN_SECONDS * $this->schedule_time_field_offset );
+						break;
+					case 'weeks' :
+						$offset = ( WEEK_IN_SECONDS * $this->schedule_time_field_offset );
+						break;
+				}
+				if ( $this->schedule_time_field_before_after == 'before' ) {
+					$schedule_datetime = $schedule_datetime - $offset;
+				} else {
+					$schedule_datetime += $offset;
+				}
+			}
+
+			return $schedule_datetime;
+		}
+
 		$entry_timestamp = $this->get_step_timestamp();
 
 		$schedule_timestamp = $entry_timestamp;
@@ -841,6 +892,56 @@ abstract class Gravity_Flow_Step extends stdClass {
 						break;
 				}
 				if ( $this->expiration_date_field_before_after == 'before' ) {
+					$expiration_datetime = $expiration_datetime - $offset;
+				} else {
+					$expiration_datetime += $offset;
+				}
+			}
+
+			return $expiration_datetime;
+		}
+
+		if ( $this->expiration_type == 'time_field' ) {
+
+			$this->log_debug( __METHOD__ . '() expiration_time_field: ' . $this->expiration_time_field );
+			$expiration_time = $entry[ (string) $this->schedule_time_field ];
+			$this->log_debug( __METHOD__ . '() expiration_time: ' . $expiration_time );
+
+			$this->log_debug( __METHOD__ . '() expiration_date_field: ' . $this->expiration_date_field );
+			$expiration_date = $entry[ (string) $this->schedule_date_field ];
+			$this->log_debug( __METHOD__ . '() expiration_date: ' . $expiration_date );
+			
+			if( $expiration_time ) {
+		        list( $expiration_time_hour, $expiration_time_min, $expiration_time_am_pm ) = array_pad( preg_split( '/[: ]/', $time ), 3, false );
+		        if( strtolower( $expiration_time_am_pm ) == 'pm' ) {
+		        	$expiration_time_hour += 12;
+		        }
+			    } else {
+			    	$expiration_time_hour = $expiration_time_min = '00';
+			    }
+			$expiration_datetime = strtotime( sprintf( '%s %s:%s:00', $expiration_date, $expiration_time_hour, $expiration_time_min ) );
+			$expiration_time     = date( 'Y-m-d H:i:s', $expiration_datetime );
+			$schedule_time_gmt = get_gmt_from_date( $expiration_time );
+			$expiration_datetime = strtotime( $schedule_date_gmt );
+
+			// Calculate offset
+			if ( $this->expiration_time_field_offset ) {
+				$offset = 0;
+				switch ( $this->expiration_time_field_offset_unit ) {
+					case 'minutes' :
+						$offset = ( MINUTE_IN_SECONDS * $this->expiration_time_field_offset );
+						break;
+					case 'hours' :
+						$offset = ( HOUR_IN_SECONDS * $this->expiration_time_field_offset );
+						break;
+					case 'days' :
+						$offset = ( DAY_IN_SECONDS * $this->expiration_time_field_offset );
+						break;
+					case 'weeks' :
+						$offset = ( WEEK_IN_SECONDS * $this->expiration_time_field_offset );
+						break;
+				}
+				if ( $this->expiration_time_field_before_after == 'before' ) {
 					$expiration_datetime = $expiration_datetime - $offset;
 				} else {
 					$expiration_datetime += $offset;


### PR DESCRIPTION
**Adds the ability to schedule to-the-minute (seconds are overwritten with `00`).**

Feature allows selection of [time fields](https://docs.gravityforms.com/time/) when [sheduling a step](https://docs.gravityflow.io/article/67-scheduling-a-step).

For consistency, I have simply copied the `schedule_date_fields` related code to create `schedule_time_fields` additions.

I haven't slept, and finally thought of uploading this for you - sorry. Feature was written in back in version 2.0.1. - many diffs to sort through to handover to you. Let me know how goes.
