### PR TITLE
Fix one-click actions

### DIFF
--- a/includes/merge-tags/class-merge-tag-workflow-approve.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve.php
@@ -59,7 +59,7 @@ class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Assignee_Bas
 				return $text;
 			}
 
-			$approve_token = $this->get_token();
+			$approve_token = $this->get_token( 'approve' );
 
 			if ( is_array( $matches ) ) {
 				foreach ( $matches as $match ) {

--- a/includes/merge-tags/class-merge-tag-workflow-reject.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject.php
@@ -59,7 +59,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 				return $text;
 			}
 
-			$reject_token = $this->get_token();
+			$reject_token = $this->get_token( 'reject' );
 
 			if ( is_array( $matches ) ) {
 				foreach ( $matches as $match ) {


### PR DESCRIPTION
The one-click actions (approve and reject) from emails weren't working anymore because the tokens were created without an action. This PR fixed that.