### PR TITLE
Inbox Page - File Field Column

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Added "Authorized" as an available choice for the entry Payment Status property in the step condition setting.
 - Fixed an issue with the Multi-User field on the entry detail pages where the ID is displayed instead of the user's name.
+- Fixed an issue with the File Upload field display the inbox shortcode page via fields attribute. The file icon/link was not displaying and generating PHP error.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -412,6 +412,7 @@ class Gravity_Flow_Inbox {
 				$field = GFFormsModel::get_field( $form, $id );
 
 				if ( is_object( $field ) ) {
+					require_once( GFCommon::get_base_path() . '/entry_list.php' );
 					$value = $field->get_value_entry_list( rgar( $entry, $id ), $entry, $id, $columns, $form );
 				} else {
 					$value = rgar( $entry, $id );


### PR DESCRIPTION
Refer to [HS 6570](https://secure.helpscout.net/conversation/640747773/6570?folderId=1113497) for details.

**To replicate issue:**
* Create form with an upload field set for single upload and a workflow step assigned to user
* Create entry
* Create page with the inbox shortcode with form / fields attributes to display
[gravityflow page="inbox" form="1" fields="2,3"]
* Receive error FATAL ERROR: UNCAUGHT ERROR: CLASS 'GFENTRYLIST' NOT FOUND IN .../WP-CONTENT/PLUGINS/GRAVITYFORMS/INCLUDES/FIELDS/CLASS-GF-FIELD-FILEUPLOAD.PHP ON LINE 449

**Analysis/Resolution:**
The UI issue is that GForms is trying to call GFEntryList::get_icon_url to display the upload icon and on GFlow side the GFEntryList is not instantiated to support it. Resolution is consistent with other requires to GForms functionality.