### PR TITLE
Update inbox and status page payment status column support

### DIFF
--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -408,6 +408,12 @@ class Gravity_Flow_Inbox {
 					$value = self::format_actions( $step );
 				}
 				break;
+			case 'payment_status':
+				$value = rgar( $entry, 'payment_status' );
+				if ( gravity_flow()->is_gravityforms_supported( '2.4' ) ) {
+					$value = GFCommon::get_entry_payment_status_text( $value );
+				}
+				break;
 			default:
 				$field = GFFormsModel::get_field( $form, $id );
 

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -747,21 +747,9 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param array $item The current entry.
 	 */
 	public function column_id( $item ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
-		$url_entry = esc_url( $url_entry );
-		$label = absint( $item['id'] );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label The value to be displayed.
-		 * @param int    $item  ['form_id'] The Form ID.
-		 * @param        string 'id' The column name.
-		 * @param array  $item  The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'id', $item );
+		$url_entry = esc_url( $this->get_entry_url( $item ) );
+		$label     = absint( $item['id'] );
+		$label     = $this->filter_field_value( $label, $item, 'id' );
 
 		$link = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -774,32 +762,20 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param string $column_name The column name.
 	 */
 	public function column_default( $item, $column_name ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
-		$url_entry = esc_url( $url_entry );
-		$form_id = rgar( $item, 'form_id' );
-		$form = GFAPI::get_form( $form_id );
+		$url_entry = esc_url( $this->get_entry_url( $item ) );
+		$form_id   = rgar( $item, 'form_id' );
+		$form      = GFAPI::get_form( $form_id );
 
 		/* @var GF_Field $field */
 		$field = GFFormsModel::get_field( $form, $column_name );
 		$value = rgar( $item, $column_name );
 		if ( $field ) {
 			$columns = RGFormsModel::get_grid_columns( $form_id, true );
-			$value = $field->get_value_entry_list( $value, $item, $column_name, $columns, $form );
+			$value   = $field->get_value_entry_list( $value, $item, $column_name, $columns, $form );
 		}
 
 		$label = esc_html( $value );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label       The value to be displayed.
-		 * @param int    $item        ['form_id'] The Form ID.
-		 * @param string $column_name The column name.
-		 * @param array  $item        The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], $column_name, $item );
+		$label = $this->filter_field_value( $label, $item, $column_name );
 
 		$link = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -811,24 +787,12 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param array $item The current entry.
 	 */
 	public function column_workflow_final_status( $item ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
+		$url_entry    = esc_url( $this->get_entry_url( $item ) );
 		$final_status = rgar( $item, 'workflow_final_status' );
-		$label = empty( $final_status ) ? '' : gravity_flow()->translate_status_label( $final_status );
-		$label = esc_html( $label );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label The value to be displayed.
-		 * @param int    $item  ['form_id'] The Form ID.
-		 * @param        string 'final_status'.
-		 * @param array  $item  The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'final_status', $item );
-		$url_entry = esc_url( $url_entry );
-		$link = "<a href='{$url_entry}'>$label</a>";
+		$label        = empty( $final_status ) ? '' : gravity_flow()->translate_status_label( $final_status );
+		$label        = esc_html( $label );
+		$label        = $this->filter_field_value( $label, $item, 'final_status' );
+		$link         = "<a href='{$url_entry}'>$label</a>";
 
 		echo $link;
 
