### PR TITLE
Added merge tag dropdown to outgoing webhook URL step setting

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,5 @@
 - Updated the processing of the workflow to trigger before the confirmation is processed.
 - Added the step merge tag attribute to allow merge tags to specify the step for which tokens must be generated. This allows feed add-ons to specify the step. For example, a Twilio or Slack message can contain a one-click approval link for the next step.
+- Updated the outgoing webhook step settings to display merge tag dropdown with the URL field.
 - Fixed an edge case where the assignee attribute will remove the assignee added in the constructor and override the assignee in subsequent instances of the merge tag.
 - Fixed an issue with the integrations with the Twilio Add-On where URLs get encoded breaking workflow links.

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -82,7 +82,7 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 			'fields' => array(
 				array(
 					'name'  => 'url',
-					'class' => 'large',
+					'class' => 'large merge-tag-support',
 					'label' => esc_html__( 'Outgoing Webhook URL', 'gravityflow' ),
 					'type'  => 'text',
 				),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4549984/46910054-90755a80-cf0b-11e8-8d06-61d6f767af4e.png)

**Test Instructions**

- Create workflow with outgoing webhook step
- Note that master does not include the merge tag dropdown at end of URL field
- Switch to webhook-url-mergetags branch and see that it does
- Both branches already successfully process merge tags in the URL value.

