### PR TITLE
Update edd sl class

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7751,14 +7751,17 @@ AND m.meta_value='queued'";
 
 				switch ( $license_status ) {
 					case 'expired':
-						$message     .= esc_html__( 'Your Gravity Flow license has expired.', 'gravityflow' );
+						/* translators: %s is the title of the plugin */
+					$message     .= sprintf( esc_html__( 'Your %s license has expired.', 'gravityflow' ), $this->_title );
 						$add_buttons = false;
 						break;
 					case 'invalid':
-						$message .= esc_html__( 'Your Gravity Flow license is invalid.', 'gravityflow' );
+						/* translators: %s is the title of the plugin */
+					$message .= sprintf( esc_html__( 'Your %s license is invalid.', 'gravityflow' ), $this->_title );
 						break;
 					case 'deactivated':
-						$message .= esc_html__( 'Your Gravity Flow license is inactive.', 'gravityflow' );
+						/* translators: %s is the title of the plugin */
+					$message .= sprintf( esc_html__( 'Your %s license is inactive.', 'gravityflow' ), $this->_title );
 						break;
 					/** @noinspection PhpMissingBreakStatementInspection */
 					case '':
@@ -7767,7 +7770,8 @@ AND m.meta_value='queued'";
 					case 'inactive':
 					case 'site_inactive':
 					default:
-						$message .= esc_html__( 'Your Gravity Flow license has not been activated.', 'gravityflow' );
+						/* translators: %s is the title of the plugin */
+						$message .= sprintf( esc_html__( 'Your %s license has not been activated.', 'gravityflow' ), $this->_title );
 						break;
 				}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7716,14 +7716,14 @@ AND m.meta_value='queued'";
 				return;
 			}
 
