### PR TITLE
Fixed editable post image field value

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -407,6 +407,7 @@ class Gravity_Flow_Entry_Editor {
 
 		$value = apply_filters( 'gravityflow_field_value_entry_editor', $value, $field, $this->form, $this->entry, $this->step );
 
+		$value = $this->get_post_image_value( $value, $field );
 		$value = $this->get_post_category_value( $value, $field );
 
 		$html = $field->get_field_input( $this->form, $value, $this->entry );
@@ -425,6 +426,36 @@ class Gravity_Flow_Entry_Editor {
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Ensures the post image field value is in the correct format for populating the field.
+	 *
+	 * @since 2.1.2-dev
+	 *
+	 * @param string|array $value The field value.
+	 * @param GF_Field     $field The current field object.
+	 *
+	 * @return string|array
+	 */
+	public function get_post_image_value( $value, $field ) {
+		if ( $field->type !== 'post_image' || empty( $value ) || ! is_string( $value ) || strpos( $value, '|:|' ) === false ) {
+			return $value;
+		}
+
+		$array = explode( '|:|', $value );
+		$value = array(
+			$field->id . '.1' => rgar( $array, 1 ), // Title.
+			$field->id . '.4' => rgar( $array, 2 ), // Caption.
+			$field->id . '.7' => rgar( $array, 3 ), // Description.
+		);
+
+		$path_info = pathinfo( rgar( $array, 0 ) );
+		if ( ! isset( GFFormsModel::$uploaded_files[ $field->formId ]["input_{$field->id}"] ) ) {
+			GFFormsModel::$uploaded_files[ $field->formId ]["input_{$field->id}"] = $path_info['basename'];
+		}
+
+		return $value;
 	}
 
 	/**

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1258,7 +1258,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	 */
 	public function maybe_pre_process_post_image_field( $field, $existing_value, $input_name ) {
 		if ( $existing_value && $field->type === 'post_image' && empty( $_FILES[ $input_name ]['name'] ) ) {
-			$parts = explode( '|:|', $existing_value, 4 );
+			$parts = explode( '|:|', $existing_value );
 			global $_gf_uploaded_files;
 			$_gf_uploaded_files[ $input_name ] = $parts[0];
 		}

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1228,7 +1228,8 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 		}
 
 		$existing_value = rgar( $entry, $field->id );
-		$value          = $field->get_value_save_entry( $existing_value, $form, $input_name, $entry['id'], $entry );
+		$this->maybe_pre_process_post_image_field( $field, $existing_value, $input_name );
+		$value = $field->get_value_save_entry( $existing_value, $form, $input_name, $entry['id'], $entry );
 
 		if ( ! empty( $value ) && $existing_value != $value ) {
 			$result = GFAPI::update_entry_field( $entry['id'], $field->id, $value );

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1248,6 +1248,23 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	}
 
 	/**
+	 * Add the existing post image URL to the $_gf_uploaded_files global so the image title, caption, and description can be updated.
+	 *
+	 * @since 2.1.2-dev
+	 *
+	 * @param GF_Field $field          The current field object.
+	 * @param string   $existing_value The current fields existing entry value.
+	 * @param string   $input_name     The input name to use when accessing the current fields values in the submission.
+	 */
+	public function maybe_pre_process_post_image_field( $field, $existing_value, $input_name ) {
+		if ( $existing_value && $field->type === 'post_image' && empty( $_FILES[ $input_name ]['name'] ) ) {
+			$parts = explode( '|:|', $existing_value, 4 );
+			global $_gf_uploaded_files;
+			$_gf_uploaded_files[ $input_name ] = $parts[0];
+		}
+	}
+
+	/**
 	 * If a post exists for this entry initiate the update.
 	 *
 	 * @since 1.5.1-dev


### PR DESCRIPTION
Fixes an issue where the post image field is not populated with the entry value on the user input step.

**Testing Instructions**

- Create a form with a post title, body, and image field. Enable display of the title, caption, and description on the post image field.
- Create a user input step with the post image field as the editable field.
- Submit the form completing all three post fields.

With master: View the entry in the workflow inbox and find the post image field is empty.

With this branch: 
- View the entry in the workflow inbox and find the post image field contains the existing file, title, caption, and description.
- Change the title and submit the step. On the entry detail find the file, caption, and description remain the same and the title has been updated. Check the media library and find the image has been replaced and contains the new title.
- Restart the workflow, delete the image, upload a new image and add new values for the image meta. Submit the step and find the entry detail contains the new image and meta. Check the media library and find the image has been replaced and contains the new meta values.