### PR TITLE
Fixed PHP warning

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Added the filter gravityflow_step_status_evaluation_approval to allow the status evaluation of approval step to check custom logic (X of Y approvals)
 - Fixed editable Post Image field not being populated with the current entry value on the User Input step.
+- Fixed a PHP warning for the Discussion field.

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -306,7 +306,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			}
 
 			if ( $format === 'html' ) {
-				if ( count( $hidden_items ) ) {
+				if ( ! empty( $hidden_items ) ) {
 					$return .= '<div class="gravityflow-dicussion-item-hidden" style="display: none;">' . $hidden_items . '</div>' . $display_items;
 				} else {
 					$return .= $display_items;


### PR DESCRIPTION
re: [HS#5695](https://secure.helpscout.net/conversation/551945900/5695?folderId=1113535)

Fixes a PHP warning for the Discussion field hidden items with PHP 7.2. 