### PR TITLE
Fix merge tag replacement timing

### DIFF
--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -542,8 +542,11 @@ class Gravity_Flow_Assignee {
 		$merge_tags = Gravity_Flow_Merge_Tags::get_all( $args );
 
 		foreach ( $merge_tags as $merge_tag ) {
-			$text = $merge_tag->replace( $text );
+			if ( $merge_tag instanceof Gravity_Flow_Merge_Tag_Assignee_Base ) {
+				$text = $merge_tag->replace( $text );
+			}
 		}
+
 		return $text;
 	}
 }

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -30,10 +30,10 @@ class Gravity_Flow_Common {
 	 * @return string
 	 */
 	public static function get_workflow_url( $query_args, $page_id = null, $assignee = null, $access_token = '' ) {
-		if ( $assignee && $assignee->get_type() == 'email' ) {
+		if ( empty( $access_token ) && $assignee && $assignee->get_type() == 'email' ) {
 			$token_lifetime_days        = apply_filters( 'gravityflow_entry_token_expiration_days', 30, $assignee );
 			$token_expiration_timestamp = strtotime( '+' . (int) $token_lifetime_days . ' days' );
-			$access_token               = $access_token ? $access_token : gravity_flow()->generate_access_token( $assignee, null, $token_expiration_timestamp );
+			$access_token               = gravity_flow()->generate_access_token( $assignee, null, $token_expiration_timestamp );
 		}
 
 		$base_url = '';

--- a/includes/merge-tags/class-merge-tag-assignee-base.php
+++ b/includes/merge-tags/class-merge-tag-assignee-base.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Gravity Flow Merge Tag Assignee Base
+ *
+ * @package     GravityFlow
+ * @copyright   Copyright (c) 2015-2018, Steven Henty S.L.
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+if ( ! class_exists( 'GFForms' ) ) {
+	die();
+}
+
+/**
+ * Class Gravity_Flow_Merge_Tag_Assignee_Base
+ *
+ * An abstract class used as the base for all assignee specific merge tags.
+ *
+ * @since 2.1.2-dev
+ */
+abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_Tag {
+
+	/**
+	 * Returns the inbox URL.
+	 *
+	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string   $access_token The access token for the current assignee.
+	 *
+	 * @return string
+	 */
+	public function get_inbox_url( $page_id = null, $access_token = '' ) {
+
+		$query_args = array(
+			'page' => 'gravityflow-inbox',
+		);
+
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
+	}
+
+	/**
+	 * Returns the entry URL.
+	 *
+	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string   $access_token The access token for the current assignee.
+	 *
+	 * @return string
+	 */
+	public function get_entry_url( $page_id = null, $access_token = '' ) {
+
+		$form_id = $this->step ? $this->step->get_form_id() : false;
+		if ( empty( $form_id ) && ! empty( $this->form ) ) {
+			$form_id = $this->form['id'];
+		}
+
+		if ( empty( $form_id ) ) {
+			return false;
+		}
+
+		$entry_id = $this->step ? $this->step->get_entry_id() : false;
+		if ( empty( $entry_id ) && ! empty( $this->entry ) ) {
+			$entry_id = $this->entry['id'];
+		}
+
+		if ( empty( $entry_id ) ) {
+			return false;
+		}
+
+		$query_args = array(
+			'page' => 'gravityflow-inbox',
+			'view' => 'entry',
+			'id'   => $form_id,
+			'lid'  => $entry_id,
+		);
+
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
+	}
+
+	/**
+	 * Get the number of days the token will remain valid for.
+	 *
+	 * @return int
+	 */
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_entry_token_expiration_days', 30, $this->assignee );
+	}
+
+	/**
+	 * Get the scopes to be used when generating the access token.
+	 *
+	 * @param string $action The access token action.
+	 *
+	 * @return array
+	 */
+	protected function get_token_scopes( $action = '' ) {
+		if ( empty( $action ) ) {
+			return array();
+		}
+
+		return array(
+			'pages'           => array( 'inbox' ),
+			'step_id'         => $this->step->get_id(),
+			'entry_timestamp' => $this->step->get_entry_timestamp(),
+			'entry_id'        => $this->step->get_entry_id(),
+			'action'          => $action,
+		);
+	}
+
+	/**
+	 * Get the reject token for the current assignee and step.
+	 *
+	 * @return string
+	 */
+	protected function get_token( $action = '' ) {
+		$scopes               = $this->get_token_scopes( $action );
+		$expiration_timestamp = strtotime( '+' . (int) $this->get_token_expiration_days() . ' days' );
+
+		return gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
+	}
+}

--- a/includes/merge-tags/class-merge-tag-workflow-approve-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve-token.php
@@ -11,16 +11,12 @@ if ( ! class_exists( 'GFForms' ) ) {
 	die();
 }
 
-if ( ! class_exists( 'Gravity_Flow_Merge_Tag_Workflow_Url' ) ) {
-	require_once( 'class-merge-tag-workflow-url.php' );
-}
-
 /**
  * Class Gravity_Flow_Merge_Tag_Approve_Token
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Workflow_Url {
+class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.
@@ -64,7 +60,7 @@ class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Workfl
 				return $text;
 			}
 
-			$token = $this->get_token();
+			$token = $this->get_token( 'approve' );
 
 			$token = $this->format_value( $token );
 
@@ -75,27 +71,14 @@ class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Workfl
 	}
 
 	/**
-	 * Get the approval token for the current assignee and step.
+	 * Get the number of days the token will remain valid for.
 	 *
-	 * @return string
+	 * @since 2.1.2-dev
+	 *
+	 * @return int
 	 */
-	protected function get_token() {
-		$expiration_days = apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
-
-		$expiration_str = '+' . (int) $expiration_days . ' days';
-
-		$expiration_timestamp = strtotime( $expiration_str );
-
-		$scopes = array(
-			'pages'           => array( 'inbox' ),
-			'step_id'         => $this->step->get_id(),
-			'entry_timestamp' => $this->step->get_entry_timestamp(),
-			'entry_id'        => $this->step->get_entry_id(),
-			'action'          => 'approve',
-		);
-		$token = gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
-
-		return $token;
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
 	}
 }
 

--- a/includes/merge-tags/class-merge-tag-workflow-approve.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve.php
@@ -11,16 +11,12 @@ if ( ! class_exists( 'GFForms' ) ) {
 	die();
 }
 
-if ( ! class_exists( 'Gravity_Flow_Merge_Tag_Approve_Token' ) ) {
-	require_once( 'class-merge-tag-workflow-approve-token.php' );
-}
-
 /**
  * Class Gravity_Flow_Merge_Tag_Approve
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Approve_Token {
+class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'GFForms' ) ) {
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Workflow_Url {
+class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.
@@ -59,17 +59,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Work
 				return $text;
 			}
 
-			$expiration_days      = apply_filters( 'gravityflow_cancel_token_expiration_days', 2, $this->assignee );
-			$expiration_str       = '+' . (int) $expiration_days . ' days';
-			$expiration_timestamp = strtotime( $expiration_str );
-
-			$scopes = array(
-				'pages'    => array( 'inbox' ),
-				'entry_id' => $this->step->get_entry_id(),
-				'action'   => 'cancel_workflow',
-			);
-
-			$cancel_token = gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
+			$cancel_token = $this->get_token( 'cancel_workflow' );
 
 			foreach ( $matches as $match ) {
 				$full_tag       = $match[0];
@@ -94,6 +84,34 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Work
 		}
 
 		return $text;
+	}
+
+	/**
+	 * Get the number of days the token will remain valid for.
+	 *
+	 * @since 2.1.2-dev
+	 *
+	 * @return int
+	 */
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_cancel_token_expiration_days', 2, $this->assignee );
+	}
+
+	/**
+	 * Get the scopes to be used when generating the access token.
+	 *
+	 * @since 2.1.2-dev
+	 *
+	 * @param string $action The access token action.
+	 *
+	 * @return array
+	 */
+	protected function get_token_scopes( $action = '' ) {
+		return array(
+			'pages'           => array( 'inbox' ),
+			'entry_id'        => $this->step->get_entry_id(),
+			'action'          => $action,
+		);
 	}
 }
 