-			$is_saving_license_key = isset( $_POST['_gaddon_setting_license_key'] ) && isset( $_POST[ '_gravityflow_save_settings_nonce' ] );
+			$is_saving_license_key = isset( $_POST['_gaddon_setting_license_key'] ) && isset( $_POST['_gravityflow_save_settings_nonce'] );
 
 			$license_details = false;
 
 			if ( $is_saving_license_key ) {
 				$posted_license_key = sanitize_text_field( rgpost( '_gaddon_setting_license_key' ) );
-				if ( wp_verify_nonce( $_POST[ '_gravityflow_save_settings_nonce' ], 'gravityflow_save_settings' ) ) {
-					$license_details    = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+				if ( wp_verify_nonce( $_POST['_gravityflow_save_settings_nonce'], 'gravityflow_save_settings' ) ) {
+					$license_details = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
 				}
 				if ( $license_details ) {
 					set_transient( 'gravityflow_license_details', $license_details, DAY_IN_SECONDS );
@@ -7752,16 +7752,16 @@ AND m.meta_value='queued'";
 				switch ( $license_status ) {
 					case 'expired':
 						/* translators: %s is the title of the plugin */
-					$message     .= sprintf( esc_html__( 'Your %s license has expired.', 'gravityflow' ), $this->_title );
+						$message     .= sprintf( esc_html__( 'Your %s license has expired.', 'gravityflow' ), $this->_title );
 						$add_buttons = false;
 						break;
 					case 'invalid':
 						/* translators: %s is the title of the plugin */
-					$message .= sprintf( esc_html__( 'Your %s license is invalid.', 'gravityflow' ), $this->_title );
+						$message .= sprintf( esc_html__( 'Your %s license is invalid.', 'gravityflow' ), $this->_title );
 						break;
 					case 'deactivated':
 						/* translators: %s is the title of the plugin */
-					$message .= sprintf( esc_html__( 'Your %s license is inactive.', 'gravityflow' ), $this->_title );
+						$message .= sprintf( esc_html__( 'Your %s license is inactive.', 'gravityflow' ), $this->_title );
 						break;
 					/** @noinspection PhpMissingBreakStatementInspection */
 					case '':
@@ -7788,10 +7788,10 @@ AND m.meta_value='queued'";
 				$key = 'gravityflow_license_notice_' . date( 'Y' ) . date( 'z' );
 
 				$notice = array(
-					'key' => $key,
+					'key'          => $key,
 					'capabilities' => 'gravityflow_settings',
-					'type' => 'error',
-					'text' => $message,
+					'type'         => 'error',
+					'text'         => $message,
 				);
 
 				$notices = array( $notice );

--- a/gravityflow.php
+++ b/gravityflow.php
@@ -31,7 +31,7 @@ define( 'GRAVITY_FLOW_VERSION', '2.2.4-dev' );
 
 define( 'GRAVITY_FLOW_EDD_STORE_URL', 'https://gravityflow.io' );
 
-define( 'GRAVITY_FLOW_EDD_ITEM_NAME', 'Gravity Flow' );
+define( 'GRAVITY_FLOW_EDD_ITEM_ID', 1473 );
 
 add_action( 'gform_loaded', array( 'Gravity_Flow_Bootstrap', 'load' ), 1 );
 
@@ -173,7 +173,7 @@ function gravityflow_edd_plugin_updater() {
 		new Gravity_Flow_EDD_SL_Plugin_Updater( GRAVITY_FLOW_EDD_STORE_URL, __FILE__, array(
 			'version'   => GRAVITY_FLOW_VERSION,
 			'license'   => $license_key,
-			'item_name' => GRAVITY_FLOW_EDD_ITEM_NAME,
+			'item_id' => GRAVITY_FLOW_EDD_ITEM_ID,
 			'author'    => 'Steven Henty',
 		) );
 	}

--- a/gravityflow.php
+++ b/gravityflow.php
@@ -171,10 +171,10 @@ function gravityflow_edd_plugin_updater() {
 		}
 
 		new Gravity_Flow_EDD_SL_Plugin_Updater( GRAVITY_FLOW_EDD_STORE_URL, __FILE__, array(
-			'version'   => GRAVITY_FLOW_VERSION,
-			'license'   => $license_key,
+			'version' => GRAVITY_FLOW_VERSION,
+			'license' => $license_key,
 			'item_id' => GRAVITY_FLOW_EDD_ITEM_ID,
-			'author'    => 'Steven Henty',
+			'author'  => 'Steven Henty',
 		) );
 	}
 

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Allows plugins to use their own update API.
  *
  * @author Easy Digital Downloads
- * @version 1.6.11
+ * @version 1.6.17
  */
 class Gravity_Flow_EDD_SL_Plugin_Updater {
 
@@ -18,6 +18,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 	private $version     = '';
 	private $wp_override = false;
 	private $cache_key   = '';
+
+	private $health_check_timeout = 5;
 
 	/**
 	 * Class constructor.
@@ -36,13 +38,22 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 		$this->api_url     = trailingslashit( $_api_url );
 		$this->api_data    = $_api_data;
 		$this->name        = plugin_basename( $_plugin_file );
-		$this->slug        = basename( $_plugin_file, '.php' );
+		$this->slug        = 'gravityflow-' . basename( $_plugin_file, '.php' );
 		$this->version     = $_api_data['version'];
 		$this->wp_override = isset( $_api_data['wp_override'] ) ? (bool) $_api_data['wp_override'] : false;
 		$this->beta        = ! empty( $this->api_data['beta'] ) ? true : false;
-		$this->cache_key   = md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
+		$this->cache_key   = 'edd_sl_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
 
 		$edd_plugin_data[ $this->slug ] = $this->api_data;
+
+		/**
+		 * Fires after the $edd_plugin_data is setup.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $edd_plugin_data Array of EDD SL plugin data.
+		 */
+		do_action( 'post_edd_sl_plugin_updater_setup', $edd_plugin_data );
 
 		// Set up hooks.
 		$this->init();
@@ -112,7 +123,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 			}
 
-			$_transient_data->last_checked           = current_time( 'timestamp' );
+			$_transient_data->last_checked           = time();
 			$_transient_data->checked[ $this->name ] = $this->version;
 
 		}
@@ -158,6 +169,19 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			if ( false === $version_info ) {
 				$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug, 'beta' => $this->beta ) );
 
+				// Since we disabled our filter for the transient, we aren't running our object conversion on banners, sections, or icons. Do this now:
+				if ( isset( $version_info->banners ) && ! is_array( $version_info->banners ) ) {
+					$version_info->banners = $this->convert_object_to_array( $version_info->banners );
+				}
+
+				if ( isset( $version_info->sections ) && ! is_array( $version_info->sections ) ) {
+					$version_info->sections = $this->convert_object_to_array( $version_info->sections );
+				}
+
+				if ( isset( $version_info->icons ) && ! is_array( $version_info->icons ) ) {
+					$version_info->icons = $this->convert_object_to_array( $version_info->icons );
+				}
+
 				$this->set_version_info_cache( $version_info );
 			}
 
