### PR TITLE
Fix assignees after restart

### DIFF
--- a/includes/assignees/class-assignees.php
+++ b/includes/assignees/class-assignees.php
@@ -95,4 +95,12 @@ class Gravity_Flow_Assignees {
 		return $assignee;
 	}
 
+	public static function get_names() {
+		$classes = self::get_class_names();
+
+		$names = array_keys( $classes );
+
+		return $names;
+	}
+
 }

--- a/includes/assignees/class-assignees.php
+++ b/includes/assignees/class-assignees.php
@@ -95,6 +95,13 @@ class Gravity_Flow_Assignees {
 		return $assignee;
 	}
 
+	/**
+	 * Returns an array of the name properties of each assignee class.
+	 *
+	 * @since 2.1.2
+	 *
+	 * @return array
+	 */
 	public static function get_names() {
 		$classes = self::get_class_names();
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -121,10 +121,8 @@ class Gravity_Flow_API {
 		 */
 		do_action( 'gravityflow_pre_cancel_workflow', $entry, $form, $step );
 
-		$assignees = $step->get_assignees();
-		foreach ( $assignees as $assignee ) {
-			$assignee->remove();
-		}
+		$step->purge_assignees();
+
 		gform_update_meta( $entry_id, 'workflow_final_status', 'cancelled' );
 		gform_delete_meta( $entry_id, 'workflow_step' );
 		$feedback = esc_html__( 'Workflow cancelled.', 'gravityflow' );
@@ -148,6 +146,7 @@ class Gravity_Flow_API {
 		}
 		$entry_id = $entry['id'];
 		$this->log_activity( 'step', 'restarted', $this->form_id, $entry_id );
+		$step->purge_assignees();
 		$step->restart_action();
 		$step->start();
 		$feedback = esc_html__( 'Workflow Step restarted.', 'gravityflow' );
@@ -178,11 +177,9 @@ class Gravity_Flow_API {
 		do_action( 'gravityflow_pre_restart_workflow', $entry, $form );
 
 		if ( $current_step ) {
-			$assignees = $current_step->get_assignees();
-			foreach ( $assignees as $assignee ) {
-				$assignee->remove();
-			}
+			$current_step->purge_assignees();
 		}
+
 		$steps = $this->get_steps();
 		foreach ( $steps as $step ) {
 			// Create a step based on the entry and use it to reset the status.
@@ -226,10 +223,7 @@ class Gravity_Flow_API {
 	public function send_to_step( $entry, $step_id ) {
 		$current_step = $this->get_current_step( $entry );
 		if ( $current_step ) {
-			$assignees = $current_step->get_assignees();
-			foreach ( $assignees as $assignee ) {
-				$assignee->remove();
-			}
+			$current_step->purge_assignees();
 			$current_step->update_step_status( 'cancelled' );
 		}
 		$entry_id = $entry['id'];

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -2184,4 +2184,42 @@ abstract class Gravity_Flow_Step extends stdClass {
 		return $validation_result;
 	}
 
+	/**
+	 * Purges assignees from the database.
+	 *
+	 * @since 2.1.2
+	 */
+	public function purge_assignees() {
+		global $wpdb;
+
+		$entry_id = $this->get_entry_id();
+
+		$entry_meta_table = Gravity_Flow_Common::get_entry_meta_table_name();
+
+		$entry_id_column = Gravity_Flow_Common::get_entry_id_column_name();
+
+		$assignee_types = array(
+			'^workflow_user_id_',
+			'^workflow_role_',
+			'^workflow_email_',
+			'^workflow_api_key_',
+		);
+
+		$assignee_names = Gravity_Flow_Assignees::get_names();
+		foreach ( $assignee_names as $assignee_name ) {
+			if ( $assignee_name == 'generic' ) {
+				continue;
+			}
+			$assignee_types[] = "^workflow_{$assignee_name}_";
+		}
+
+		$assignee_types_str = join( '|', $assignee_types );
+
+		$sql = $wpdb->prepare( "DELETE FROM {$entry_meta_table} WHERE {$entry_id_column}=%d AND meta_key REGEXP %s", $entry_id, $assignee_types_str );
+
+		$result = $wpdb->query( $sql );
+
+		$this->log_debug( 'Assignees purged. number of rows deleted: ' . $result );
+	}
+
 }


### PR DESCRIPTION
Fixes [HS5571](https://secure.helpscout.net/conversation/539669601/5571?folderId=1113498).

Entries can get stuck in the inbox of assignees even when removed. The PR purges all assignees when a step or workflow is restarted or cancelled.

**Testing instructions**
Master:
- Add a user field to a form and assign a step to it.
- Submit the form then change the user in the Gravity Forms entry edit page.
- Restart the step from the admin actions
- The old assignee still sees the entry in the inbox.

This branch:
- Restart the step and check the old assignee no longer sees the entry in the inbox.
- Check the same with workflow restart and cancel.
- Ensure there are no side effects with the SQL like deleting meta that shouldn't be deleted
- Ensure it works on both Gravity Forms 2.2 and 2.3.
