### PR TITLE
Trigger user input notification event after entry save instead of before

### DIFF
--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -411,7 +411,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 				}
 			}
 
-			$original_entry = $entry;
+			$original_entry = $entry = $this->refresh_entry();
 
 			$this->save_entry( $form, $entry, $editable_fields );
 
@@ -436,6 +436,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			}
 
 			$this->maybe_send_notification( $new_status );
+			GFAPI::send_notifications( $form, $entry, 'workflow_user_input' );
 		}
 
 		return $feedback;
@@ -567,9 +568,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 
 		$status = $this->evaluate_status();
 		$this->update_step_status( $status );
-		$entry = $this->refresh_entry();
-
-		GFAPI::send_notifications( $form, $entry, 'workflow_user_input' );
 
 		return $feedback;
 	}


### PR DESCRIPTION
re: [HS#6863](https://secure.helpscout.net/conversation/673021181/6863?folderId=1113495)

Fixes an issue where the "Workflow: user input" notification event is triggered before the entry has been updated which results in stale data being used when notification routing/conditional logic is evaluated and when merge tags in the notification settings are processed.