### PR TITLE
HS#5583 - Re-factor get_value_export for multiple user field types

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Added the "Workflow: cancelled" notification event for sending form notifications when the workflow is cancelled.
 - Fixed an issue which prevents tokens from working correctly with role assignees.
+- Fixed an issue which prevents form connector mapping assignee field and export display of user-based field types (assignee, user, multiuser)

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -306,7 +306,20 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 			$input_id = $this->id;
 		}
 
-		return $this->get_display_name( rgar( $entry, $input_id ) );
+		$assignee = rgar( $entry, $input_id );
+
+		list( $type, $value ) = explode( '|', $assignee, 2 );
+		switch ( $type ) {
+			case 'role' :
+				$value = translate_user_role( $value );
+				break;
+			case 'user_id' :
+				if( $use_text == true || $is_csv == true ) {
+					$value = $this->get_display_name( $value );
+				}
+		}
+		
+		return $value;
 	}
 
 	/**

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -314,11 +314,10 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 				$value = translate_user_role( $value );
 				break;
 			case 'user_id' :
-				if( $use_text == true || $is_csv == true ) {
-					$value = $this->get_display_name( $value );
-				}
 				if( $use_text == false && $is_csv == false ) {
 					$value = $assignee;
+				} else {
+					$value = $this->get_display_name( $assignee );
 				}
 		}
 		

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -310,17 +310,17 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 
 		list( $type, $value ) = explode( '|', $assignee, 2 );
 		switch ( $type ) {
-			case 'role' :
+			case 'role':
 				$value = translate_user_role( $value );
 				break;
-			case 'user_id' :
-				if( $use_text == false && $is_csv == false ) {
+			case 'user_id':
+				if ( $use_text == false && $is_csv == false ) {
 					$value = $assignee;
 				} else {
 					$value = $this->get_display_name( $assignee );
 				}
 		}
-		
+
 		return $value;
 	}
 

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -317,6 +317,9 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 				if( $use_text == true || $is_csv == true ) {
 					$value = $this->get_display_name( $value );
 				}
+				if( $use_text == false && $is_csv == false ) {
+					$value = $assignee;
+				}
 		}
 		
 		return $value;

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -244,10 +244,14 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 			$input_id = $this->id;
 		}
 
-		$value         = json_decode( rgar( $entry, $input_id ), true );
-		$display_names = $this->get_display_names( $value );
+		$value = json_decode( rgar( $entry, $input_id ), true );
 
-		return GFCommon::implode_non_blank( ', ', $display_names );
+		if( $use_text == true || $is_csv == true ) {
+			$display_names = $this->get_display_names( $value );
+			return GFCommon::implode_non_blank( ', ', $display_names );
+		}
+
+		return GFCommon::implode_non_blank( ', ', $value );
 	}
 
 	/**

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -251,6 +251,10 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 			return GFCommon::implode_non_blank( ', ', $display_names );
 		}
 
+		if( $use_text == false && $is_csv == false ) {
+			return rgar( $entry, $input_id );
+		}
+
 		return GFCommon::implode_non_blank( ', ', $value );
 	}
 

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -246,12 +246,13 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 
 		$value = json_decode( rgar( $entry, $input_id ), true );
 
-		if( $use_text == true || $is_csv == true ) {
+		if ( $use_text == true || $is_csv == true ) {
 			$display_names = $this->get_display_names( $value );
+
 			return GFCommon::implode_non_blank( ', ', $display_names );
 		}
 
-		if( $use_text == false && $is_csv == false ) {
+		if ( $use_text == false && $is_csv == false ) {
 			return rgar( $entry, $input_id );
 		}
 

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -211,7 +211,13 @@ class Gravity_Flow_Field_User extends GF_Field_Select {
 			$input_id = $this->id;
 		}
 
-		return $this->get_display_name( rgar( $entry, $input_id ) );
+		$user_id =  rgar( $entry, $input_id );
+
+		if( $use_text == true || $is_csv == true ) {
+			return $this->get_display_name( $user_id );
+		}
+		
+		return $user_id;
 	}
 
 	/**

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -211,12 +211,12 @@ class Gravity_Flow_Field_User extends GF_Field_Select {
 			$input_id = $this->id;
 		}
 
-		$user_id =  rgar( $entry, $input_id );
+		$user_id = rgar( $entry, $input_id );
 
-		if( $use_text == true || $is_csv == true ) {
+		if ( $use_text == true || $is_csv == true ) {
 			return $this->get_display_name( $user_id );
 		}
-		
+
 		return $user_id;
 	}
 


### PR DESCRIPTION
A resolution to https://github.com/gravityflow/gravityflowformconnector/pull/6 which is now closed.

The form export attached has two forms that validate the form connector assignment by field works for the GFlow field types (assignee - by user, role, user, role and multi-user). They all also work for export. PR also passes all unit and acceptance tests currently.

[gravityforms-export-2018-07-01.json.zip](https://github.com/gravityflow/gravityflow/files/2153269/gravityforms-export-2018-07-01.json.zip)

Adding Steven and Richard for review