### PR TITLE
Fix date field expiration

### DIFF
--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -814,7 +814,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		if ( $this->expiration_type == 'date_field' ) {
 
 			$this->log_debug( __METHOD__ . '() expiration_date_field: ' . $this->expiration_date_field );
-			$expiration_date = $entry[ (string) $this->schedule_date_field ];
+			$expiration_date = $entry[ (string) $this->expiration_date_field ];
 			$this->log_debug( __METHOD__ . '() expiration_date: ' . $expiration_date );
 
 			$expiration_datetime = strtotime( $expiration_date );


### PR DESCRIPTION
This PR fixes an issue with date field expiration where the incorrect date field can be used if there are multiple date fields on the form. Fixes [HS6095](https://secure.helpscout.net/conversation/588889353/6095/)