### PR TITLE
Add the step merge tag attribute

### DIFF
--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -200,6 +200,17 @@ class Gravity_Flow_Assignee {
 	}
 
 	/**
+	 * Return the step for this assignee.
+	 *
+	 * @since 2.3.2
+	 *
+	 * @return Gravity_Flow_Step|bool
+	 */
+	public function get_step() {
+		return $this->step;
+	}
+
+	/**
 	 * Return the editable field IDs for this assignee.
 	 *
 	 * @return array

--- a/includes/merge-tags/class-merge-tag-assignee-base.php
+++ b/includes/merge-tags/class-merge-tag-assignee-base.php
@@ -23,31 +23,49 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 	/**
 	 * Returns the inbox URL.
 	 *
-	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string   $access_token The access token for the current assignee.
+	 * @since 2.3.2 Added $assignee arg.
+	 * @since 2.1.2
+	 *
+	 * @param int|null              $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string                $access_token The access token for the current assignee.
+	 * @param Gravity_Flow_Assignee $assignee     The assignee for the URL.
 	 *
 	 * @return string
 	 */
-	public function get_inbox_url( $page_id = null, $access_token = '' ) {
+	public function get_inbox_url( $page_id = null, $access_token = '', $assignee = null ) {
+
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
 
 		$query_args = array(
 			'page' => 'gravityflow-inbox',
 		);
 
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $assignee, $access_token );
 	}
 
 	/**
 	 * Returns the entry URL.
 	 *
-	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string   $access_token The access token for the current assignee.
+	 * @since 2.3.2 Added $assignee arg.
+	 * @since 2.1.2
+	 *
+	 * @param int|null              $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string                $access_token The access token for the current assignee.
+	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return string
 	 */
