### PR TITLE
Ensure the PDF methods exist before trying to use it

### DIFF
--- a/includes/steps/class-common-step-settings.php
+++ b/includes/steps/class-common-step-settings.php
@@ -45,7 +45,7 @@ class Gravity_Flow_Common_Step_Settings {
 	 * @since 1.5.1-dev
 	 */
 	public function set_gpdf_choices() {
-		if ( defined( 'PDF_EXTENDED_VERSION' ) && version_compare( PDF_EXTENDED_VERSION, '4.0-RC2', '>=' ) ) {
+		if ( method_exists( 'GPDFAPI', 'get_form_pdfs' ) ) {
 			$form_id    = rgget( 'id' );
 			$gpdf_feeds = GPDFAPI::get_form_pdfs( $form_id );
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1756,7 +1756,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 * @return array
 	 */
 	public function gpdf_add_notification_attachment( $notification, $gpdf_id ) {
-		if ( ! class_exists( 'GPDFAPI' ) ) {
+		if ( ! method_exists( 'GPDFAPI', 'get_pdf' ) || ! method_exists( 'GPDFAPI', 'create_pdf' ) ) {
 			return $notification;
 		}
 


### PR DESCRIPTION
Resolve a fatal error when Gravity PDF is activated, but the system requirements aren't met, and a Gravity Flow step is loaded.