@@ -171,7 +195,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 			}
 
-			$update_cache->last_checked = current_time( 'timestamp' );
+			$update_cache->last_checked = time();
 			$update_cache->checked[ $this->name ] = $this->version;
 
 			set_site_transient( 'update_plugins', $update_cache );
@@ -251,7 +275,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			'is_ssl' => is_ssl(),
 			'fields' => array(
 				'banners' => array(),
-				'reviews' => false
+				'reviews' => false,
+				'icons'   => array(),
 			)
 		);
 
@@ -278,25 +303,41 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
-			$new_sections = array();
-			foreach ( $_data->sections as $key => $key ) {
-				$new_sections[ $key ] = $key;
-			}
-
-			$_data->sections = $new_sections;
+			$_data->sections = $this->convert_object_to_array( $_data->sections );
 		}
 
 		// Convert banners into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->banners ) && ! is_array( $_data->banners ) ) {
-			$new_banners = array();
-			foreach ( $_data->banners as $key => $key ) {
-				$new_banners[ $key ] = $key;
-			}
+			$_data->banners = $this->convert_object_to_array( $_data->banners );
+		}
 
-			$_data->banners = $new_banners;
+		// Convert icons into an associative array, since we're getting an object, but Core expects an array.
+		if ( isset( $_data->icons ) && ! is_array( $_data->icons ) ) {
+			$_data->icons = $this->convert_object_to_array( $_data->icons );
 		}
 
 		return $_data;
+	}
+
+	/**
+	 * Convert some objects to arrays when injecting data into the update API
+	 *
+	 * Some data like sections, banners, and icons are expected to be an associative array, however due to the JSON
+	 * decoding, they are objects. This method allows us to pass in the object and return an associative array.
+	 *
+	 * @since 3.6.5
+	 *
+	 * @param stdClass $data
+	 *
+	 * @return array
+	 */
+	private function convert_object_to_array( $data ) {
+		$new_data = array();
+		foreach ( $data as $key => $value ) {
+			$new_data[ $key ] = $value;
+		}
+
+		return $new_data;
 	}
 
 	/**
@@ -307,11 +348,13 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 	 * @return object $array
 	 */
 	public function http_request_args( $args, $url ) {
-		// If it is an https request and we are performing a package download, disable ssl verification
+
+		$verify_ssl = $this->verify_ssl();
 		if ( strpos( $url, 'https://' ) !== false && strpos( $url, 'edd_action=package_download' ) ) {
-			$args['sslverify'] = false;
+			$args['sslverify'] = $verify_ssl;
 		}
 		return $args;
+
 	}
 
 	/**
@@ -327,7 +370,29 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 	 */
 	private function api_request( $_action, $_data ) {
 
-		global $wp_version;
+		global $wp_version, $edd_plugin_url_available;
+
+		// Do a quick status check on this domain if we haven't already checked it.
+		$store_hash = md5( $this->api_url );
+		if ( ! is_array( $edd_plugin_url_available ) || ! isset( $edd_plugin_url_available[ $store_hash ] ) ) {
+			$test_url_parts = parse_url( $this->api_url );
+
+			$scheme = ! empty( $test_url_parts['scheme'] ) ? $test_url_parts['scheme']     : 'http';
+			$host   = ! empty( $test_url_parts['host'] )   ? $test_url_parts['host']       : '';
+			$port   = ! empty( $test_url_parts['port'] )   ? ':' . $test_url_parts['port'] : '';
+
+			if ( empty( $host ) ) {
+				$edd_plugin_url_available[ $store_hash ] = false;
+			} else {
+				$test_url = $scheme . '://' . $host . $port;
+				$response = wp_remote_get( $test_url, array( 'timeout' => $this->health_check_timeout, 'sslverify' => true ) );
+				$edd_plugin_url_available[ $store_hash ] = is_wp_error( $response ) ? false : true;
+			}
+		}
+
+		if ( false === $edd_plugin_url_available[ $store_hash ] ) {
+			return;
+		}
 
 		$data = array_merge( $this->api_data, $_data );
 
@@ -335,7 +400,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			return;
 		}
 