--- a/includes/merge-tags/class-merge-tag-workflow-reject-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject-token.php
@@ -11,16 +11,12 @@ if ( ! class_exists( 'GFForms' ) ) {
 	die();
 }
 
-if ( ! class_exists( 'Gravity_Flow_Merge_Tag_Workflow_Url' ) ) {
-	require_once( 'class-merge-tag-workflow-url.php' );
-}
-
 /**
  * Class Gravity_Flow_Merge_Tag_Workflow_Reject_Token
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Tag_Workflow_Url {
+class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.
@@ -64,7 +60,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Ta
 				return $text;
 			}
 
-			$token = $this->get_token();
+			$token = $this->get_token( 'reject' );
 
 			$token = $this->format_value( $token );
 
@@ -74,29 +70,10 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Ta
 		return $text;
 	}
 
-	/**
-	 * Get the reject token for the current assignee and step.
-	 *
-	 * @return string
-	 */
-	protected function get_token() {
-		$expiration_days = apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
-
-		$expiration_str = '+' . (int) $expiration_days . ' days';
-
-		$expiration_timestamp = strtotime( $expiration_str );
-
-		$scopes = array(
-			'pages'           => array( 'inbox' ),
-			'step_id'         => $this->step->get_id(),
-			'entry_timestamp' => $this->step->get_entry_timestamp(),
-			'entry_id'        => $this->step->get_entry_id(),
-			'action'          => 'reject',
-		);
-		$token = gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
-
-		return $token;
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
 	}
