### PR TITLE
Fix RTL entry detail

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -63,6 +63,7 @@ table.entry-detail-view td{
 }
 .rtl #poststuff #post-body.columns-2 {
     margin-left: 280px;
+    margin-right: 0;
 }
 
 #poststuff .postbox-container {
@@ -158,6 +159,10 @@ table.entry-detail-view td{
     margin-top:5px;
     margin-bottom:5px;
     clear:both;
+}
+
+.rtl .gravityflow-note-body-wrap {
+    margin-left: 0;
 }
 
 @media screen and (max-width: 880px) {


### PR DESCRIPTION
Fixes an issue on some RTL themes where the content is too narrow. e.g. on TwentySeventeen
![rtl-issue](https://user-images.githubusercontent.com/368815/40889273-1169d4be-6764-11e8-8d92-5258ca760b42.png)
Fixes [HS6133](https://secure.helpscout.net/conversation/593320004/6133?folderId=1113418)