### PR TITLE
Added email related app settings

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3810,40 +3810,6 @@ PRIMARY KEY  (id)
 		 * @return array
 		 */
 		public function app_settings_fields() {
-
-			$forms = GFAPI::get_forms();
-			$choices = array();
-			foreach ( $forms as $form ) {
-				$form_id = absint( $form['id'] );
-				$feeds = $this->get_feeds( $form_id );
-				if ( ! empty( $feeds ) ) {
-					$choices[] = array(
-						'label'         => esc_html( $form['title'] ),
-						'name'          => 'publish_form_' . absint( $form['id'] ),
-					);
-				}
-			}
-
-			if ( ! empty( $choices ) ) {
-				$published_forms_fields = array(
-					array(
-						'name'          => 'form_ids',
-						'label'         => esc_html__( 'Published', 'gravityflow' ),
-						'type'          => 'checkbox',
-						'choices'       => $choices,
-					),
-				);
-			} else {
-				$published_forms_fields = array(
-					array(
-						'name'          => 'no_workflows',
-						'label'         => '',
-						'type'          => 'html',
-						'html'          => esc_html__( 'No workflow steps have been added to any forms yet.', 'gravityflow' ),
-					),
-				);
-			}
-
 			$settings = array();
 
 			if ( ( ! is_multisite() || ( is_multisite() && is_main_site() ) ) && ! defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ) {
@@ -3876,13 +3842,231 @@ PRIMARY KEY  (id)
 				);
 			}
 