@@ -926,7 +890,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param array $item The current entry.
 	 */
 	public function column_created_by( $item ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
+		$url_entry = esc_url( $this->get_entry_url( $item ) );
 
 		$user_id = $item['created_by'];
 		if ( $user_id ) {
@@ -952,20 +916,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		 * @param array  $form  The form object for the current entry.
 		 */
 		$label = apply_filters( 'gravityflow_status_submitter_name', $label, $item, $form );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label The value to be displayed.
-		 * @param int    $item  ['form_id'] The Form ID.
-		 * @param        string 'created_by'.
-		 * @param array  $item  The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'created_by', $item );
-
-		$url_entry = esc_url( $url_entry );
+		$label = $this->filter_field_value( $label, $item, 'created_by' );
 
 		$link  = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -977,26 +928,13 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param array $item The current entry.
 	 */
 	public function column_form_id( $item ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
+		$url_entry = esc_url( $this->get_entry_url( $item ) );
 
 		$form_id = $item['form_id'];
 		$form    = $this->get_form( $form_id );
 
 		$label = esc_html( $form['title'] );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label The value to be displayed
-		 * @param int $item['form_id'] The Form ID
-		 * @param string 'form_id'
-		 * @param array $item The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'form_id', $item );
-
-		$url_entry = esc_url( $url_entry );
+		$label = $this->filter_field_value( $label, $item, 'form_id' );
 
 		$link  = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
@@ -1011,23 +949,10 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$step_id = rgar( $item, 'workflow_step' );
 		if ( $step_id > 0 ) {
 			$step      = gravity_flow()->get_step( $step_id );
-			$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
-
-			$url_entry = esc_url( $url_entry );
+			$url_entry = esc_url( $this->get_entry_url( $item ) );
 
 			$label = $step ? esc_html( $step->get_name() ) : '';
-
-			/**
-			 * Allows the field value to be filtered in the status table.
-			 *
-			 * @since 1.7.1
-			 *
-			 * @param string $label The value to be displayed.
-			 * @param int    $item  ['form_id'] The Form ID.
-			 * @param        string 'workflow_step'.
-			 * @param array  $item  The entry array.
-			 */
-			$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'workflow_step', $item );
+			$label = $this->filter_field_value( $label, $item, 'workflow_step' );
 			$link  = "<a href='{$url_entry}'>$label</a>";
 			$output = $link;
 		} else {
@@ -1050,22 +975,10 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	 * @param array $item The current entry.
 	 */
 	public function column_date_created( $item ) {
-		$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
-		$url_entry = esc_url( $url_entry );
-		$label = GFCommon::format_date( $item['date_created'] );
-
-		/**
-		 * Allows the field value to be filtered in the status table.
-		 *
-		 * @since 1.7.1
-		 *
-		 * @param string $label The value to be displayed.
-		 * @param int    $item  ['form_id'] The Form ID.
-		 * @param        string 'date_created'.
-		 * @param array  $item  The entry array.
-		 */
-		$label = apply_filters( 'gravityflow_field_value_status_table', $label, $item['form_id'], 'date_created', $item );
-		$link  = "<a href='{$url_entry}'>$label</a>";
+		$url_entry = esc_url( $this->get_entry_url( $item ) );
+		$label     = GFCommon::format_date( $item['date_created'] );
+		$label     = $this->filter_field_value( $label, $item, 'date_created' );
+		$link      = "<a href='{$url_entry}'>$label</a>";
 		echo $link;
 	}
 
@@ -1079,25 +992,72 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		if ( ! empty( $item['workflow_timestamp'] ) ) {
 			$last_updated = date( 'Y-m-d H:i:s', $item['workflow_timestamp'] );
-			$url_entry = $this->detail_base_url . sprintf( '&id=%d&lid=%d', $item['form_id'], $item['id'] );
+			$url_entry    = esc_url( $this->get_entry_url( $item ) );
 			$last_updated = esc_html( GFCommon::format_date( $last_updated, true, 'Y/m/d' ) );
-
-			/**
-			 * Allows the field value to be filtered in the status table.
-			 *
-			 * @since 1.7.1
-			 *
-			 * @param string $label The value to be displayed.
-			 * @param int    $item  ['form_id'] The Form ID.
-			 * @param        string 'workflow_timestamp'.
-			 * @param array  $item  The entry array.
-			 */
-			$last_updated = apply_filters( 'gravityflow_field_value_status_table', $last_updated, $item['form_id'], 'workflow_timestamp', $item );
-			$url_entry = esc_url( $url_entry );
-			$label  = "<a href='{$url_entry}'>$last_updated</a>";
+			$last_updated = $this->filter_field_value( $last_updated, $item, 'workflow_timestamp' );
+			$label        = "<a href='{$url_entry}'>$last_updated</a>";
 		}
 
 		echo $label;
+	}
+
+	/**
+	 * Outputs the entry payment status.
+	 *
+	 * @since 2.2.4-dev
+	 *
+	 * @param array $item The current entry.
+	 */
+	public function column_payment_status( $item ) {
+		$url_entry      = esc_url( $this->get_entry_url( $item ) );
+		$payment_status = rgar( $item, 'payment_status' );
+		if ( gravity_flow()->is_gravityforms_supported( '2.4' ) ) {
+			$payment_status = GFCommon::get_entry_payment_status_text( $payment_status );
+		}
+
+		$label = $this->filter_field_value( $payment_status, $item, 'payment_status' );
+		$link  = "<a href='{$url_entry}'>$label</a>";
+		echo $link;
+	}
+
+	/**
+	 * Returns the entry detail URL.
+	 *
+	 * @since 2.2.4-dev
+	 *
+	 * @param array $entry The current entry.
+	 *
+	 * @return string
+	 */
+	public function get_entry_url( $entry ) {
+		return sprintf( '%s&id=%d&lid=%d', $this->detail_base_url, $entry['form_id'], $entry['id'] );
+	}
+
+	/**
+	 * Allows the field value to be filtered before being displayed in the status table.
+	 *
+	 * @since 2.2.4-dev
+	 *
+	 * @param string $value       The value to be displayed.
+	 * @param array  $entry       The current entry.
+	 * @param string $column_name The current column name.
+	 *
+	 * @return string
+	 */
+	public function filter_field_value( $value, $entry, $column_name ) {
+		$form_id = $entry['form_id'];
+
+		/**
+		 * Allows the field value to be filtered in the status table.
+		 *
+		 * @since 1.7.1
+		 *
+		 * @param string $value       The value to be displayed.
+		 * @param int    $form_id     The Form ID.
+		 * @param string $column_name The column name.
+		 * @param array  $item        The entry array.
+		 */
+		return apply_filters( 'gravityflow_field_value_status_table', $value, $form_id, $column_name, $entry );
 	}
 
 	/**


### PR DESCRIPTION
Updates the inbox and status pages to use `GFCommon::get_entry_payment_status_text()` with Gravity Forms 2.4 and greater when getting the payment status to be displayed in the column. This change adds support for custom and translatable payment statuses.

Also refactors the status page column methods to reduce duplication around getting the entry url and gravityflow_field_value_status_table filter.

## Screenshots

<img width="657" alt="inbox-page-payment-status" src="https://user-images.githubusercontent.com/1872371/44954140-bed83280-ae95-11e8-87f7-e2ca9d6533af.png">
<img width="726" alt="status-page-payment-status" src="https://user-images.githubusercontent.com/1872371/44954145-c0a1f600-ae95-11e8-8ad8-6570f32b3de9.png">

## Code snippets for testing
```
add_filter( 'gettext', function ( $translated_text, $text, $domain ) {
    if ( $domain === 'gravityforms' && $text === 'Authorized' ) {
        $translated_text = "Authy'd";
    }

    return $translated_text;
}, 10, 3 );
add_filter( 'gravityflow_inbox_args', function ( $args ) {
    $args['form_id'] = 8;
    $args['field_ids'] = array( 'payment_status' );

    return $args;
} );
add_filter( 'gravityflow_status_args', function ( $args ) {
	$args['constraint_filters'] = array(
		'form_id'    => 8,
	);
	$args['field_ids'] = array( 'payment_status' );

	return $args;
} );
```