### PR TITLE
Updates filter_gform_pre_render() method to only apply to current form.

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -190,6 +190,11 @@ class Gravity_Flow_Entry_Editor {
 	 * @return array The filtered form.
 	 */
 	public function filter_gform_pre_render( $form ) {
+
+		if( $form['id'] != rgget( 'id' ) ) {
+			return $form;
+		}
+
 		$form                              = $this->remove_page_fields( $form );
 		$fields                            = array();
 		$dynamic_conditional_logic_enabled = $this->_is_dynamic_conditional_logic_enabled;


### PR DESCRIPTION
In some situations (like with GP Nested Forms), the gform_pre_render may be called multiple times in a single page load. Currently, Gravity Flow will filter all forms that are filtered through gform_pre_render when editing an entry.