+			$settings[] = $this->get_app_settings_fields_emails();
+			$settings[] = $this->get_app_settings_fields_pages();
+			$settings[] = $this->get_app_settings_fields_published_forms();
+
 			$settings[] = array(
+				'id'     => 'save_button',
+				'fields' => array(
+					array(
+						'id'       => 'save_button',
+						'name'     => 'save_button',
+						'type'     => 'save',
+						'value'    => __( 'Update Settings', 'gravityflow' ),
+						'messages' => array(
+							'success' => __( 'Settings updated successfully', 'gravityflow' ),
+							'error'   => __( 'There was an error while saving the settings', 'gravityflow' ),
+						),
+					),
+				)
+			);
+
+			return $settings;
+
+		}
+
+		/**
+		 * Returns an array of email related settings to be displayed on the app settings page.
+		 *
+		 * @since 2.3.4
+		 *
+		 * @return array
+		 */
+		public function get_app_settings_fields_emails() {
+
+			$settings = array(
+				'title'  => esc_html__( 'Workflow Emails', 'gravityflow' ),
+				'fields' => array(),
+			);
+
+			require_once GFCommon::get_base_path() . '/notification.php';
+			$notification_services = GFNotification::get_notification_services();
+
+			if ( count( $notification_services ) > 1 ) {
+				$service_choices = array();
+
+				foreach ( $notification_services as $key => $service ) {
+					$service_choices[] = array(
+						'label' => rgar( $service, 'label' ),
+						'value' => $key,
+						'icon'  => rgar( $service, 'image' ),
+					);
+				}
+
+				$settings['fields'][] = array(
+					'name'          => 'email_service',
+					'label'         => esc_html__( 'Email Service', 'gravityflow' ),
+					'tooltip'       => __( 'Select which service should be used to send the workflow emails. WordPress uses the server hosting your site or an active SMTP plugin.', 'gravityflow' ),
+					'type'          => 'radio',
+					'horizontal'    => true,
+					'default_value' => 'wordpress',
+					'choices'       => $service_choices,
+					'onchange'      => 'jQuery(this).parents("form").submit();',
+				);
+			}
+
+			$settings['fields'][] = array(
+				'name'          => 'from_name',
+				'label'         => esc_html__( 'From Name', 'gravityflow' ),
+				'tooltip'       => __( 'The default From Name to be used when the From Name setting is not configured on the individual steps.', 'gravityflow' ),
+				'type'          => 'text',
+				'default_value' => get_bloginfo( 'name' ),
+				'class'         => 'medium',
+			);
+
+			$settings['fields'][] = $this->get_app_settings_field_from_email();
+
+			return $settings;
+		}
+
+		/**
+		 * Returns an array of properties for the From Email setting to be displayed on the app settings page.
+		 *
+		 * @since 2.3.4
+		 *
+		 * @return array
+		 */
+		public function get_app_settings_field_from_email() {
+			$setting = array(
+				'name'                => 'from_email',
+				'label'               => esc_html__( 'From Email', 'gravityflow' ),
+				'tooltip'             => __( 'The default From Email to be used when the From Email setting is not configured on the individual steps.', 'gravityflow' ),
+				'type'                => 'text',
+				'default_value'       => get_bloginfo( 'admin_email' ),
+				'class'               => 'medium',
+				'validation_callback' => array( $this, 'validate_from_email' ),
+			);
+
+			$service = $this->get_setting( 'email_service' );
+
+			if ( $service == 'postmark' && function_exists( 'gf_postmark' ) ) {
+				$choices = array();
+
+				try {
+					$postmark = new GF_Postmark_API();
+					$postmark->set_account_token( gf_postmark()->get_plugin_setting( 'accountToken' ) );
+					$sender_signatures = $postmark->get_sender_signatures();
+
+					foreach ( $sender_signatures as $sender_signature ) {
+						$choices[] = array(
+							'label' => $sender_signature['EmailAddress'],
+							'value' => $sender_signature['EmailAddress'],
+						);
+					}
+
+					unset( $setting['default_value'], $setting['class'], $setting['validation_callback'] );
+					$setting['type']    = 'select';
+					$setting['choices'] = $choices;
+				} catch ( Exception $e ) {
+					// Do nothing. The text based setting will be used instead.
+				}
+			}
+
+			return $setting;
+		}
+
+		/**
+		 * Validates the From Name app setting.
+		 *
+		 * @since 2.3.4
+		 *
+		 * @param array  $field The setting properties.
+		 * @param string $value The setting value.
+		 */
+		public function validate_from_email( $field, $value ) {
+			if ( empty( $value ) || GFCommon::has_merge_tag( $value ) ) {
+				return;
+			}
+
+			if ( ! GFCommon::is_valid_email( $value ) ) {
+				$this->set_field_error( array( 'name' => 'from_email' ), esc_html__( 'Please enter a valid email address.', 'gravityflow' ) );
+				return;
+			}
+
+			$service = $this->get_setting( 'email_service', 'wordpress' );
+			if ( $service == 'wordpress' ) {
+				return;
+			}
+
+			$error_message = '';
+
+			if ( $service == 'mailgun' && function_exists( 'gf_mailgun' ) ) {
+				$from_domain = explode( '@', $value );
+				$from_domain = end( $from_domain );
+				if ( ! gf_mailgun()->is_valid_domain( $from_domain ) ) {
+					$error_message = sprintf(
+						esc_html__( 'From Email domain must be an %1$sactive domain%3$s. You can learn more about verifying your domain in the %2$sMailgun documentation%3$s.', 'gravityflow' ),
+						"<a href='https://mailgun.com/app/domains'>",
+						"<a href='https://documentation.mailgun.com/user_manual.html#verifying-your-domain'>",
+						'</a>'
+					);
+				}
+			}
+
+			if ( $error_message ) {
+				$this->set_field_error( array( 'name' => 'from_email' ), $error_message );
+			}
+
+		}
+
+		/**
+		 * Returns the Published Forms section of fields to be displayed on the app settings page.
+		 *
+		 * @since 2.3.4
+		 *
+		 * @return array
+		 */
+		public function get_app_settings_fields_published_forms() {
+			$forms   = GFAPI::get_forms();
+			$choices = array();
+			foreach ( $forms as $form ) {
+				$form_id = absint( $form['id'] );
+				$feeds   = $this->get_feeds( $form_id );
+				if ( ! empty( $feeds ) ) {
+					$choices[] = array(
+						'label' => esc_html( $form['title'] ),
+						'name'  => 'publish_form_' . absint( $form['id'] ),
+					);
+				}
+			}
+
+			if ( ! empty( $choices ) ) {
+				$published_forms_fields = array(
+					array(
+						'name'    => 'form_ids',
+						'label'   => esc_html__( 'Published', 'gravityflow' ),
+						'type'    => 'checkbox',
+						'choices' => $choices,
+					),
+				);
+			} else {
+				$published_forms_fields = array(
+					array(
+						'name'  => 'no_workflows',
+						'label' => '',
+						'type'  => 'html',
+						'html'  => esc_html__( 'No workflow steps have been added to any forms yet.', 'gravityflow' ),
+					),
+				);
+			}
+
+			return array(
 				'title'       => esc_html__( 'Published Workflow Forms', 'gravityflow' ),
 				'description' => esc_html__( 'Select the forms you wish to publish on the Submit page.', 'gravityflow' ),
 				'fields'      => $published_forms_fields,
 			);
+		}
 
