### PR TITLE
Fix missing users multiselect UI

### DIFF
--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -46,7 +46,7 @@
 			}
 		};
 
-		$('#assignees').multiSelect(multiSelectWithSearch);
+		$('#assignees, #workflow_notification_users').multiSelect(multiSelectWithSearch);
 
 		var gravityFlowIsDirty = false, gravityFlowSubmitted = false;
 


### PR DESCRIPTION
This PR fixes the bug that the multiselect UI was missing for notification users.

**Test instructions:**

1. Currently in the notification step and PDF step, there's no multiselect UI for notification users.
2. With this PR, the multiselect UI is back for them.
3. And we also enable the search feature to this field.