-		if( $this->api_url == trailingslashit (home_url() ) ) {
+		if( $this->api_url == trailingslashit ( home_url() ) ) {
 			return false; // Don't allow a plugin to ping itself
 		}
 
@@ -351,7 +416,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			'beta'       => ! empty( $data['beta'] ),
 		);
 
-		$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+		$verify_ssl = $this->verify_ssl();
+		$request    = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$request = json_decode( wp_remote_retrieve_body( $request ) );
@@ -373,6 +439,10 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		if ( $request && isset( $request->banners ) ) {
 			$request->banners = maybe_unserialize( $request->banners );
+		}
+
+		if ( $request && isset( $request->icons ) ) {
+			$request->icons = maybe_unserialize( $request->icons );
 		}
 
 		if( ! empty( $request->sections ) ) {
@@ -421,7 +491,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				'beta'       => ! empty( $data['beta'] )
 			);
 
-			$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+			$verify_ssl = $this->verify_ssl();
+			$request    = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ) );
 
 			if ( ! is_wp_error( $request ) ) {
 				$version_info = json_decode( wp_remote_retrieve_body( $request ) );
@@ -459,11 +530,17 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		$cache = get_option( $cache_key );
 
-		if( empty( $cache['timeout'] ) || current_time( 'timestamp' ) > $cache['timeout'] ) {
+		if( empty( $cache['timeout'] ) || time() > $cache['timeout'] ) {
 			return false; // Cache is expired
 		}
 
-		return json_decode( $cache['value'] );
+		// We need to turn the icons into an array, thanks to WP Core forcing these into an object at some point.
+		$cache['value'] = json_decode( $cache['value'] );
+		if ( ! empty( $cache['value']->icons ) ) {
+			$cache['value']->icons = (array) $cache['value']->icons;
+		}
+
+		return $cache['value'];
 
 	}
 
@@ -474,12 +551,22 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 		}
 
 		$data = array(
-			'timeout' => strtotime( '+3 hours', current_time( 'timestamp' ) ),
+			'timeout' => strtotime( '+3 hours', time() ),
 			'value'   => json_encode( $value )
 		);
 
-		update_option( $cache_key, $data );
+		update_option( $cache_key, $data, 'no' );
 
+	}
+
+	/**
+	 * Returns if the SSL of the store should be verified.
+	 *
+	 * @since  1.6.13
+	 * @return bool
+	 */
+	private function verify_ssl() {
+		return (bool) apply_filters( 'edd_sl_api_request_verify_ssl', true, $this );
 	}
 
 }

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -515,8 +515,9 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		}
 
-		if( ! empty( $version_info ) && isset( $version_info->sections['changelog'] ) ) {
-			echo '<div style="background:#fff;padding:10px;">' . $version_info->sections['changelog'] . '</div>';
+
+		if( ! empty( $version_info ) && isset( $version_info->sections->changelog ) ) {
+			echo '<div style="background:#fff;padding:10px;">' . $version_info->sections->changelog . '</div>';
 		}
 
 		exit;

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -259,7 +259,6 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		$response        = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
-
 	}
 
 	/**
@@ -282,7 +281,6 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		}
 
 		$this->activate_license( $field_setting );
-
 	}
 
 	/**

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -24,9 +24,19 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	/**
 	 * The item name used by Easy Digital Downloads.
 	 *
+	 * @deprecated 2.2.4 Use $edd_item_id instead
 	 * @var string
 	 */
 	public $edd_item_name = '';
