### PR TITLE
Fix file upload field not displaying entry value following save

### DIFF
--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -394,7 +394,12 @@ class Gravity_Flow_Entry_Editor {
 		$posted_form_id = rgpost( 'gravityflow_submit' );
 		if ( $posted_form_id == $this->form['id'] && rgpost( 'step_id' ) == $this->step->get_id() ) {
 			// Updated or failed validation.
-			$value = GFFormsModel::get_field_value( $field );
+			if ( $field->get_input_type() == 'fileupload' && ( $field->multipleFiles || $field->is_value_submission_empty( $posted_form_id ) ) ) {
+				// Use the entry value so the field will be re-populated following progress being saved.
+				$value = GFFormsModel::get_lead_field_value( $this->entry, $field );
+			} else {
+				$value = GFFormsModel::get_field_value( $field );
+			}
 		} else {
 			$value = GFFormsModel::get_lead_field_value( $this->entry, $field );
 			if ( $field->get_input_type() == 'email' && $field->emailConfirmEnabled ) {


### PR DESCRIPTION
re: [HS#7081](https://secure.helpscout.net/conversation/698671601/7081?folderId=1113535)

Fixes an issue where the file upload field appears to lose its value following progress save on the user input step. The file does remain and the URL is in the entry its just the field does not display it.

**Testing Instructions**
- Import test form from ticket
- Preview form, upload file and submit form
- Go to inbox and view the entry
- Find the existing file upload value is populated
- Add value to text input and save progress
- Find the existing file upload value is not populated
- View the Gravity Forms entry detail page and find the file upload field value is present
- Switch to this branch
- Repeat user input step tests and find that the file upload field retains its value following progress being saved