### PR TITLE
Added workflow cancelled notification event

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
+- Added the "Workflow: cancelled" notification event for sending form notifications when the workflow is cancelled.
 - Fixed an issue which prevents tokens from working correctly with role assignees.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4640,6 +4640,7 @@ PRIMARY KEY  (id)
 				$events['workflow_approval']   = __( 'Workflow: approved or rejected', 'gravityflow' );
 				$events['workflow_user_input'] = __( 'Workflow: user input', 'gravityflow' );
 				$events['workflow_complete']   = __( 'Workflow: complete', 'gravityflow' );
+				$events['workflow_cancelled']  = __( 'Workflow: cancelled', 'gravityflow' );
 			}
 
 			return $events;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -128,6 +128,7 @@ class Gravity_Flow_API {
 		$feedback = esc_html__( 'Workflow cancelled.', 'gravityflow' );
 		gravity_flow()->add_timeline_note( $entry_id, $feedback );
 		gravity_flow()->log_event( 'workflow', 'cancelled', $form['id'], $entry_id );
+		GFAPI::send_notifications( $form, $entry, 'workflow_cancelled' );
 
 		return true;
 	}


### PR DESCRIPTION
re: [HS#6233](https://secure.helpscout.net/conversation/605682690/6233?folderId=1113492)

Added the "Workflow: cancelled" choice to the event setting on the Gravity Forms edit notification page. Notifications assigned to this event will be sent at the end of the cancellation process.