### PR TITLE
Fix admin notice style

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4309,7 +4309,7 @@ PRIMARY KEY  (id)
 					}
 					?>
 					<div class="notice error is-dismissible gravityflow_validation_error" style="padding:6px;">
-						<?php echo esc_html( $feedback->get_error_message() ); ?>
+						<p><?php echo esc_html( $feedback->get_error_message() ); ?></p>
 					</div>
 					<?php
 
@@ -4318,6 +4318,9 @@ PRIMARY KEY  (id)
 
 					$entry = GFAPI::get_entry( $entry_id ); // Refresh entry.
 
+                    if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
+                        $feedback = sprintf( '<p>%s</p>', $feedback );
+                    }
 					?>
 					<div class="gravityflow_workflow_notice updated notice notice-success is-dismissible" style="padding:6px;">
 						<?php echo $feedback; ?>

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4318,6 +4318,9 @@ PRIMARY KEY  (id)
 
 					$entry = GFAPI::get_entry( $entry_id ); // Refresh entry.
 
+					if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
+						$feedback = sprintf( '<p>%s</p>', $feedback );
+					}
 					?>
 					<div class="gravityflow_workflow_notice updated notice notice-success is-dismissible" style="padding:6px;">
 						<?php echo $feedback; ?>

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4318,9 +4318,6 @@ PRIMARY KEY  (id)
 
 					$entry = GFAPI::get_entry( $entry_id ); // Refresh entry.
 
-					if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
-						$feedback = sprintf( '<p>%s</p>', $feedback );
-					}
 					?>
 					<div class="gravityflow_workflow_notice updated notice notice-success is-dismissible" style="padding:6px;">
 						<?php echo $feedback; ?>

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4318,9 +4318,9 @@ PRIMARY KEY  (id)
 
 					$entry = GFAPI::get_entry( $entry_id ); // Refresh entry.
 
-                    if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
-                        $feedback = sprintf( '<p>%s</p>', $feedback );
-                    }
+					if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
+						$feedback = sprintf( '<p>%s</p>', $feedback );
+					}
 					?>
 					<div class="gravityflow_workflow_notice updated notice notice-success is-dismissible" style="padding:6px;">
 						<?php echo $feedback; ?>


### PR DESCRIPTION
This PR adds the `<p>` tag to the admin screen feedback when it's missing in the original message.

## Screenshots
### Admin notice before this PR
<img width="391" alt="screenshot 2018-10-03 17 03 23" src="https://user-images.githubusercontent.com/12166/46599420-ed42d080-cb19-11e8-8f0c-00a317c25fec.png">

### Admin notice after this PR
<img width="346" alt="screenshot 2018-10-03 17 05 10" src="https://user-images.githubusercontent.com/12166/46599450-f895fc00-cb19-11e8-898e-a304120ae0b7.png">

