### PR TITLE
Trigger the workflow on gform_entry_pre_handle_confirmation

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -199,7 +199,9 @@ if ( class_exists( 'GFForms' ) ) {
 			add_action( 'wp_login', array( $this, 'filter_wp_login' ), 10, 2 );
 			add_action( 'gform_post_add_entry', array( $this, 'action_gform_post_add_entry' ), 10, 2 );
 
-			if ( $this->is_gravityforms_supported( '2.3.3.10' ) ) {
+			if ( $this->is_gravityforms_supported( '2.3.4.2' ) ) {
+				add_filter( 'gform_entry_pre_handle_confirmation', array( $this, 'after_submission' ), 9, 2 );
+			} elseif ( $this->is_gravityforms_supported( '2.3.3.10' ) ) {
 				add_action( 'gform_pre_handle_confirmation', array( $this, 'after_submission' ), 9, 2 );
 			} else {
 				add_action( 'gform_after_submission', array( $this, 'after_submission' ), 9, 2 );
@@ -4770,15 +4772,21 @@ PRIMARY KEY  (id)
 		 *
 		 * @param array $entry The current entry.
 		 * @param array $form  The current form.
+		 *
+		 * @return array|WP_Error
 		 */
 		public function after_submission( $entry, $form ) {
 			if ( ! isset( $entry['id'] ) || $entry['status'] === 'spam' ) {
-				return;
+				return $entry;
 			}
+
 			if ( isset( $entry['workflow_step'] ) ) {
 				$entry_id = absint( $entry['id'] );
 				$this->process_workflow( $form, $entry_id );
+				$entry = GFAPI::get_entry( $entry_id );
 			}
+
+			return $entry;
 		}
 
 		/**


### PR DESCRIPTION
This PR triggers the workflow using the gform_entry_pre_handle_confirmation filter added in Gravity Forms 2.3.4.2 so the merge tags and confirmation can use the updated entry.
Fixes [HS#6851](https://secure.helpscout.net/conversation/671087176/6851?folderId=516732)

**Testing instructions**
- Create a form with an email field and two text fields.
- Add a webhook step to update one of the text fields e.g. the translation example
- Add a Form Submission step with a condition based on the value in a field changed by the webhook
- Add another Form Submission step without a condition as a catchall
- Set the confirmation redirect to `{workflow_form_submission_url: assignee=email_field|3}` where 3 is the ID of the email field.
- Submit the form while logged out to ensure the email toke is working correctly.
- Ensure that the redirect is correct depending on the value in the changed field.
