### PR TITLE
Add support for tokens in the confirmation

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4727,7 +4727,11 @@ PRIMARY KEY  (id)
 
 			if ( $is_delayed ) {
 				$this->log_debug( __METHOD__ . '() - processing delayed for entry id ' . $entry['id'] );
-				remove_action( 'gform_after_submission', array( $this, 'after_submission' ), 9 );
+				if ( $this->is_gravityforms_supported( '2.3.3.10' ) ) {
+					remove_action( 'gform_pre_handle_confirmation', array( $this, 'after_submission' ), 9 );
+				} else {
+					remove_action( 'gform_after_submission', array( $this, 'after_submission' ), 9 );
+				}
 			} else {
 				gform_update_meta( $entry['id'], "{$this->_slug}_is_fulfilled", true );
 			}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7319,7 +7319,7 @@ AND m.meta_value='queued'";
 
 			$assignee = null;
 
-			if ( $step && ! $assignee ) {
+			if ( $step ) {
 				$current_assignees = $step->get_assignees();
 				foreach ( $current_assignees as $current_assignee ) {
 					if ( $current_assignee->is_current_user() ) {

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7300,7 +7300,7 @@ AND m.meta_value='queued'";
 		 * Target for the gform_pre_replace_merge_tags filter. Replaces the workflow_timeline and created_by merge tags.
 		 *
 		 * @since 2.2.4 Added the assignee to the merge tag if the current user is an assignee.
-		 * @since unkown
+		 * @since unknown
 		 *
 		 * @param string $text       The text which may contain merge tags to be processed.
 		 * @param array  $form       The current form.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -198,7 +198,13 @@ if ( class_exists( 'GFForms' ) ) {
 			add_action( 'gform_register_init_scripts', array( $this, 'filter_gform_register_init_scripts' ), 10, 3 );
 			add_action( 'wp_login', array( $this, 'filter_wp_login' ), 10, 2 );
 			add_action( 'gform_post_add_entry', array( $this, 'action_gform_post_add_entry' ), 10, 2 );
-			add_action( 'gform_after_submission', array( $this, 'after_submission' ), 9, 2 );
+
+			if ( $this->is_gravityforms_supported( '2.3.3.10' ) ) {
+				add_action( 'gform_pre_handle_confirmation', array( $this, 'after_submission' ), 9, 2 );
+			} else {
+				add_action( 'gform_after_submission', array( $this, 'after_submission' ), 9, 2 );
+			}
+
 			add_action( 'gform_after_update_entry', array( $this, 'filter_after_update_entry' ), 10, 2 );
 
 			$this->add_delayed_payment_support(
@@ -7306,7 +7312,21 @@ AND m.meta_value='queued'";
 			}
 
 			$step = gravity_flow()->get_current_step( $form, $entry );
-			$args = compact( 'form', 'entry', 'url_encode', 'esc_html', 'nl2br', 'format', 'step' );
+
+			$assignee = null;
+
+			if ( ! $assignee ) {
+				$current_assignees = $step->get_assignees();
+				foreach ( $current_assignees as $current_assignee ) {
+					if ( $current_assignee->is_current_user() ) {
+						$assignee = $current_assignee;
+						break;
+					}
+				}
+			}
+
+			$args = compact( 'form', 'entry', 'url_encode', 'esc_html', 'nl2br', 'format', 'step', 'assignee' );
+
 			$merge_tags = Gravity_Flow_Merge_Tags::get_all( $args );
 
 			foreach ( $merge_tags as $merge_tag ) {

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7299,6 +7299,9 @@ AND m.meta_value='queued'";
 		/**
 		 * Target for the gform_pre_replace_merge_tags filter. Replaces the workflow_timeline and created_by merge tags.
 		 *
+		 * @since 2.2.4 Added the assignee to the merge tag if the current user is an assignee.
+		 * @since unkown
+		 *
 		 * @param string $text       The text which may contain merge tags to be processed.
 		 * @param array  $form       The current form.
 		 * @param array  $entry      The current entry.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7319,7 +7319,7 @@ AND m.meta_value='queued'";
 
 			$assignee = null;
 
-			if ( ! $assignee ) {
+			if ( $step && ! $assignee ) {
 				$current_assignees = $step->get_assignees();
 				foreach ( $current_assignees as $current_assignee ) {
 					if ( $current_assignee->is_current_user() ) {

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -58,9 +58,9 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 				$options_string = isset( $match[4] ) ? $match[4] : '';
 
 				$a = $this->get_attributes( $options_string, array(
-					'page_id' => gravity_flow()->get_app_setting( 'inbox_page' ),
-					'text'    => $location == 'inbox' ? esc_html__( 'Inbox', 'gravityflow' ) : esc_html__( 'Entry', 'gravityflow' ),
-					'token'   => false,
+					'page_id'  => gravity_flow()->get_app_setting( 'inbox_page' ),
+					'text'     => $location == 'inbox' ? esc_html__( 'Inbox', 'gravityflow' ) : esc_html__( 'Entry', 'gravityflow' ),
+					'token'    => false,
 					'assignee' => '',
 				) );
 

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -61,7 +61,12 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 					'page_id' => gravity_flow()->get_app_setting( 'inbox_page' ),
 					'text'    => $location == 'inbox' ? esc_html__( 'Inbox', 'gravityflow' ) : esc_html__( 'Entry', 'gravityflow' ),
 					'token'   => false,
+					'assignee' => '',
 				) );
+
+				if ( ! empty( $a['assignee'] ) ) {
+					$this->assignee = $this->step->get_assignee( $a['assignee'] );
+				}
 
 				$token = $this->get_workflow_url_access_token( $a );
 


### PR DESCRIPTION
This PR allows tokens to be used inside the Gravity Forms confirmations by processing the workflow before the confirmation is handled. It also adds the assignee attribute to the workflow URL merge tags which takes the assignee key. This is useful for displaying email assignees a workflow link inside the confirmation. e.g. {workflow_entry_link: assignee=email_field|3}

**Testing instructions**
- This requires Gravity Forms 2.3.3.10 which contains the gform_pre_handle_confirmation action.
- Add the assignee attribute to a workflow URL merge tag in a Gravity Forms confirmation e.g. {workflow_entry_link: assignee=email_field|3}
- Ensure that the link works as expected.
- Remove the assignee attribute and submit while logged in as the assignee of the first step. The token="true" attribute must be set for non-email assignees for the token to be added. Ensure that the URL works as expected.
- Check for regression issues e.g. with the PayPal Extension