### PR TITLE
Fix display on entry detail pages

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with the Multi-User field on the entry detail pages where the ID is displayed instead of the user's name.

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -197,7 +197,7 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 
 		$user_ids = $this->to_array( $value );
 
-		$display_names = $use_text ? $this->get_display_names( $user_ids ) : $user_ids;
+		$display_names = $this->get_display_names( $user_ids );
 
 		return parent::get_value_entry_detail( $display_names, $currency, $use_text, $format, $media );
 	}


### PR DESCRIPTION
This PR fixes an issue with the Multiuser field where the user IDs are displayed instead of the names on the entry detail page and the workflow entry detail page.