### PR TITLE
Fix multi-user editable fields

### DIFF
--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1594,10 +1594,12 @@ abstract class Gravity_Flow_Step extends stdClass {
 					$json_value = $entry[ $id ];
 					$user_ids   = json_decode( $json_value );
 					if ( $user_ids && is_array( $user_ids ) ) {
+						$args['type'] = 'user_id';
 						foreach ( $user_ids as $user_id ) {
 							$user = get_userdata( $user_id );
 							if ( $user ) {
-								$user_assignee = $this->get_assignee( 'user_id|' . $user_id );;
+								$args['id'] = $user_id;
+								$user_assignee = $this->get_assignee( $args );
 								$this->_assignees[] = $user_assignee;
 							}
 						}


### PR DESCRIPTION
This PR fixes an issue with the Multi-User field on the User Input step where no fields are editable for the assignee.

**Testing instructions**

To reproduce the issue on master
- Add a Multi-User field to a form.
- Assign a User Input step to the Multi-User field and configure some editable fields.
- Select some users in the Multi-User field and submit the form.
- Check the inbox and verify that the editable fields are not editable.

On this branch, the editable fields will be editable.