+
 }
 
 Gravity_Flow_Merge_Tags::register( new Gravity_Flow_Merge_Tag_Workflow_Reject_Token );

--- a/includes/merge-tags/class-merge-tag-workflow-reject.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject.php
@@ -11,16 +11,12 @@ if ( ! class_exists( 'GFForms' ) ) {
 	die();
 }
 
-if ( ! class_exists( 'Gravity_Flow_Merge_Tag_Workflow_Reject_Token' ) ) {
-	require_once( 'class-merge-tag-workflow-reject-token.php' );
-}
-
 /**
  * Class Gravity_Flow_Merge_Tag_Workflow_Reject
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Workflow_Reject_Token {
+class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'GFForms' ) ) {
  *
  * @since 1.7.1-dev
  */
-class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag {
+class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assignee_Base {
 
 	/**
 	 * The name of the merge tag.
@@ -96,68 +96,12 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag {
 		$token       = '';
 
 		if ( $this->assignee && $force_token ) {
-			$token_lifetime_days        = apply_filters( 'gravityflow_entry_token_expiration_days', 30, $this->assignee );
-			$token_expiration_timestamp = strtotime( '+' . (int) $token_lifetime_days . ' days' );
-			$token                      = gravity_flow()->generate_access_token( $this->assignee, null, $token_expiration_timestamp );
+			$token = $this->get_token();
 		}
 
 		return $token;
 	}
 
-	/**
-	 * Returns the inbox URL.
-	 *
-	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string   $access_token The access token for the current assignee.
-	 *
-	 * @return string
-	 */
-	public function get_inbox_url( $page_id = null, $access_token = '' ) {
-
-		$query_args = array(
-			'page' => 'gravityflow-inbox',
-		);
-
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
-	}
-
-	/**
-	 * Returns the entry URL.
-	 *
-	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string   $access_token The access token for the current assignee.
-	 *
-	 * @return string
-	 */
-	public function get_entry_url( $page_id = null, $access_token = '' ) {
-
-		$form_id = $this->step ? $this->step->get_form_id() : false;
-		if ( empty( $form_id ) && ! empty( $this->form ) ) {
-			$form_id = $this->form['id'];
-		}
-
-		if ( empty( $form_id ) ) {
-			return false;
-		}
-
-		$entry_id = $this->step ? $this->step->get_entry_id() : false;
-		if ( empty( $entry_id ) && ! empty( $this->entry ) ) {
-			$entry_id = $this->entry['id'];
-		}
-
-		if ( empty( $entry_id ) ) {
-			return false;
-		}
-
-		$query_args = array(
-			'page' => 'gravityflow-inbox',
-			'view' => 'entry',
-			'id'   => $form_id,
-			'lid'  => $entry_id,
-		);
-
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
-	}
 }
 
 Gravity_Flow_Merge_Tags::register( new Gravity_Flow_Merge_Tag_Workflow_Url );

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -890,30 +890,6 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	}
 
 	/**
-	 * Replaces the step merge tags.
-	 *
-	 * @param string                $text     The text containing merge tags to be processed.
-	 * @param Gravity_Flow_Assignee $assignee The assignee properties.
-	 *
-	 * @return string
-	 */
-	public function replace_variables( $text, $assignee ) {
-		$text = parent::replace_variables( $text, $assignee );
-
-		$args = array(
-			'assignee' => $assignee,
-			'step'     => $this,
-		);
-
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_approve_token', $args )->replace( $text );
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_approve', $args )->replace( $text );
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_reject_token', $args )->replace( $text );
-		$text = Gravity_Flow_Merge_Tags::get( 'workflow_reject', $args )->replace( $text );
-
-		return $text;
-	}
-
-	/**
 	 * Provides a way for a step to process a token action before anything else. If feedback is returned it is displayed and nothing else with be rendered.
 	 *
 	 * @param array $action The action properties.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1044,17 +1044,6 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 * @return string
 	 */
 	public function replace_variables( $text, $assignee ) {
-
-		$args = array(
-			'assignee' => $assignee,
-			'step'     => $this,
-		);
-
-		$merge_tags = Gravity_Flow_Merge_Tags::get_all( $args );
-
-		foreach ( $merge_tags as $merge_tag ) {
-			$text = $merge_tag->replace( $text );
-		}
 		return $text;
 	}
 


### PR DESCRIPTION
re: [HS#5737](https://secure.helpscout.net/conversation/555366910/5737?folderId=1113535)

Fixes an issue where the created_by merge tag is being replaced in `Gravity_Flow_Assignee` when the entry is not passed in the `Gravity_Flow_Merge_Tags` initialization arguments.

Merge tags which extend `Gravity_Flow_Merge_Tag_Assignee_Base` will be replaced when processing is triggered in `Gravity_Flow_Assignee` while all other merge tags will be replaced when `GFCommon::send_notification` triggers merge tag processing. This also ensures merge tags such as workflow_fields are only replaced after the gform_notification filter has been used to change the message format from html to text.