-	public function get_entry_url( $page_id = null, $access_token = '' ) {
+	public function get_entry_url( $page_id = null, $access_token = '', $assignee = null ) {
 
-		$form_id = $this->step ? $this->step->get_form_id() : false;
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
+
+		$step = $assignee ? $assignee->get_step() : $this->step;
+
+		$form_id = $step ? $step->get_form_id() : false;
 		if ( empty( $form_id ) && ! empty( $this->form ) ) {
 			$form_id = $this->form['id'];
 		}
@@ -56,7 +74,7 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 			return false;
 		}
 
-		$entry_id = $this->step ? $this->step->get_entry_id() : false;
+		$entry_id = $step ? $this->step->get_entry_id() : false;
 		if ( empty( $entry_id ) && ! empty( $this->entry ) ) {
 			$entry_id = $this->entry['id'];
 		}
@@ -72,35 +90,51 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 			'lid'  => $entry_id,
 		);
 
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $assignee, $access_token );
 	}
 
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
+	 * @since 2.3.2 Added $assignee arg.
+	 * @since 2.1.2
+	 *
+	 * @param Gravity_Flow_Assignee $assignee
+	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days() {
-		return apply_filters( 'gravityflow_entry_token_expiration_days', 30, $this->assignee );
+	protected function get_token_expiration_days( $assignee = null ) {
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
+		return apply_filters( 'gravityflow_entry_token_expiration_days', 30, $assignee );
 	}
 
 	/**
 	 * Get the scopes to be used when generating the access token.
 	 *
-	 * @param string $action The access token action.
+	 * @since 2.3.2 Added $assignee arg.
+	 * @since 2.1.2
+	 *
+	 * @param string                $action The access token action.
+	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return array
 	 */
-	protected function get_token_scopes( $action = '' ) {
+	protected function get_token_scopes( $action = '', $assignee = null ) {
 		if ( empty( $action ) ) {
 			return array();
 		}
 
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
+
 		return array(
 			'pages'           => array( 'inbox' ),
-			'step_id'         => $this->step->get_id(),
-			'entry_timestamp' => $this->step->get_entry_timestamp(),
-			'entry_id'        => $this->step->get_entry_id(),
+			'step_id'         => $assignee->get_step()->get_id(),
+			'entry_timestamp' => $assignee->get_step()->get_entry_timestamp(),
+			'entry_id'        => $assignee->get_step()->get_entry_id(),
 			'action'          => $action,
 		);
 	}
@@ -108,14 +142,21 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 	/**
 	 * Get the token for the current assignee and step.
 	 *
-	 * @param string $action The access token action.
+	 * @since 2.3.2 Added $assignee arg.
+	 * @since 2.1.2
+	 *
+	 * @param string                $action The access token action.
+	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return string
 	 */
-	protected function get_token( $action = '' ) {
-		$scopes               = $this->get_token_scopes( $action );
-		$expiration_timestamp = strtotime( '+' . (int) $this->get_token_expiration_days() . ' days' );
+	protected function get_token( $action = '', $assignee = null ) {
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
+		$scopes               = $this->get_token_scopes( $action, $assignee );
+		$expiration_timestamp = strtotime( '+' . (int) $this->get_token_expiration_days( $assignee ) . ' days' );
 
-		return gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
+		return gravity_flow()->generate_access_token( $assignee, $scopes, $expiration_timestamp );
 	}
 }

--- a/includes/merge-tags/class-merge-tag-assignee-base.php
+++ b/includes/merge-tags/class-merge-tag-assignee-base.php
@@ -23,49 +23,31 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 	/**
 	 * Returns the inbox URL.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
-	 * @since 2.1.2
-	 *
-	 * @param int|null              $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string                $access_token The access token for the current assignee.
-	 * @param Gravity_Flow_Assignee $assignee     The assignee for the URL.
+	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string   $access_token The access token for the current assignee.
 	 *
 	 * @return string
 	 */
-	public function get_inbox_url( $page_id = null, $access_token = '', $assignee = null ) {
-
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
+	public function get_inbox_url( $page_id = null, $access_token = '' ) {
 
 		$query_args = array(
 			'page' => 'gravityflow-inbox',
 		);
 
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $assignee, $access_token );
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
 	}
 
 	/**
 	 * Returns the entry URL.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
-	 * @since 2.1.2
-	 *
-	 * @param int|null              $page_id      The ID of the WordPress Page where the shortcode is located.
-	 * @param string                $access_token The access token for the current assignee.
-	 * @param Gravity_Flow_Assignee $assignee
+	 * @param int|null $page_id      The ID of the WordPress Page where the shortcode is located.
+	 * @param string   $access_token The access token for the current assignee.
 	 *
 	 * @return string
 	 */
-	public function get_entry_url( $page_id = null, $access_token = '', $assignee = null ) {
+	public function get_entry_url( $page_id = null, $access_token = '' ) {
 
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
-
-		$step = $assignee ? $assignee->get_step() : $this->step;
-
-		$form_id = $step ? $step->get_form_id() : false;
+		$form_id = $this->step ? $this->step->get_form_id() : false;
 		if ( empty( $form_id ) && ! empty( $this->form ) ) {
 			$form_id = $this->form['id'];
 		}
@@ -74,7 +56,7 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 			return false;
 		}
 
-		$entry_id = $step ? $this->step->get_entry_id() : false;
+		$entry_id = $this->step ? $this->step->get_entry_id() : false;
 		if ( empty( $entry_id ) && ! empty( $this->entry ) ) {
 			$entry_id = $this->entry['id'];
 		}
@@ -90,51 +72,34 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 			'lid'  => $entry_id,
 		);
 
-		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $assignee, $access_token );
+		return Gravity_Flow_Common::get_workflow_url( $query_args, $page_id, $this->assignee, $access_token );
 	}
 
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
-	 * @since 2.1.2
-	 *
-	 * @param Gravity_Flow_Assignee $assignee
-	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days( $assignee = null ) {
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
-		return apply_filters( 'gravityflow_entry_token_expiration_days', 30, $assignee );
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_entry_token_expiration_days', 30, $this->assignee );
 	}
 
 	/**
 	 * Get the scopes to be used when generating the access token.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
-	 * @since 2.1.2
-	 *
-	 * @param string                $action The access token action.
-	 * @param Gravity_Flow_Assignee $assignee
+	 * @param string $action The access token action.
 	 *
 	 * @return array
 	 */
