### PR TITLE
Discussion display toggle

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Added the "Workflow: cancelled" notification event for sending form notifications when the workflow is cancelled.
 - Fixed an issue which prevents tokens from working correctly with role assignees.
+- Fixed an issue which causes discussion field show / hide toggle to display on non-Gravity Flow pages.

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -262,7 +262,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 			 */
 			$display_toggle = apply_filters( 'gravityflow_discussion_items_display_toggle', true, $this );
 
-			if ( ( ! $this->is_form_editor() && $display_toggle ) ) {
+			if ( ( rgget( 'view' ) == 'entry' && $display_toggle ) ) {
 				/**
 				 * Set the amount of discussion items to be shown in non-print inbox / status view when toggle is active.
 				 *

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -282,7 +282,6 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 
 					if ( $format === 'html' ) {
 						$return .= sprintf( "<a href='javascript:void(0);' title='%s' data-title='%s' onclick='GravityFlowEntryDetail.displayDiscussionItemToggle(%d, %d, %d);'  class='gravityflow-dicussion-item-toggle-display'>%s</a>", $view_more_label, $view_less_label, $this['formId'], $this['id'], $recent_display_limit, __( 'View More', 'gravityflow' ) );
-						$return .= $this->inline_scripts();
 					}
 				}
 			}
@@ -332,28 +331,6 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 		$limit     = rgar( $modifiers, 'limit', 0 );
 
 		return absint( $limit );
-	}
-
-	public function inline_scripts() {
-
-		$scripts = '<script type="text/javascript">
-			if (typeof GravityFlowEntryDetail == "undefined") {
-				(function (GravityFlowEntryDetail, $) {
-					GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
-						console.log("Inline script version");
-						$toggle = jQuery(":focus").parent();
-						console.dir( $toggle );
-						$toggle.find( ".gravityflow-dicussion-item-hidden" ).slideToggle( "fast" );
-						var $viewMore = $toggle.children( ".gravityflow-dicussion-item-toggle-display" );
-						var oldText = $viewMore.attr( "title" );
-						var newText = $viewMore.data( "title" );
-						$viewMore.attr( "title", newText ).text( newText );
-						$viewMore.data( "title", oldText );
-					}
-				}(window.GravityFlowEntryDetail = window.GravityFlowEntryDetail || {}, jQuery));
-			}
-		</script>';
-		return $scripts;
 	}
 
 	/**

--- a/includes/fields/class-field-discussion.php
+++ b/includes/fields/class-field-discussion.php
@@ -282,6 +282,7 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 
 					if ( $format === 'html' ) {
 						$return .= sprintf( "<a href='javascript:void(0);' title='%s' data-title='%s' onclick='GravityFlowEntryDetail.displayDiscussionItemToggle(%d, %d, %d);'  class='gravityflow-dicussion-item-toggle-display'>%s</a>", $view_more_label, $view_less_label, $this['formId'], $this['id'], $recent_display_limit, __( 'View More', 'gravityflow' ) );
+						$return .= $this->inline_scripts();
 					}
 				}
 			}
@@ -331,6 +332,28 @@ class Gravity_Flow_Field_Discussion extends GF_Field_Textarea {
 		$limit     = rgar( $modifiers, 'limit', 0 );
 
 		return absint( $limit );
+	}
+
+	public function inline_scripts() {
+
+		$scripts = '<script type="text/javascript">
+			if (typeof GravityFlowEntryDetail == "undefined") {
+				(function (GravityFlowEntryDetail, $) {
+					GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
+						console.log("Inline script version");
+						$toggle = jQuery(":focus").parent();
+						console.dir( $toggle );
+						$toggle.find( ".gravityflow-dicussion-item-hidden" ).slideToggle( "fast" );
+						var $viewMore = $toggle.children( ".gravityflow-dicussion-item-toggle-display" );
+						var oldText = $viewMore.attr( "title" );
+						var newText = $viewMore.data( "title" );
+						$viewMore.attr( "title", newText ).text( newText );
+						$viewMore.data( "title", oldText );
+					}
+				}(window.GravityFlowEntryDetail = window.GravityFlowEntryDetail || {}, jQuery));
+			}
+		</script>';
+		return $scripts;
 	}
 
 	/**


### PR DESCRIPTION
**Prior to this PR:**
- Discussion show/hide toggle would show on any page scenario where field values were output except for the form editor or cases where gravityflow_discussion_items_display_toggle was set to false.
- The JS to provide show/hide functionality would only occur on Gravity Flow pages, resulting fully hidden discussion items when being displayed in other contexts.

PR resolves this issue by ensuring show/hide toggle only displays on Gravity Flow pages.

**Testing**
- Data - Create entry with discussion field and > 10 comments to it.
- Positive - Continue to see show/hide on inbox and status entry detail views
- Negative - Display field value through a separate plugin (GView or generated posts as example) does not have show/hide toggle.

**Documentation**
Upon version deployment with this update, https://docs.gravityflow.io/article/116-the-discussion-field will be updated to note the scope of display and link to a snippet to achieve similar effect through custom JS snippet (i.e. similar show/hide toggle on a non-GFlow page that other plugins or theme can implement).