### PR TITLE
Fix assignee policy for multiple role assignees

### DIFF
--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -412,32 +412,33 @@ class Gravity_Flow_Assignee {
 	 */
 	public function is_current_user() {
 
-		$assignee_key = $this->step->get_current_assignee_key();
-		$assignee     = $this->step->get_assignee( $assignee_key );
+		$assignee_key  = $this->step->get_current_assignee_key();
+		$step_assignee = $this->step->get_assignee( $assignee_key );
 
-		if ( ! $assignee || in_array( $this->get_type(), array( 'user_id', 'email' ) ) && $assignee->get_id() != $this->get_id() ) {
+		$type = $this->get_type();
+
+		if ( ! $step_assignee ) {
 			return false;
 		}
 
-		$status = $assignee->get_status();
+		$status = $this->get_status();
 
-		if ( $status == 'pending' ) {
+		if ( $status != 'pending' ) {
+			return false;
+		}
+
+		if ( in_array( $type, array( 'user_id', 'email' ) ) && $step_assignee->get_id() == $this->get_id() ) {
 			return true;
 		}
 
-		// Check roles
-		$current_role_status = false;
-
-		foreach ( gravity_flow()->get_user_roles() as $role ) {
-			$current_role_status = $this->step->get_role_status( $role );
-			if ( $current_role_status == 'pending' ) {
-				break;
+		if ( $type == 'role' ) {
+			$user = wp_get_current_user();
+			$role = $this->get_id();
+			if ( in_array( $role, (array) $user->roles ) ) {
+				return true;
 			}
 		}
 
-		if ( $current_role_status == 'pending' ) {
-			return true;
-		}
 		return false;
 	}
 


### PR DESCRIPTION
This PR fixes an issue where the 'all' assignee policy is ignored when multiple roles are assigned to a step. Fixes [HS6055](https://secure.helpscout.net/conversation/583746467/6055?folderId=1113498)

**Testing instructions**
- To reproduce the issue on the master branch, create a form, assign it to two roles and select "all assignees must complete this step". The entry is approved and the step is complete when only one role approves.
- On this branch, the assignee policy will be respected requiring both roles to complete the step.
- Test with more than two roles
- Check for regression issues with different assignee types: user, multi-user & email fields combined with different assignee policies.