-	protected function get_token_scopes( $action = '', $assignee = null ) {
+	protected function get_token_scopes( $action = '' ) {
 		if ( empty( $action ) ) {
 			return array();
 		}
-
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
-
 		return array(
 			'pages'           => array( 'inbox' ),
-			'step_id'         => $assignee->get_step()->get_id(),
-			'entry_timestamp' => $assignee->get_step()->get_entry_timestamp(),
-			'entry_id'        => $assignee->get_step()->get_entry_id(),
+			'step_id'         => $this->step->get_id(),
+			'entry_timestamp' => $this->step->get_entry_timestamp(),
+			'entry_id'        => $this->step->get_entry_id(),
 			'action'          => $action,
 		);
 	}
@@ -142,21 +107,13 @@ abstract class Gravity_Flow_Merge_Tag_Assignee_Base extends Gravity_Flow_Merge_T
 	/**
 	 * Get the token for the current assignee and step.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
-	 * @since 2.1.2
-	 *
-	 * @param string                $action The access token action.
-	 * @param Gravity_Flow_Assignee $assignee
+	 * @param string $action The access token action.
 	 *
 	 * @return string
 	 */
-	protected function get_token( $action = '', $assignee = null ) {
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
-		$scopes               = $this->get_token_scopes( $action, $assignee );
-		$expiration_timestamp = strtotime( '+' . (int) $this->get_token_expiration_days( $assignee ) . ' days' );
-
-		return gravity_flow()->generate_access_token( $assignee, $scopes, $expiration_timestamp );
+	protected function get_token( $action = '' ) {
+		$scopes               = $this->get_token_scopes( $action );
+		$expiration_timestamp = strtotime( '+' . (int) $this->get_token_expiration_days() . ' days' );
+		return gravity_flow()->generate_access_token( $this->assignee, $scopes, $expiration_timestamp );
 	}
 }

--- a/includes/merge-tags/class-merge-tag-workflow-approve-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve-token.php
@@ -73,20 +73,12 @@ class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Assign
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
 	 * @since 2.1.2-dev
-	 *
-	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days( $assignee = null ) {
-
-		if ( empty( $assignee ) ) {
-			$assignee = $this->assignee;
-		}
-
-		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $assignee );
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
 	}
 }
 

--- a/includes/merge-tags/class-merge-tag-workflow-approve-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve-token.php
@@ -73,12 +73,20 @@ class Gravity_Flow_Merge_Tag_Approve_Token extends Gravity_Flow_Merge_Tag_Assign
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
+	 * @since 2.3.2 Added $assignee arg.
 	 * @since 2.1.2-dev
+	 *
+	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days() {
-		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
+	protected function get_token_expiration_days( $assignee = null ) {
+
+		if ( empty( $assignee ) ) {
+			$assignee = $this->assignee;
+		}
+
+		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $assignee );
 	}
 }
 

--- a/includes/merge-tags/class-merge-tag-workflow-approve.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve.php
@@ -49,7 +49,7 @@ class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Assignee_Bas
 
 		$matches = $this->get_matches( $text );
 
-		if ( is_array( $matches ) ) {
+		if ( ! empty( $matches ) ) {
 			foreach ( $matches as $match ) {
 				$full_tag       = $match[0];
 				$type           = $match[1];

--- a/includes/merge-tags/class-merge-tag-workflow-approve.php
+++ b/includes/merge-tags/class-merge-tag-workflow-approve.php
@@ -63,23 +63,33 @@ class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Assignee_Bas
 					'step'     => '',
 				) );
 
-				$step = empty( $a['step'] ) ? $this->step : gravity_flow()->get_step( $a['step'], $this->entry );
+				$original_step = $this->step;
 
-				if ( empty( $step ) ) {
-					$text = str_replace( $full_tag, '', $text );
+				if ( ! empty( $a['step'] ) ) {
+					$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
+				}
+
+				if ( empty( $this->step ) ) {
+					$text       = str_replace( $full_tag, '', $text );
+					$this->step = $original_step;
 					continue;
 				}
 
-				$assignee = empty( $a['assignee'] ) ? $this->assignee : $step->get_assignee( $a['assignee'] );
+				$original_assignee = $this->assignee;
 
-				if ( empty( $assignee ) ) {
-					$text = str_replace( $full_tag, '', $text );
+				if ( ! empty( $a['assignee'] ) ) {
+					$this->assignee = $this->step->get_assignee( $a['assignee'] );
+				}
+
+				if ( empty( $this->assignee ) ) {
+					$text           = str_replace( $full_tag, '', $text );
+					$this->assignee = $original_assignee;
 					continue;
 				}
 
-				$approve_token = $this->get_token( 'approve', $assignee );
+				$approve_token = $this->get_token( 'approve' );
 
-				$approve_url = $this->get_entry_url( $a['page_id'], $approve_token, $assignee );
+				$approve_url = $this->get_entry_url( $a['page_id'], $approve_token );
 				$approve_url = esc_url_raw( $approve_url );
 
 				$approve_url = $this->format_value( $approve_url );
@@ -89,6 +99,10 @@ class Gravity_Flow_Merge_Tag_Approve extends Gravity_Flow_Merge_Tag_Assignee_Bas
 				}
 
 				$text = str_replace( $full_tag, $approve_url, $text );
+
+				$this->step = $original_step;
+
+				$this->assignee = $original_assignee;
 			}
 		}
 

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -59,6 +59,8 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 				return $text;
 			}
 