-			$settings[] = array(
+		/**
+		 * Returns the Default Pages section of settings to be displayed on the app settings page.
+		 *
+		 * @since 2.3.4
+		 *
+		 * @return array
+		 */
+		public function get_app_settings_fields_pages() {
+			return array(
 				'title'       => esc_html__( 'Default Pages', 'gravityflow' ),
 				'description' => esc_html__( 'Select the pages which contain the following gravityflow shortcodes. For example, the inbox page selected below will be used when preparing merge tags such as {workflow_inbox_link} when the page_id attribute is not specified.', 'gravityflow' ),
 				'fields'      => array(
@@ -3903,25 +4087,6 @@ PRIMARY KEY  (id)
 					),
 				),
 			);
-
-			$settings[] = array(
-				'id'     => 'save_button',
-				'fields' => array(
-					array(
-						'id'       => 'save_button',
-						'name'     => 'save_button',
-						'type'     => 'save',
-						'value'    => __( 'Update Settings', 'gravityflow' ),
-						'messages' => array(
-							'success' => __( 'Settings updated successfully', 'gravityflow' ),
-							'error'   => __( 'There was an error while saving the settings', 'gravityflow' ),
-						),
-					),
-				)
-			);
-
-			return $settings;
-
 		}
 
 		/**
@@ -5250,21 +5415,27 @@ PRIMARY KEY  (id)
 		/**
 		 * Returns the specified app setting.
 		 *
+		 * @since 2.3.4
 		 * @since 1.4.3-dev
 		 *
 		 * @param string $setting_name The app setting to be returned.
+		 * @param null|string $default The default value to be returned when the setting does not have a value.
 		 *
 		 * @return mixed|string
 		 */
-		public function get_app_setting( $setting_name ) {
+		public function get_app_setting( $setting_name, $default = null ) {
 			$setting = parent::get_app_setting( $setting_name );
 
+			if ( ! empty( $setting ) ) {
+				return $setting;
+			}
+
 			// If a default page hasn't been configured use the admin page.
-			if ( ! $setting && in_array( $setting_name, array( 'inbox_page', 'status_page', 'submit_page' ) ) ) {
+			if ( in_array( $setting_name, array( 'inbox_page', 'status_page', 'submit_page' ) ) ) {
 				return 'admin';
 			}
 
-			return $setting;
+			return $default;
 		}
 
 		/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -936,15 +936,18 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 * @return array
 	 */
 	public function get_notification( $type ) {
-		$notification = array( 'workflow_notification_type' => $type );
+		$notification = array(
+			'workflow_notification_type' => $type,
+			'service'                    => gravity_flow()->get_app_setting( 'email_service', 'wordpress' ),
+		);
 
 		$type .= '_notification_';
 		$from_name  = $type . 'from_name';
 		$from_email = $type . 'from_email';
 		$subject    = $type . 'subject';
 
-		$notification['fromName']          = empty( $this->{$from_name} ) ? get_bloginfo() : $this->{$from_name};
-		$notification['from']              = empty( $this->{$from_email} ) ? get_bloginfo( 'admin_email' ) : $this->{$from_email};
+		$notification['fromName']          = empty( $this->{$from_name} ) ? gravity_flow()->get_app_setting( 'from_name', get_bloginfo( 'name' ) ) : $this->{$from_name};
+		$notification['from']              = empty( $this->{$from_email} ) ? gravity_flow()->get_app_setting( 'from_email', get_bloginfo( 'admin_email' ) ) : $this->{$from_email};
 		$notification['replyTo']           = $this->{$type . 'reply_to'};
 		$notification['bcc']               = $this->{$type . 'bcc'};
 		$notification['message']           = $this->{$type . 'message'};


### PR DESCRIPTION
Added settings for the Email Service, default From Name, and default From Email. 

The From Email setting defaults to a text type setting unless Postmark is the selected service in which case it will change to a drop down populated with email addresses from the Postmark account.

If Mailgun is the selected service the email address domain will be validated on save.

Also reordered the app settings so the email and page settings are located before the published forms settings.

<img width="1471" alt="gravityflow-app-settings" src="https://user-images.githubusercontent.com/1872371/48311271-382a8a80-e595-11e8-9006-ad3d0077c92d.png">

Updated `Gravity_Flow_Step::get_notification()` to use the new settings.