### PR TITLE
Added filter to allow inbox columns to be adjusted

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,5 @@
 - Added "Authorized" as an available choice for the entry Payment Status property in the step condition setting.
+- Added gravityflow_columns_inbox_table to allow columns in inbox to be adjusted in similar fashion to status (gravityflow_columns_status_table)
 - Added gravityflow_date_format_current_step_merge_tag filter to allow the date/time-based modifiers for {current_step} adjust format: expiration, schedule, and start.
 - Updated the Entry Detail workflow info box display of step expiration date to use existing gravityflow_date_format_entry_detail filter.
 - Updated the step condition setting to support custom payment statuses added by the gform_payment_statuses filter with Gravity Forms 2.4 and greater.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -269,6 +269,16 @@ class Gravity_Flow_Inbox {
 			$columns['last_updated'] = __( 'Last Updated', 'gravityflow' );
 		}
 
+		/**
+		 * Allows the columns to be filtered for the inbox table.
+		 *
+		 * @since 2.2.4-dev
+		 *
+		 * @param array         $columns The columns to be filtered
+		 * @param array         $args    The array of args for this inbox table.
+		 */
+		$columns = apply_filters( 'gravityflow_columns_inbox_table', $columns, $args );
+
 		return $columns;
 	}
 


### PR DESCRIPTION
See HS#6681

This PR adds the filter gravityflow_columns_inbox_table to enable customization of columns on the inbox or shortcode display of inbox. It brings parity to the status page of the shortcode with [gravityflow_columns_status_table](https://docs.gravityflow.io/article/161-gravityflowcolumnsstatustable) filter.

An example usage to remove a default column and add a custom column would be:

```
add_filter( 'gravityflow_columns_inbox_table', 'custom_inbox_column_titles', 10, 2 );
function custom_inbox_column_titles( $columns, $args ) {
	unset( $columns['created_by'] );
	$columns['assignees'] = 'Assignee(s)';
	return $columns;
}
```

FYI - The associated filter to display a custom column value would be 
```
add_filter( 'gform_entries_field_value', 'custom_column_assignees_field_values', 10, 4 );
function custom_column_assignees_field_values( $value, $form_id, $column_name, $entry ) {
	if( $column_name == 'assignees' ) {
		//Replace with actual column data
		$value = 'Human';
	}
	return $value;
}
```