+			$cancel_token = $this->get_token( 'cancel_workflow' );
+
 			foreach ( $matches as $match ) {
 				$full_tag       = $match[0];
 				$type           = $match[1];
@@ -71,16 +73,13 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 					'assignee' => '',
 				) );
 
-				$assignee = empty( $a['assignee'] ) ? $this->assignee : $this->step->get_assignee( $a['assignee'] );
+				$original_assignee = $this->assignee;
 
-				if ( empty( $assignee ) ) {
-					$text = str_replace( $full_tag, '', $text );
-					continue;
+				if ( ! empty( $a['assignee'] ) ) {
+					$this->assignee = $this->step->get_assignee( $a['assignee'] );
 				}
 
-				$cancel_token = $this->get_token( 'cancel_workflow', $assignee );
-
-				$url = $this->get_entry_url( $a['page_id'], $cancel_token, $assignee );
+				$url = $this->get_entry_url( $a['page_id'], $cancel_token );
 
 				$url = $this->format_value( $url );
 
@@ -89,6 +88,8 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 				}
 
 				$text = str_replace( $full_tag, $url, $text );
+
+				$this->assignee = $original_assignee;
 			}
 		}
 
@@ -98,33 +99,28 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
-	 * @since 2.3.2 Added the $assignee arg.
 	 * @since 2.1.2-dev
-	 *
-	 * @param Gravity_Flow_Assignee $assignee
 	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days( $assignee = null ) {
-		return apply_filters( 'gravityflow_cancel_token_expiration_days', 2, $assignee );
+	protected function get_token_expiration_days() {
+		return apply_filters( 'gravityflow_cancel_token_expiration_days', 2, $this->assignee );
 	}
 
 	/**
 	 * Get the scopes to be used when generating the access token.
 	 *
-	 * @since 2.3.2 Added $assignee arg.
 	 * @since 2.1.2-dev
 	 *
-	 * @param string                $action The access token action.
-	 * @param Gravity_Flow_Assignee $assignee
+	 * @param string $action The access token action.
 	 *
 	 * @return array
 	 */
-	protected function get_token_scopes( $action = '', $assignee = null ) {
+	protected function get_token_scopes( $action = '' ) {
 		return array(
-			'pages'    => array( 'inbox' ),
-			'entry_id' => $this->step->get_entry_id(),
-			'action'   => $action,
+			'pages'           => array( 'inbox' ),
+			'entry_id'        => $this->step->get_entry_id(),
+			'action'          => $action,
 		);
 	}
 }

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -59,8 +59,6 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 				return $text;
 			}
 
-			$cancel_token = $this->get_token( 'cancel_workflow' );
-
 			foreach ( $matches as $match ) {
 				$full_tag       = $match[0];
 				$type           = $match[1];
@@ -78,6 +76,8 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 				if ( ! empty( $a['assignee'] ) ) {
 					$this->assignee = $this->step->get_assignee( $a['assignee'] );
 				}
+
+				$cancel_token = $this->assignee ? $this->get_token( 'cancel_workflow' ) : '';
 
 				$url = $this->get_entry_url( $a['page_id'], $cancel_token );
 

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -50,26 +50,30 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 		$matches = $this->get_matches( $text );
 
 		if ( ! empty( $matches ) ) {
-
-			if ( empty( $this->step ) ) {
-				foreach ( $matches as $match ) {
-					$full_tag = $match[0];
-					$text = str_replace( $full_tag, '', $text );
-				}
-				return $text;
-			}
-
 			foreach ( $matches as $match ) {
 				$full_tag       = $match[0];
 				$type           = $match[1];
 				$options_string = isset( $match[3] ) ? $match[3] : '';
 
 				$a = $this->get_attributes( $options_string, array(
-					'page_id' => gravity_flow()->get_app_setting( 'inbox_page' ),
-					'text'    => esc_html__( 'Cancel Workflow', 'gravityflow' ),
+					'page_id'  => gravity_flow()->get_app_setting( 'inbox_page' ),
+					'text'     => esc_html__( 'Cancel Workflow', 'gravityflow' ),
 					'token'    => false,
 					'assignee' => '',
+					'step'     => '',
 				) );
+
+				$original_step = $this->step;
+
+				if ( ! empty( $a['step'] ) ) {
+					$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
+				}
+
+				if ( empty( $this->step ) ) {
+					$text       = str_replace( $full_tag, '', $text );
+					$this->step = $original_step;
+					continue;
+				}
 
 				$original_assignee = $this->assignee;
 

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -77,7 +77,13 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 					$this->assignee = $this->step->get_assignee( $a['assignee'] );
 				}
 
-				$cancel_token = $this->assignee ? $this->get_token( 'cancel_workflow' ) : '';
+				if ( empty( $this->assignee ) ) {
+					$text           = str_replace( $full_tag, '', $text );
+					$this->assignee = $original_assignee;
+					continue;
+				}
+
+				$cancel_token = $this->get_token( 'cancel_workflow' );
 
 				$url = $this->get_entry_url( $a['page_id'], $cancel_token );
 

--- a/includes/merge-tags/class-merge-tag-workflow-cancel.php
+++ b/includes/merge-tags/class-merge-tag-workflow-cancel.php
@@ -99,6 +99,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Cancel extends Gravity_Flow_Merge_Tag_Assi
 
 				$text = str_replace( $full_tag, $url, $text );
 
+				$this->step     = $original_step;
 				$this->assignee = $original_assignee;
 			}
 		}

