### PR TITLE
Fix RTL CSS in the entry detail page for Divi and other themes

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -9,3 +9,4 @@
 - Updated the step condition setting, inbox, and status pages to support custom payment statuses added by the gform_payment_statuses filter with Gravity Forms 2.4 and greater.
 - Fixed an issue with the Multi-User field on the entry detail pages where the ID is displayed instead of the user's name.
 - Fixed an issue with the File Upload field display the inbox shortcode page via fields attribute. The file icon/link was not displaying and generating PHP error.
+- Fixed RTL CSS in the entry detail page for Divi and other themes that set table cells to `text-align:left`.

--- a/change_log.txt
+++ b/change_log.txt
@@ -9,4 +9,4 @@
 - Updated the step condition setting, inbox, and status pages to support custom payment statuses added by the gform_payment_statuses filter with Gravity Forms 2.4 and greater.
 - Fixed an issue with the Multi-User field on the entry detail pages where the ID is displayed instead of the user's name.
 - Fixed an issue with the File Upload field display the inbox shortcode page via fields attribute. The file icon/link was not displaying and generating PHP error.
-- Fixed RTL CSS in the entry detail page for Divi and other themes that set table cells to `text-align:left`.
+- Fixed RTL CSS in the inbox and entry detail page for Divi and other themes that set table cells to `text-align:left`.

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -206,6 +206,7 @@ table#gravityflow-inbox th{
 }
 .rtl table#gravityflow-inbox th{
     border-left:0;
+    text-align: right;
 }
 table#gravityflow-inbox td {
     padding: 0;
@@ -213,6 +214,7 @@ table#gravityflow-inbox td {
 }
 .rtl table#gravityflow-inbox td {
     border-left:0;
+    text-align: right;
 }
 table#gravityflow-inbox td a {
     text-decoration:none!important;

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -16,7 +16,9 @@ table.entry-detail-view td{
 .rtl table.entry-detail-view th,
 .rtl table.entry-detail-view td{
     border-left:0;
+    text-align: right;
 }
+
 .gravityflow-no-sidebar .gravityflow-action-buttons{
     text-align:left;
 }


### PR DESCRIPTION
This PR fixes RTL CSS styles issue in Divi and other themes that force table cells to be `text-align: left;`.

See the screenshot for the result of the inbox page in a Divi theme:
![screen shot on 2018-09-14 at 14 56 39](https://user-images.githubusercontent.com/12166/45534646-69553b80-b82e-11e8-8496-b1a3c6946100.png)

See the screenshot for the result of the entry detail page in a Divi theme:
![screen shot on 2018-09-14 at 14 51 21](https://user-images.githubusercontent.com/12166/45534463-c6042680-b82d-11e8-8a88-2030132e2782.png)
