### PR TITLE
User Input Step - Only check for required fields on step complete

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,5 @@
 - Updated the processing of the workflow to trigger before the confirmation is processed.
+- Updated the processing of user input step to skip required field validation on in progress updates.
 - Added the step merge tag attribute to allow merge tags to specify the step for which tokens must be generated. This allows feed add-ons to specify the step. For example, a Twilio or Slack message can contain a one-click approval link for the next step.
 - Fixed an edge case where the assignee attribute will remove the assignee added in the constructor and override the assignee in subsequent instances of the merge tag.
 - Fixed an issue with the integrations with the Twilio Add-On where URLs get encoded breaking workflow links.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,5 @@
 - Updated the processing of the workflow to trigger before the confirmation is processed.
-- Updated the processing of user input step to skip required field validation on in progress updates.
+- Updated the processing of user input step to skip required field validation on in progress updates. Custom validation is still executed in all cases.
 - Added the step merge tag attribute to allow merge tags to specify the step for which tokens must be generated. This allows feed add-ons to specify the step. For example, a Twilio or Slack message can contain a one-click approval link for the next step.
 - Fixed an edge case where the assignee attribute will remove the assignee added in the constructor and override the assignee in subsequent instances of the merge tag.
 - Fixed an issue with the integrations with the Twilio Add-On where URLs get encoded breaking workflow links.

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -626,6 +626,10 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	public function validate_editable_fields( $valid, &$form ) {
 		$editable_fields = $this->get_editable_fields();
 
+		if( rgpost( 'gravityflow_status' ) == 'in_progress' ) {
+			return $valid;
+		}
+
 		$conditional_logic_enabled           = gravity_flow()->fields_have_conditional_logic( $form ) && $this->conditional_logic_editable_fields_enabled;
 		$page_load_conditional_logic_enabled = $conditional_logic_enabled && $this->conditional_logic_editable_fields_mode == 'page_load';
 		$dynamic_conditional_logic_enabled   = $conditional_logic_enabled && $this->conditional_logic_editable_fields_mode != 'page_load';

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -626,10 +626,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	public function validate_editable_fields( $valid, &$form ) {
 		$editable_fields = $this->get_editable_fields();
 
-		if( rgpost( 'gravityflow_status' ) == 'in_progress' ) {
-			return $valid;
-		}
-
 		$conditional_logic_enabled           = gravity_flow()->fields_have_conditional_logic( $form ) && $this->conditional_logic_editable_fields_enabled;
 		$page_load_conditional_logic_enabled = $conditional_logic_enabled && $this->conditional_logic_editable_fields_mode == 'page_load';
 		$dynamic_conditional_logic_enabled   = $conditional_logic_enabled && $this->conditional_logic_editable_fields_mode != 'page_load';
@@ -677,7 +673,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 					$field_is_hidden = false;
 				}
 
-				if ( ! $field_is_hidden && $submission_is_empty && $field->isRequired ) {
+				if ( ! $field_is_hidden && $submission_is_empty && $field->isRequired && rgpost( 'gravityflow_status' ) == 'complete' ) {
 					$field->failed_validation  = true;
 					$field->validation_message = empty( $field->errorMessage ) ? esc_html__( 'This field is required.', 'gravityflow' ) : $field->errorMessage;
 					$valid                     = false;


### PR DESCRIPTION
Currently when a user input step is saving progress the required field validation is performed in addition to any custom validations. The expectation is that saving progress shouldn’t trigger the required fields validation.

**Test Instructions**

1. Setup form with multiple administrative fields as required
1. Add a workflow user input step with one of the Save Progress options enabled.
1. Submit the form and note that on attempt to save progress the required fields are....required.
1. Switch to user-input-save-validation branch and repeat step 3. Note that required fields are...not required.
1. Attempt to complete the user input step and note that required fields are...required.