+
+	/**
+	 * The item name used by Easy Digital Downloads.
+	 *
+	 * @since 2.2.4
+	 *
+	 * @var string
+	 */
+	public $edd_item_id = '';
 
 	/**
 	 * If the extensions minimum requirements are met add the general hooks.
@@ -62,6 +72,8 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			remove_filter( 'members_get_capabilities', array( $this, 'members_get_capabilities' ) );
 			add_filter( 'gravityflow_members_capabilities', array( $this, 'get_members_capabilities' ) );
 		}
+
+		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
 	/**
@@ -114,7 +126,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		}
 		?>
 
-		<h3><span><?php echo $icon ?><?php echo $this->app_settings_title() ?></span></h3>
+		<h3><span><?php echo $icon ?> <?php echo $this->app_settings_title() ?></span></h3>
 
 		<?php
 
@@ -227,15 +239,9 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 		$license_data = $this->check_license( $value );
 
-		$valid = null;
-		if ( empty( $license_data ) || $license_data->license == 'invalid' ) {
-			$valid = false;
-		} elseif ( $license_data->license == 'valid' ) {
-			$valid = true;
-		}
+		$valid = $license_data && $license_data->license == 'valid' ? true : false;
 
 		return $valid;
-
 	}
 
 	/**
@@ -245,8 +251,12 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 *
 	 * @return array|mixed|object
 	 */
-	public function check_license( $value ) {
-		$response = gravity_flow()->perform_edd_license_request( 'check_license', $value, $this->edd_item_name );
+	public function check_license( $value = '' ) {
+		if ( empty( $value ) ) {
+			$value = $this->get_app_setting( 'license_key' );
+		}
+		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+		$response = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
 
@@ -262,7 +272,8 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		$old_license = $this->get_app_setting( 'license_key' );
 
 		if ( $old_license && $field_setting != $old_license ) {
-			$response = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $this->edd_item_name );
+			$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+			$response = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $item_name_or_id );
 			$this->log_debug( __METHOD__ . '(): response: ' . print_r( $response, 1 ) );
 		}
 
@@ -282,7 +293,8 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 * @return array|mixed|object
 	 */
 	public function activate_license( $license_key ) {
-		$response = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $this->edd_item_name );
+		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+		$response = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $item_name_or_id );
 
 		// Force plugins page to refresh the update info.
 		set_site_transient( 'update_plugins', null );
@@ -375,4 +387,111 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 		return $links;
 	}