--- a/includes/merge-tags/class-merge-tag-workflow-reject-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject-token.php
@@ -70,7 +70,14 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Ta
 		return $text;
 	}
 
-	protected function get_token_expiration_days() {
+	/**
+	 * Get the number of days the token will remain valid for.
+	 *
+	 * @param Gravity_Flow_Assignee $assignee
+	 *
+	 * @return int
+	 */
+	protected function get_token_expiration_days( $assignee = null ) {
 		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
 	}
 

--- a/includes/merge-tags/class-merge-tag-workflow-reject-token.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject-token.php
@@ -73,11 +73,9 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject_Token extends Gravity_Flow_Merge_Ta
 	/**
 	 * Get the number of days the token will remain valid for.
 	 *
-	 * @param Gravity_Flow_Assignee $assignee
-	 *
 	 * @return int
 	 */
-	protected function get_token_expiration_days( $assignee = null ) {
+	protected function get_token_expiration_days() {
 		return apply_filters( 'gravityflow_approval_token_expiration_days', 2, $this->assignee );
 	}
 

--- a/includes/merge-tags/class-merge-tag-workflow-reject.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject.php
@@ -50,70 +50,59 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 		$matches = $this->get_matches( $text );
 
 		if ( ! empty( $matches ) ) {
+			foreach ( $matches as $match ) {
+				$full_tag       = $match[0];
+				$type           = $match[1];
+				$options_string = isset( $match[3] ) ? $match[3] : '';
 
-			if ( empty( $this->step ) ) {
-				foreach ( $matches as $match ) {
-					$full_tag = $match[0];
-					$text     = str_replace( $full_tag, '', $text );
+				$a = $this->get_attributes( $options_string, array(
+					'page_id'  => gravity_flow()->get_app_setting( 'inbox_page' ),
+					'text'     => esc_html__( 'Reject', 'gravityflow' ),
+					'token'    => false,
+					'assignee' => '',
+					'step'     => '',
+				) );
+
+				$original_step = $this->step;
+
+				if ( ! empty( $a['step'] ) ) {
+					$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
 				}
 
-				return $text;
-			}
-
-			if ( is_array( $matches ) ) {
-				foreach ( $matches as $match ) {
-					$full_tag       = $match[0];
-					$type           = $match[1];
-					$options_string = isset( $match[3] ) ? $match[3] : '';
-
-					$a = $this->get_attributes( $options_string, array(
-						'page_id'  => gravity_flow()->get_app_setting( 'inbox_page' ),
-						'text'     => esc_html__( 'Reject', 'gravityflow' ),
-						'token'    => false,
-						'assignee' => '',
-					) );
-
-					$original_step = $this->step;
-
-					if ( ! empty( $a['step'] ) ) {
-						$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
-					}
-
-					if ( empty( $this->step ) ) {
-						$text       = str_replace( $full_tag, '', $text );
-						$this->step = $original_step;
-						continue;
-					}
-
-					$original_assignee = $this->assignee;
-
-					if ( ! empty( $a['assignee'] ) ) {
-						$this->assignee = $this->step->get_assignee( $a['assignee'] );
-					}
-
-					if ( empty( $this->assignee ) ) {
-						$text           = str_replace( $full_tag, '', $text );
-						$this->assignee = $original_assignee;
-						continue;
-					}
-
-					$reject_token = $this->get_token( 'reject' );
-
-					$url = $this->get_entry_url( $a['page_id'], $reject_token );
-					$url = esc_url_raw( $url );
-
-					$url = $this->format_value( $url );
-
-					if ( $type == 'link' ) {
-						$url = sprintf( '<a href="%s">%s</a>', $url, $a['text'] );
-					}
-
-					$text = str_replace( $full_tag, $url, $text );
-
+				if ( empty( $this->step ) ) {
+					$text       = str_replace( $full_tag, '', $text );
 					$this->step = $original_step;
-
-					$this->assignee = $original_assignee;
+					continue;
 				}
+
+				$original_assignee = $this->assignee;
+
+				if ( ! empty( $a['assignee'] ) ) {
+					$this->assignee = $this->step->get_assignee( $a['assignee'] );
+				}
+
+				if ( empty( $this->assignee ) ) {
+					$text           = str_replace( $full_tag, '', $text );
+					$this->assignee = $original_assignee;
+					continue;
+				}
+
+				$reject_token = $this->get_token( 'reject' );
+
+				$url = $this->get_entry_url( $a['page_id'], $reject_token );
+				$url = esc_url_raw( $url );
+
+				$url = $this->format_value( $url );
+
+				if ( $type == 'link' ) {
+					$url = sprintf( '<a href="%s">%s</a>', $url, $a['text'] );
+				}
+
+				$text = str_replace( $full_tag, $url, $text );
+
+				$this->step = $original_step;
+
+				$this->assignee = $original_assignee;
 			}
 		}
 

--- a/includes/merge-tags/class-merge-tag-workflow-reject.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject.php
@@ -54,8 +54,9 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 			if ( empty( $this->step ) ) {
 				foreach ( $matches as $match ) {
 					$full_tag = $match[0];
-					$text = str_replace( $full_tag, '', $text );
+					$text     = str_replace( $full_tag, '', $text );
 				}
+
 				return $text;
 			}
 
@@ -66,29 +67,39 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 					$options_string = isset( $match[3] ) ? $match[3] : '';
 
 					$a = $this->get_attributes( $options_string, array(
-						'page_id' => gravity_flow()->get_app_setting( 'inbox_page' ),
-						'text'    => esc_html__( 'Reject', 'gravityflow' ),
+						'page_id'  => gravity_flow()->get_app_setting( 'inbox_page' ),
+						'text'     => esc_html__( 'Reject', 'gravityflow' ),
 						'token'    => false,
 						'assignee' => '',
 					) );
 
-					$step = empty( $a['step'] ) ? $this->step : gravity_flow()->get_step( $a['step'], $this->entry );
+					$original_step = $this->step;
 
-					if ( empty( $step ) ) {
-						$text = str_replace( $full_tag, '', $text );
+					if ( ! empty( $a['step'] ) ) {
+						$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
+					}
+
+					if ( empty( $this->step ) ) {
+						$text       = str_replace( $full_tag, '', $text );
+						$this->step = $original_step;
 						continue;
 					}
 
-					$assignee = empty( $a['assignee'] ) ? $this->assignee : $step->get_assignee( $a['assignee'] );
+					$original_assignee = $this->assignee;
 
-					if ( empty( $assignee ) ) {
-						$text = str_replace( $full_tag, '', $text );
+					if ( ! empty( $a['assignee'] ) ) {
+						$this->assignee = $this->step->get_assignee( $a['assignee'] );
+					}
+
+					if ( empty( $this->assignee ) ) {
+						$text           = str_replace( $full_tag, '', $text );
+						$this->assignee = $original_assignee;
 						continue;
 					}
 
-					$reject_token = $this->get_token( 'reject', $assignee );
+					$reject_token = $this->get_token( 'reject' );
 
-					$url = $this->get_entry_url( $a['page_id'], $reject_token, $assignee );
+					$url = $this->get_entry_url( $a['page_id'], $reject_token );
 					$url = esc_url_raw( $url );
 
 					$url = $this->format_value( $url );
@@ -98,6 +109,10 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 					}
 
 					$text = str_replace( $full_tag, $url, $text );
+
+					$this->step = $original_step;
+
+					$this->assignee = $original_assignee;
 				}
 			}
 		}

--- a/includes/merge-tags/class-merge-tag-workflow-reject.php
+++ b/includes/merge-tags/class-merge-tag-workflow-reject.php
@@ -51,15 +51,13 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 
 		if ( ! empty( $matches ) ) {
 
-			if ( empty( $this->step ) || empty( $this->assignee ) ) {
+			if ( empty( $this->step ) ) {
 				foreach ( $matches as $match ) {
 					$full_tag = $match[0];
 					$text = str_replace( $full_tag, '', $text );
 				}
 				return $text;
 			}
-
-			$reject_token = $this->get_token( 'reject' );
 
 			if ( is_array( $matches ) ) {
 				foreach ( $matches as $match ) {
@@ -70,9 +68,27 @@ class Gravity_Flow_Merge_Tag_Workflow_Reject extends Gravity_Flow_Merge_Tag_Assi
 					$a = $this->get_attributes( $options_string, array(
 						'page_id' => gravity_flow()->get_app_setting( 'inbox_page' ),
 						'text'    => esc_html__( 'Reject', 'gravityflow' ),
+						'token'    => false,
+						'assignee' => '',
 					) );
 
-					$url = $this->get_entry_url( $a['page_id'], $reject_token );
+					$step = empty( $a['step'] ) ? $this->step : gravity_flow()->get_step( $a['step'], $this->entry );
+
+					if ( empty( $step ) ) {
+						$text = str_replace( $full_tag, '', $text );
+						continue;
+					}
+
+					$assignee = empty( $a['assignee'] ) ? $this->assignee : $step->get_assignee( $a['assignee'] );
+
+					if ( empty( $assignee ) ) {
+						$text = str_replace( $full_tag, '', $text );
+						continue;
+					}
+
+					$reject_token = $this->get_token( 'reject', $assignee );
+
+					$url = $this->get_entry_url( $a['page_id'], $reject_token, $assignee );
 					$url = esc_url_raw( $url );
 
 					$url = $this->format_value( $url );

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -62,11 +62,18 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 					'text'     => $location == 'inbox' ? esc_html__( 'Inbox', 'gravityflow' ) : esc_html__( 'Entry', 'gravityflow' ),
 					'token'    => false,
 					'assignee' => '',
+					'step'     => '',
 				) );
+
+				$original_step = $this->step;
+
+				if ( ! empty( $a['step'] ) ) {
+					$this->step = gravity_flow()->get_step( $a['step'], $this->entry );
+				}
 
 				$original_assignee = $this->assignee;
 
-				if ( ! empty( $a['assignee'] ) ) {
+				if ( ! empty( $this->step ) && ! empty( $a['assignee'] ) ) {
 					$this->assignee = $this->step->get_assignee( $a['assignee'] );
 				}
 
@@ -85,6 +92,8 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 				}
 
 				$text = str_replace( $full_tag, $url, $text );
+
+				$this->step = $original_step;
 
 				$this->assignee = $original_assignee;
 			}

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -64,16 +64,19 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 					'assignee' => '',
 				) );
 
-				if ( ! empty( $a['assignee'] ) ) {
-					$this->assignee = $this->step->get_assignee( $a['assignee'] );
+				$assignee = empty( $a['assignee'] ) ? $this->assignee : $this->step->get_assignee( $a['assignee'] );
+
+				if ( empty( $assignee ) ) {
+					$text = str_replace( $full_tag, '', $text );
+					continue;
 				}
 
-				$token = $this->get_workflow_url_access_token( $a );
+				$token = $this->get_workflow_url_access_token( $a, $assignee );
 
 				if ( $location == 'inbox' ) {
-					$url = $this->get_inbox_url( $a['page_id'], $token );
+					$url = $this->get_inbox_url( $a['page_id'], $token, $assignee );
 				} else {
-					$url = $this->get_entry_url( $a['page_id'], $token );
+					$url = $this->get_entry_url( $a['page_id'], $token, $assignee );
 				}
 
 				$url = $this->format_value( $url );
@@ -96,7 +99,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 	 *
 	 * @return string
 	 */
-	private function get_workflow_url_access_token( $a ) {
+	private function get_workflow_url_access_token( $a, $assignee = null ) {
 		$force_token = $a['token'];
 		$token       = '';
 

--- a/includes/merge-tags/class-merge-tag-workflow-url.php
+++ b/includes/merge-tags/class-merge-tag-workflow-url.php
@@ -64,19 +64,18 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 					'assignee' => '',
 				) );
 
-				$assignee = empty( $a['assignee'] ) ? $this->assignee : $this->step->get_assignee( $a['assignee'] );
+				$original_assignee = $this->assignee;
 
-				if ( empty( $assignee ) ) {
-					$text = str_replace( $full_tag, '', $text );
-					continue;
+				if ( ! empty( $a['assignee'] ) ) {
+					$this->assignee = $this->step->get_assignee( $a['assignee'] );
 				}
 
-				$token = $this->get_workflow_url_access_token( $a, $assignee );
+				$token = $this->get_workflow_url_access_token( $a );
 
 				if ( $location == 'inbox' ) {
-					$url = $this->get_inbox_url( $a['page_id'], $token, $assignee );
+					$url = $this->get_inbox_url( $a['page_id'], $token );
 				} else {
-					$url = $this->get_entry_url( $a['page_id'], $token, $assignee );
+					$url = $this->get_entry_url( $a['page_id'], $token );
 				}
 
 				$url = $this->format_value( $url );
@@ -86,6 +85,8 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 				}
 
 				$text = str_replace( $full_tag, $url, $text );
+
+				$this->assignee = $original_assignee;
 			}
 		}
 
@@ -99,7 +100,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Url extends Gravity_Flow_Merge_Tag_Assigne
 	 *
 	 * @return string
 	 */
-	private function get_workflow_url_access_token( $a, $assignee = null ) {
+	private function get_workflow_url_access_token( $a ) {
 		$force_token = $a['token'];
 		$token       = '';
 

--- a/includes/merge-tags/class-merge-tag.php
+++ b/includes/merge-tags/class-merge-tag.php
@@ -113,6 +113,8 @@ abstract class Gravity_Flow_Merge_Tag {
 	/**
 	 * Gravity_Flow_Merge_Tag constructor.
 	 *
+	 * @since 1.7.1
+	 *
 	 * @param null|array $args The arguments used to initialize the class.
 	 */
 	public function __construct( $args = null ) {
@@ -153,6 +155,8 @@ abstract class Gravity_Flow_Merge_Tag {
 	/**
 	 * Get an array of matches for the current merge tags pattern.
 	 *
+	 * @since 1.7.1
+	 *
 	 * @param string $text The text which may contain merge tags to be processed.
 	 *
 	 * @return array
@@ -168,6 +172,8 @@ abstract class Gravity_Flow_Merge_Tag {
 
 	/**
 	 * Override this to replace the matches in the supplied text.
+	 *
+	 * @since 1.7.1
 	 *
 	 * @param string $text The text which may contain merge tags to be processed.
 	 *

--- a/includes/steps/class-step-feed-twilio.php
+++ b/includes/steps/class-step-feed-twilio.php
@@ -49,6 +49,36 @@ class Gravity_Flow_Step_Feed_Twilio extends Gravity_Flow_Step_Feed_Add_On {
 	public function get_icon_url() {
 		return $this->get_base_url() . '/images/twilio-icon-red.svg';
 	}
+
+	/**
+	 * Processes this step.
+	 *
+	 * @since 2.3.2
+	 *
+	 * @return bool Is the step complete?
+	 */
+	function process() {
+		// The Gravity Forms Twilio Add-On manipulates the merge tags when the URLs are shortened and prevents merge tag attributes from working.
+		// So the Gravity Flow merge tags are replaced early.
+		add_filter( 'gform_twilio_message', array( $this, 'filter_gform_twilio_message' ), 10, 4 );
+		parent::process();
+		remove_filter( 'gform_twilio_message', array( $this, 'filter_gform_twilio_message' ) );
+		return true;
+	}
+
+	/**
+	 * Callback for the gform_twilio_message filter.
+	 *
+	 * Replaces the merge tags in the SMS body before the Twilio Add-On mangles them.
+	 *
+	 * @since 2.3.2
+	 *
+	 * @return array
+	 */
+	function filter_gform_twilio_message( $args, $feed, $entry, $form ) {
+		$args['body'] = gravity_flow()->replace_variables( $args['body'], $form, $entry, false, false, false, 'text' );
+		return $args;
+	}
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Twilio() );


### PR DESCRIPTION
This PR does the following:

1. Adds the step merge tag attribute to allow merge tags to specify the step for which tokens must be generated. This allows feed add-ons to specify the step. For example, a Twilio or Slack message can contain a one-click approval link for the next step.

2. Fixes an edge case where the assignee attribute will remove the assignee added in the constructor and override the assignee in subsequent instances of the merge tag.

3. Fixes an issue with the current version of the Twilio Add-On where URLs get encoded breaking parameters. There's another issue with the shortener - currently, the URL Shortener in the Twilio Add-On will break links with more than one parameter. This is addressed in the Twilio Add-On repo PR5.

Fixes [HS#6406](https://secure.helpscout.net/conversation/624596724/6406?folderId=516732)

**Testing Instructions**
1. Add a Twilio feed with the one-click approval merge tag for an approval step approval step. e.g {workflow_approve_url: assignee="assignee_field|4" step="300" token="true"} where the assignee attribute is the assignee key (e.g. assignee_user_field|4 or email_field|4 ) and step is the step ID of the approval step.
2. On master, the URL sent via Twilio will be broken. On this branch, the SMS will contain the URL intact.
3. With PR5 in the Twilio Add-On repo, the shortener will shorten the link correctly.
4. Check for regression issues.