### PR TITLE
Creation of 2 filters to control form(s) used in GFAPI searches for inbox and status tables

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,3 @@
+- Added the filter gravityflow_form_ids_inbox which allows adjustment of form id(s) when searching for entries for the inbox table.
+- Added the filter gravityflow_form_ids_status which allows adjustment of form id(s) when searching for entries for the status table.
 - Fixed a notice which can get displayed if GravityView is installed.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -168,6 +168,18 @@ class Gravity_Flow_Inbox {
 
 			$form_ids = $args['form_id'] ? $args['form_id'] : gravity_flow()->get_workflow_form_ids();
 
+			/**
+			 * Allows form id(s) to be adjusted to define which forms' entries are displayed in inbox table.
+			 *
+			 * @since 2.2.2-dev
+			 * 
+			 * Return an array of form ids for use with GFAPI.
+			 *
+			 * @param array   $form_ids        The form ids
+			 * @param array   $search_criteria The search criteria
+			 */
+			$form_ids = apply_filters( 'gravityflow_form_ids_inbox', $form_ids, $search_criteria);
+
 			gravity_flow()->log_debug( __METHOD__ . '(): $form_ids => ' . print_r( $form_ids, 1 ) );
 			gravity_flow()->log_debug( __METHOD__ . '(): $search_criteria => ' . print_r( $search_criteria, 1 ) );
 

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -171,10 +171,10 @@ class Gravity_Flow_Inbox {
 			/**
 			 * Allows form id(s) to be adjusted to define which forms' entries are displayed in inbox table.
 			 *
+			 * Return an array of form ids for use with GFAPI.
+			 * 
 			 * @since 2.2.2-dev
 			 * 
-			 * Return an array of form ids for use with GFAPI.
-			 *
 			 * @param array   $form_ids        The form ids
 			 * @param array   $search_criteria The search criteria
 			 */

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1639,11 +1639,11 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		/**
 		 * Allows form id(s) to be adjusted to define which forms' entries are displayed in status table.
-		 *
-		 * @since 2.2.2-dev
 		 * 
 		 * Return an array of form ids for use with GFAPI.
 		 *
+		 * @since 2.2.2-dev
+		 * 
 		 * @param array   $form_ids       The form ids
 		 * @param array   $search_criteria The search criteria
 		 */

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1637,6 +1637,18 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		$sorting = array( 'key' => $orderby, 'direction' => $order );
 
+		/**
+		 * Allows form id(s) to be adjusted to define which forms' entries are displayed in status table.
+		 *
+		 * @since 2.2.2-dev
+		 * 
+		 * Return an array of form ids for use with GFAPI.
+		 *
+		 * @param array   $form_ids       The form ids
+		 * @param array   $search_criteria The search criteria
+		 */
+		$form_ids = apply_filters( 'gravityflow_form_ids_status', $form_ids, $search_criteria );
+
 		gravity_flow()->log_debug( __METHOD__ . '(): search criteria: ' . print_r( $search_criteria, true ) );
 
 		$entries = GFAPI::get_entries( $form_ids, $search_criteria, $sorting, $paging, $total_count );


### PR DESCRIPTION
Refer to #6067 for specific request scenario.

An example snippet which uses the new filters to prevent entries of a specific form from being shown to inbox / status. 

```
add_filter( 'gravityflow_form_ids_status', 'shortcode_display_args_control', 10, 2 );
add_filter( 'gravityflow_form_ids_inbox', 'shortcode_display_args_control', 10, 2 );
function shortcode_display_args_control( $form_ids, $search_criteria ) {
	$workflow_form_ids = gravity_flow()->get_workflow_form_ids();	
	unset( $workflow_form_ids[ array_search( '3', $workflow_form_ids ) ] );
	return $workflow_form_ids;
}
```


Do you think additional parameters be added?
Something that might help to differentiate between admin view or shortcode view perhaps?