+
+	/**
+	 * Adds the invalid license admin notice.
+	 *
+	 * @since 2.2.4
+	 */
+	public function action_admin_notices() {
+
+		$is_saving_license_key = isset( $_POST['_gaddon_setting_license_key'] ) && isset( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ] );
+
+		$transient_key = $this->get_slug() . '_license_details';
+
+		if ( $is_saving_license_key ) {
+			$posted_license_key = sanitize_text_field( rgpost( '_gaddon_setting_license_key' ) );
+			$license_details    = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+			if ( $license_details ) {
+				set_transient( $transient_key, $license_details, DAY_IN_SECONDS );
+			}
+		} else {
+			$license_details = get_transient( $transient_key );
+			if ( ! $license_details ) {
+				$license_details = $this->check_license();
+				if ( $license_details ) {
+					set_transient( $transient_key, $license_details, DAY_IN_SECONDS );
+				}
+			}
+		}
+
+		$license_status = $license_details ? $license_details->license : '';
+
+		if ( $license_status != 'valid' ) {
+
+			$add_buttons = ! is_multisite() || ( is_multisite() && is_main_site() );
+
+			$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings&view=' . $this->get_slug() );
+
+			$message = sprintf( '<img src="%s" style="vertical-align:text-bottom;margin-right:5px;"/>', GFCommon::get_base_url() . '/images/exclamation.png' );
+
+			switch ( $license_status ) {
+				case 'expired':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your license for %s has expired.', 'gravityflow' ), $this->_title );
+
+					$add_buttons = false;
+					break;
+				case 'invalid':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license is invalid.', 'gravityflow' ), $this->_title );
+					break;
+				case 'deactivated':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license is inactive.', 'gravityflow' ), $this->_title );
+					break;
+				/** @noinspection PhpMissingBreakStatementInspection */
+				case '':
+					$license_status = 'site_inactive';
+				// break intentionally left blank
+				case 'inactive':
+				case 'site_inactive':
+				default:
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license has not been activated.', 'gravityflow' ), $this->_title );
+					break;
+			}
+
+			$message .= ' ' . esc_html__( 'This means you&rsquo;re missing out on security fixes, updates and support!', 'gravityflow' );
+
+			if ( ! empty( $this->edd_item_id ) ) {
+				$url = 'https://gravityflow.io/?p=' . $this->edd_item_id . '&utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';
+			} else {
+				$url = 'https://gravityflow.io/extensions/?utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';
+			}
+
+			// Show a different notice on settings page for inactive licenses (hide the buttons)
+			if ( $add_buttons && ! $this->is_extension_settings() ) {
+				$message .= '<br /><br />' . esc_html__( '%sActivate your license%s or %sget a license here%s', 'gravityflow' );
+				$message = sprintf( $message, '<a href="' . esc_url( $primary_button_link ) . '" class="button button-primary">', '</a>', '<a href="' . esc_url( $url ) . '" class="button button-secondary">', '</a>' );
+			}
+
+			$key = $this->get_slug() . '_license_notice_' . date( 'Y' ) . date( 'z' );
+
+			$notice = array(
+				'key'          => $key,
+				'capabilities' => $this->_capabilities_app_settings,
+				'type'         => 'error',
+				'text'         => $message,
+			);
+
+			$notices = array( $notice );
+
+			GFCommon::display_dismissible_message( $notices );
+		}
+	}
+	/**
+	 * Returns TRUE if the current page is the extension settings main page.
+	 *
+	 * @since 2.2.4
+	 *
+	 * @return bool
+	 */
+	public function is_extension_settings() {
+
+		$is_extension_settings = rgget( 'page' ) == 'gravityflow_settings' && rgget( 'view' ) == $this->get_slug();
+
+		return $is_extension_settings;
+	}
+
 }

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -256,7 +256,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			$value = $this->get_app_setting( 'license_key' );
 		}
 		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
-		$response = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
+		$response        = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
 
@@ -273,7 +273,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 		if ( $old_license && $field_setting != $old_license ) {
 			$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
-			$response = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $item_name_or_id );
+			$response        = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $item_name_or_id );
 			$this->log_debug( __METHOD__ . '(): response: ' . print_r( $response, 1 ) );
 		}
 
@@ -294,7 +294,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 */
 	public function activate_license( $license_key ) {
 		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
-		$response = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $item_name_or_id );
+		$response        = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $item_name_or_id );
 
 		// Force plugins page to refresh the update info.
 		set_site_transient( 'update_plugins', null );
