### PR TITLE
Add the entry filter step setting

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2744,6 +2744,46 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 </script>";
 			$hidden_field = array( 'name' => $field['name'], 'type'=> 'hidden' );
 			$html .= $this->settings_hidden( $hidden_field, false );
+
+			if ( rgar( $field, 'show_sorting_options' ) ) {
+				$html .= '<br />' . esc_html__( 'Sort by field') . '&nbsp;';
+				$sort_field_choices = array();
+				foreach( $filter_settings as $filter_setting ) {
+				    if ( $filter_setting['key'] === '0' ) {
+				        continue;
+                    }
+					$sort_field_choices[] = array(
+					        'value' =>  $filter_setting['key'],
+                            'label' => $filter_setting['text'],
+                    );
+                }
+
+                $sort_field = array(
+                        'name' => $field['name'] . 'sort_key',
+                        'default_value' => 'entry_id',
+                        'choices' => $sort_field_choices,
+                );
+
+				$html .= $this->settings_select( $sort_field, false );
+
+				$direction_field = array(
+				        'name' => $field['name'] . 'sort_direction',
+				        'default_value' => 'DESC',
+                        'choices' => array(
+                            array(
+                                'value' => 'ASC',
+                                'label' => 'ASC',
+                            ),
+	                        array(
+		                        'value' => 'DESC',
+		                        'label' => 'DESC',
+	                        ),
+                        )
+                );
+
+				$html .= $this->settings_select( $direction_field, false );
+            }
+
 			if ( $echo ) {
 				echo $html;
 			}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -612,6 +612,16 @@ PRIMARY KEY  (id)
 					),
 				),
 				array(
+					'handle'  => 'gform_field_filter',
+					'src'     => GFCommon::get_base_url() . "/js/routing-setting{$min}.js",
+					'deps'    => array( 'jquery', 'gform_datepicker_init' ),
+					'version' => $this->_version,
+					'enqueue' => array(
+						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflow&fid=_notempty_' ),
+						array( 'query' => 'page=gf_edit_forms&view=settings&subview=gravityflow&fid=0' ),
+					),
+				),
+				array(
 					'handle'   => 'gravityflow_generic_map_js',
 					'src'      => $this->get_base_url() . "/js/generic-map{$min}.js",
 					'version'  => $this->_version,
@@ -2658,6 +2668,89 @@ PRIMARY KEY  (id)
 		}
 
 		/**
+		 * Displays the setting HTML.
+		 *
+		 * @param array $field The setting properties.
+		 */
+		public function settings_html( $field ) {
+			echo $field['html'];
+		}
+
+		/**
+		 * Displays the entry filter setting.
+		 *
+		 * @since 2.4
+		 *
+		 * @param array $field  The setting properties.
+		 * @param bool $echo    Whether to output the markup.
+		 *
+		 * @return string
+		 */
+		public function settings_entry_filter( $field, $echo = true ) {
+			$form = isset( $form['form_id'] ) ? GFFormsModel::get_form_meta( $field['form_id'] ) : $this->get_current_form();
+			$filter_settings      = GFCommon::get_field_filter_settings( $form );
+			$filter_settings_json = json_encode( $filter_settings );
+			$value = $this->get_setting( $field['name'] );
+			if ( ! $value ) {
+				$value = array(
+                    'mode' => 'all',
+					'filters' => array(
+						array(
+							'field'    => 0,
+							'operator' => 'contains',
+							'value'    => '',
+						),
+					),
+				);
+
+			}
+			$value_json = json_encode( $value );
+			$text = isset( $field['filter_text'] ) ? $field['filter_text'] : esc_html__( 'Match {0} of the following criteria:', 'gravityflow' );
+			$text_json = json_encode( $text );
+			$name = $field['name'];
+			$html = "
+<div id='setting-entry-filter-{$name}' class='setting-entry-filter'>
+    <!--placeholder-->
+</div>
+<script>
+gf_vars.filterAndAny = {$text_json};
+jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$value_json});
+
+(function($){
+    $(document).ready(function () {
+         function setFilterValue(){
+         	var filterSetting = $(this).closest('.setting-entry-filter').parent(),
+                filterRows = filterSetting.find('.gform-field-filter'),
+                filters = [];
+            filterRows.each( function( i )  {
+            	var f = $(this).find('.gform-filter-field').val(),
+            	    o = $(this).find('.gform-filter-operator').val(),
+            	    v = $(this).find('.gform-filter-value').val();
+                filters.push({field : f, operator: o, value: v });
+            });
+            var input = filterSetting.find('input.gaddon-hidden'),
+                mode = filterSetting.find('select[name=mode]').val(),
+                val = {
+                    mode : mode,
+                    filters : filters
+                };
+            input.val(JSON.stringify(val));
+        };
+        $('#setting-entry-filter-{$name}').on('change', 'select[name=mode]', setFilterValue);
+	    $('#setting-entry-filter-{$name}').on('change', '.gform-filter-operator', setFilterValue);
+	    $('#setting-entry-filter-{$name}').on('change blur', '.gform-filter-value', setFilterValue);
+    });
+})(jQuery);
+</script>";
+			$hidden_field = array( 'name' => $field['name'], 'type'=> 'hidden' );
+			$html .= $this->settings_hidden( $hidden_field, false );
+			if ( $echo ) {
+				echo $html;
+			}
+			return $html;
+		}
+
+		/**
 		 * Adds columns to the list of feeds.
 		 *
 		 * Setting name => label.
@@ -4068,15 +4161,6 @@ PRIMARY KEY  (id)
 			$response = wp_remote_post( GRAVITY_FLOW_EDD_STORE_URL, $args );
 
 			return $response;
-		}
-
-		/**
-		 * Displays the setting HTML.
-		 *
-		 * @param array $field The setting properties.
-		 */
-		public function settings_html( $field ) {
-			echo $field['html'];
 		}
 
 		/**

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2765,7 +2765,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
                 );
 
 				$html .= $this->settings_select( $sort_field, false );
-
+				$html .= '&nbsp;';
 				$direction_field = array(
 				        'name' => $field['name'] . 'sort_direction',
 				        'default_value' => 'DESC',

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2687,7 +2687,7 @@ PRIMARY KEY  (id)
 		 * @return string
 		 */
 		public function settings_entry_filter( $field, $echo = true ) {
-			$form = isset( $form['form_id'] ) ? GFFormsModel::get_form_meta( $field['form_id'] ) : $this->get_current_form();
+			$form = isset( $field['form_id'] ) ? GFFormsModel::get_form_meta( $field['form_id'] ) : $this->get_current_form();
 			$filter_settings      = GFCommon::get_field_filter_settings( $form );
 			$filter_settings_json = json_encode( $filter_settings );
 			$value = $this->get_setting( $field['name'] );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2687,7 +2687,7 @@ PRIMARY KEY  (id)
 		 * @return string
 		 */
 		public function settings_entry_filter( $field, $echo = true ) {
-			$form = isset( $field['form_id'] ) ? GFFormsModel::get_form_meta( $field['form_id'] ) : $this->get_current_form();
+			$form = ! empty( $field['form_id'] ) ? GFFormsModel::get_form_meta( $field['form_id'] ) : $this->get_current_form();
 			$filter_settings      = GFCommon::get_field_filter_settings( $form );
 			$filter_settings_json = json_encode( $filter_settings );
 			$value = $this->get_setting( $field['name'] );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2751,11 +2751,18 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				foreach( $filter_settings as $filter_setting ) {
 				    if ( $filter_setting['key'] === '0' ) {
 				        continue;
-                    }
-					$sort_field_choices[] = array(
-					        'value' =>  $filter_setting['key'],
+					}
+					if( $filter_setting['key'] === 'entry_id' ) {
+						$sort_field_choices[] = array(
+					        'value' =>  'id',
                             'label' => $filter_setting['text'],
-                    );
+                    	);
+					} else {
+						$sort_field_choices[] = array(
+								'value' =>  $filter_setting['key'],
+								'label' => $filter_setting['text'],
+						);
+					}
                 }
 
                 $sort_field = array(

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2752,17 +2752,13 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				    if ( $filter_setting['key'] === '0' ) {
 				        continue;
 					}
-					if( $filter_setting['key'] === 'entry_id' ) {
-						$sort_field_choices[] = array(
-					        'value' =>  'id',
-                            'label' => $filter_setting['text'],
-                    	);
-					} else {
-						$sort_field_choices[] = array(
-								'value' =>  $filter_setting['key'],
-								'label' => $filter_setting['text'],
-						);
-					}
+
+					$filter_key = $filter_setting['key'] === 'entry_id' ? 'id' : $filter_setting['key'];
+
+					$sort_field_choices[] = array(
+						'value' => $filter_key,
+						'label' => $filter_setting['text'],
+					);
                 }
 
                 $sort_field = array(


### PR DESCRIPTION
This PR adds the entry filter setting which renders the Gravity Forms entry filter UI. The form_id setting property is mandatory. The filter_text property is optional but it must include a placeholder for the any/all drop down e.g. "Match {0} of the following criteria".

It supports multiple instances on the same step.

**Testing instructions**
Add a step setting of type entry_filter. Set the values and save to ensure the settings are saved. Add another setting of the same type and ensure the value are saved correctly.
Test with the [Update Fields step PR](https://github.com/gravityflow/gravityflowformconnector/pull/19) in the Form Connector.