### PR TITLE
Load users only when needed

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -503,7 +503,7 @@ PRIMARY KEY  (id)
 				}
 			}
 
-			$users = is_admin() ? $this->get_users_as_choices() : array();
+			$users = $this->is_form_settings( 'gravityflow' ) ? $this->get_users_as_choices() : array();
 
 			$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG || isset( $_GET['gform_debug'] ) ? '' : '.min';
 


### PR DESCRIPTION
This PR fixes a performance issue which can affect sites with a lot of users. The list of users is currently generated on every admin request. The WordPress function `get_users()` performs one query for every user meaning that a site with 1000 users will generate 1000 unnecessary requests on every admin page load. This PR generates the list only on the settings page.
Fixes [HS5993](https://secure.helpscout.net/conversation/578178309/5993/?folderId=516731)