@@ -413,7 +413,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		if ( $is_saving_license_key ) {
 			$posted_license_key = sanitize_text_field( rgpost( '_gaddon_setting_license_key' ) );
 			if ( wp_verify_nonce( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ], $this->get_slug() . '_save_settings' ) ) {
-				$license_details    = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+				$license_details = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
 			}
 			if ( $license_details ) {
 				set_transient( $transient_key, $license_details, DAY_IN_SECONDS );

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -395,13 +395,26 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 */
 	public function action_admin_notices() {
 
+		if ( is_multisite() && ! is_main_site() ) {
+			return;
+		}
+
+		$pending_installation = ! is_multisite() && ( get_option( 'gravityflow_pending_installation' ) || isset( $_GET['gravityflow_installation_wizard'] ) );
+
+		if ( $pending_installation ) {
+			return;
+		}
+
 		$is_saving_license_key = isset( $_POST['_gaddon_setting_license_key'] ) && isset( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ] );
 
 		$transient_key = $this->get_slug() . '_license_details';
 
+		$license_details = false;
 		if ( $is_saving_license_key ) {
 			$posted_license_key = sanitize_text_field( rgpost( '_gaddon_setting_license_key' ) );
-			$license_details    = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+			if ( wp_verify_nonce( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ], $this->get_slug() . '_save_settings' ) ) {
+				$license_details    = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+			}
 			if ( $license_details ) {
 				set_transient( $transient_key, $license_details, DAY_IN_SECONDS );
 			}

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -24,9 +24,19 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	/**
 	 * The item name used by Easy Digital Downloads.
 	 *
+	 * @deprecated 2.2.4 Use $edd_item_id instead
 	 * @var string
 	 */
 	public $edd_item_name = '';
+
+	/**
+	 * The item name used by Easy Digital Downloads.
+	 *
+	 * @since 2.2.4
+	 *
+	 * @var string
+	 */
+	public $edd_item_id = '';
 
 	/**
 	 * If the extensions minimum requirements are met add the general hooks.
@@ -62,6 +72,8 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 			remove_filter( 'members_get_capabilities', array( $this, 'members_get_capabilities' ) );
 			add_filter( 'gravityflow_members_capabilities', array( $this, 'get_members_capabilities' ) );
 		}
+
+		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
 	/**
@@ -114,7 +126,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		}
 		?>
 
-		<h3><span><?php echo $icon ?><?php echo $this->app_settings_title() ?></span></h3>
+		<h3><span><?php echo $icon ?> <?php echo $this->app_settings_title() ?></span></h3>
 
 		<?php
 
@@ -245,11 +257,14 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	 *
 	 * @return array|mixed|object
 	 */
-	public function check_license( $value ) {
-		$response = gravity_flow()->perform_edd_license_request( 'check_license', $value, $this->edd_item_name );
+	public function check_license( $value = '' ) {
+		if ( empty( $value ) ) {
+			$value = $this->get_app_setting( 'license_key' );
+		}
+		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+		$response        = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
-
 	}
 
 	/**
@@ -262,17 +277,16 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		$old_license = $this->get_app_setting( 'license_key' );
 
 		if ( $old_license && $field_setting != $old_license ) {
-			// Deactivate the old site.
-			$response = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $this->edd_item_name );
+			$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+			$response        = gravity_flow()->perform_edd_license_request( 'deactivate_license', $old_license, $item_name_or_id );
+			$this->log_debug( __METHOD__ . '(): response: ' . print_r( $response, 1 ) );
 		}
-
 
 		if ( empty( $field_setting ) ) {
 			return;
 		}
 
 		$this->activate_license( $field_setting );
-
 	}
 
 	/**
@@ -283,7 +297,8 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	 * @return array|mixed|object
 	 */
 	public function activate_license( $license_key ) {
-		$response = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $this->edd_item_name );
+		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
+		$response        = gravity_flow()->perform_edd_license_request( 'activate_license', $license_key, $item_name_or_id );
 
 		// Force plugins page to refresh the update info.
 		set_site_transient( 'update_plugins', null );
@@ -374,5 +389,124 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		array_unshift( $links, '<a href="' . admin_url( 'admin.php' ) . '?page=gravityflow_settings&view=' . $this->_slug . '">' . esc_html__( 'Settings', 'gravityflow' ) . '</a>' );
 
 		return $links;
+	}
+
+	/**
+	 * Adds the invalid license admin notice.
+	 *
+	 * @since 2.2.4
+	 */
+	public function action_admin_notices() {
+
+		if ( is_multisite() && ! is_main_site() ) {
+			return;
+		}
+
+		$pending_installation = ! is_multisite() && ( get_option( 'gravityflow_pending_installation' ) || isset( $_GET['gravityflow_installation_wizard'] ) );
+
+		if ( $pending_installation ) {
+			return;
+		}
+
+		$is_saving_license_key = isset( $_POST['_gaddon_setting_license_key'] ) && isset( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ] );
+
+		$transient_key = $this->get_slug() . '_license_details';
+
+		$license_details = false;
+		if ( $is_saving_license_key ) {
+			$posted_license_key = sanitize_text_field( rgpost( '_gaddon_setting_license_key' ) );
+			if ( wp_verify_nonce( $_POST[ '_' . $this->get_slug() . '_save_settings_nonce' ], $this->get_slug() . '_save_settings' ) ) {
+				$license_details = $posted_license_key ? $this->activate_license( $posted_license_key ) : false;
+			}
+			if ( $license_details ) {
+				set_transient( $transient_key, $license_details, DAY_IN_SECONDS );
+			}
+		} else {
+			$license_details = get_transient( $transient_key );
+			if ( ! $license_details ) {
+				$license_details = $this->check_license();
+				if ( $license_details ) {
+					set_transient( $transient_key, $license_details, DAY_IN_SECONDS );
+				}
+			}
+		}
+
+		$license_status = $license_details ? $license_details->license : '';
+
+		if ( $license_status != 'valid' ) {
+
+			$add_buttons = ! is_multisite() || ( is_multisite() && is_main_site() );
+
+			$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings&view=' . $this->get_slug() );
+
+			$message = sprintf( '<img src="%s" style="vertical-align:text-bottom;margin-right:5px;"/>', GFCommon::get_base_url() . '/images/exclamation.png' );
+
+			switch ( $license_status ) {
+				case 'expired':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your license for %s has expired.', 'gravityflow' ), $this->_title );
+
+					$add_buttons = false;
+					break;
+				case 'invalid':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license is invalid.', 'gravityflow' ), $this->_title );
+					break;
+				case 'deactivated':
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license is inactive.', 'gravityflow' ), $this->_title );
+					break;
+				/** @noinspection PhpMissingBreakStatementInspection */
+				case '':
+					$license_status = 'site_inactive';
+				// break intentionally left blank
+				case 'inactive':
+				case 'site_inactive':
+				default:
+					/* translators: %s is the title of the Gravity Flow Extension */
+					$message .= sprintf( esc_html__( 'Your %s license has not been activated.', 'gravityflow' ), $this->_title );
+					break;
+			}
+
+			$message .= ' ' . esc_html__( 'This means you&rsquo;re missing out on security fixes, updates and support!', 'gravityflow' );
+
+			if ( ! empty( $this->edd_item_id ) ) {
+				$url = 'https://gravityflow.io/?p=' . $this->edd_item_id . '&utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';
+			} else {
+				$url = 'https://gravityflow.io/extensions/?utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';
+			}
+
+			// Show a different notice on settings page for inactive licenses (hide the buttons)
+			if ( $add_buttons && ! $this->is_extension_settings() ) {
+				$message .= '<br /><br />' . esc_html__( '%sActivate your license%s or %sget a license here%s', 'gravityflow' );
+				$message = sprintf( $message, '<a href="' . esc_url( $primary_button_link ) . '" class="button button-primary">', '</a>', '<a href="' . esc_url( $url ) . '" class="button button-secondary">', '</a>' );
+			}
+
+			$key = $this->get_slug() . '_license_notice_' . date( 'Y' ) . date( 'z' );
+
+			$notice = array(
+				'key'          => $key,
+				'capabilities' => $this->_capabilities_app_settings,
+				'type'         => 'error',
+				'text'         => $message,
+			);
+
+			$notices = array( $notice );
+
+			GFCommon::display_dismissible_message( $notices );
+		}
+	}
+	/**
+	 * Returns TRUE if the current page is the extension settings main page.
+	 *
+	 * @since 2.2.4
+	 *
+	 * @return bool
+	 */
+	public function is_extension_settings() {
+
+		$is_extension_settings = rgget( 'page' ) == 'gravityflow_settings' && rgget( 'view' ) == $this->get_slug();
+
+		return $is_extension_settings;
 	}
 }


### PR DESCRIPTION
This PR update the EDD SL Class to the latest version and adds some fixes. The EDD item name is now deprecated in  favour of the item ID. It also adds admin notices for invalid extension licenses, fixes admin notices on multisite and ensures that the admin notices are not displayed while the installation wizard is being displayed on single site.

**Testing instructions**
- Ensure the admin notices for Gravity Flow and extensions are only displayed on the main site.
- Ensure there are no regression issues for single site.
- Ensure the admin notices are not displayed while the installation wizard is being displayed.