### PR TITLE
Fixed assignee fatal error

### DIFF
--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -415,7 +415,7 @@ class Gravity_Flow_Assignee {
 		$assignee_key = $this->step->get_current_assignee_key();
 		$assignee     = $this->step->get_assignee( $assignee_key );
 
-		if ( in_array( $this->get_type(), array( 'user_id', 'email' ) ) && $assignee->get_id() != $this->get_id() ) {
+		if ( ! $assignee || in_array( $this->get_type(), array( 'user_id', 'email' ) ) && $assignee->get_id() != $this->get_id() ) {
 			return false;
 		}
 


### PR DESCRIPTION
re: [HS#5910](https://secure.helpscout.net/conversation/571956500/5910/?folderId=1113492)

Fixes a fatal error which can occur when the current users permissions are checked on the entry detail page and the user is accessing the page anonymously using `{workflow_entry_url: page_id=n}` in a form notification, sent before the workflow starts, pointing to a page containing `[gravityflow page="status" allow_anonymous="true"]`