### PR TITLE
Fix responsive status shortcode for translations

### DIFF
--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -357,8 +357,8 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 
 		$default_args = array(
-			'singular'           => __( 'entry', 'gravityflow' ),
-			'plural'             => __( 'entries', 'gravityflow' ),
+			'singular'           => 'entry',    // Not translated - only used in class names
+			'plural'             => 'entries',  // Not translated - only used in class names
 			'ajax'               => false,
 			'base_url'           => admin_url( 'admin.php?page=gravityflow-status' ),
 			'detail_base_url'    => admin_url( 'admin.php?page=gravityflow-inbox&view=entry' ),


### PR DESCRIPTION
Fixes [HS5740](https://secure.helpscout.net/conversation/555460464/5740/?folderId=1113492).

This PR fixes an issue where the status shortcode is only responsive when using an English translation. This is because the styles target the table classes with 'entries' e.g. table.wp-list-table.entries. 'entries' is currently translated so making it not translated in this context fixes the issue.

**Testing instructions**
On master
- Switch to Spanish, Italian or any or supported language
- Check the status shortcode is not responsive

On this branch
- Check the status shortcode is responsive and check there are no other side effects of this fix.