### PR TITLE
Ensure merge tags can be used in webhook response mapping field keys

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Updated outgoing webhook response mapping to parse merge tags in field keys

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -913,12 +913,17 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 	 * @return array|string|WP_Error
 	 */
 	public function parse_response_value( $value, $key, $default = '' ) {
+		gravity_flow()->log_debug( __METHOD__ . '(): JO: ' . $key );
 		if ( ! is_array( $value ) && ! ( is_object( $value ) && $value instanceof ArrayAccess ) ) {
 			return $default;
 		}
 
 		/* translators: %s is the key used to lookup the value in the REST API response */
 		$error_message = sprintf( __( 'The key %s does not match any element in the response.', 'gravityflow' ), $key ) ;
+		
+		$this->log_debug( __METHOD__ . '() - key before replacing variables: ' . $key );
+		$key = GFCommon::replace_variables( $key, $this->get_form(), $this->get_entry(), true, false, false, 'text' );
+		$this->log_debug( __METHOD__ . '() - key after replacing variables: ' . $key );
 
 		if ( strpos( $key, '\\' ) === false ) {
 			return isset( $value[ $key ] ) ? $value[ $key ] : new WP_Error( 'invalid_key', $error_message );


### PR DESCRIPTION
**This PR is not yet ready for merge**
It will be complete and review ready when it includes:
- Automated test with coverage for response mapping including merge tags in key and value
- (Done) Revision to parse_response_value to support merge tags
