### PR TITLE
Add authorized choice to feed logic

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
+- Added "Authorized" as an available choice for the entry Payment Status property in the step condition setting.
 - Fixed an issue with the Multi-User field on the entry detail pages where the ID is displayed instead of the user's name.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7154,6 +7154,10 @@ AND m.meta_value='queued'";
 						'operators' => array( 'is', 'isnot' ),
 						'choices'   => array(
 							array(
+								'text'  => esc_html__( 'Authorized', 'gravityflow' ),
+								'value' => 'Authorized',
+							),
+							array(
 								'text'  => esc_html__( 'Paid', 'gravityflow' ),
 								'value' => 'Paid',
 							),


### PR DESCRIPTION
Adds "Authorized" as an available choice for the entry Payment Status property in the step condition setting.