### PR TITLE
Process default value merge tags

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -422,10 +422,16 @@ class Gravity_Flow_Entry_Editor {
 			// Process merge tags in default values.
 			if ( is_array( $field->get_entry_inputs() ) ) {
 				foreach ( $value as $key => $item ) {
-					$value[ $key ] = GFCommon::replace_variables_prepopulate( $item );
+					$input = GFFormsModel::get_input( $field, $key );
+					if ( $item === rgar( $input, 'defaultValue' ) ) {
+						$value[ $key ] = GFCommon::replace_variables_prepopulate( $item );
+					}
 				}
 			} elseif ( $field->get_input_type() == 'email' && $field->emailConfirmEnabled ) {
-				$value = GFCommon::replace_variables_prepopulate( $value );
+				$input = GFFormsModel::get_input( $field, $field->id );
+				if ( $value === rgar( $input, 'defaultValue' ) ) {
+					$value = GFCommon::replace_variables_prepopulate( $value );
+				}
 				$value = array( $value, $value );
 			} else {
 				$value = $field->get_value_default_if_empty( $value );


### PR DESCRIPTION
re: [HS#5938](https://secure.helpscout.net/conversation/573644191/5938?folderId=1113492)

Fixes an issue where merge tags added to the field default value setting are not processed for multi-input or choice based fields when Gravity Forms saves the initial entry.

See the ticket for a test form.

Testing with master you will find the "User ID" field is the only field where the merge tag is replaced.

Testing with this brach all the fields will display the correct value.