### PR TITLE
Add back link to shortcode

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,5 +2,5 @@
 - Added shortcode attribute back_link (default: false) to identify if back link should be displayed on entry detail for entries loaded via shortcode.
 - Added shortcode attribute back_link_text (default: "Return to list" translatable) to allow customization of text for back link on entry detail page.
 - Added shortcode attribute back_link_url (default: null) to allow customization of back link on entry detail page.
-- Added filter gravityflow_back_link_entry_detail to allow customization of back link on entry detail page.
+- Added filter gravityflow_back_link_url_entry_detail to allow customization of back link on entry detail page.
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,6 @@
-- Added link on entry detail page, shortcode only, to 'Return to list'
-- Added shortcode attribute 'display_back_link' to allow new 'Return to list' link on entry detail page to be hidden
+- Added link on entry detail page, shortcode only, to 'Return to list' which links user back to inbox / status page.
+- Added shortcode attribute back_link (default: false) to identify if back link should be displayed on entry detail for entries loaded via shortcode.
+- Added shortcode attribute back_link_text (default: "Return to list" translatable) to allow customization of text for back link on entry detail page.
+- Added shortcode attribute back_link_url (default: null) to allow customization of back link on entry detail page.
+- Added filter gravityflow_back_link_entry_detail to allow customization of back link on entry detail page.
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,3 @@
+- Added link on entry detail page, shortcode only, to 'Return to list'
+- Added shortcode attribute 'display_back_link' to allow new 'Return to list' link on entry detail page to be hidden
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5370,7 +5370,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'     => true,
 				'sidebar'           => true,
 				'step_highlight'    => true,
-				'display_back_link' => false,
+				'back_link'         => false,
+				'back_link_text'    => __( 'Return to list', 'gravityflow' ),
+				'back_link_url'     => null,
 			);
 
 			return $defaults;
@@ -5423,7 +5425,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'        => $a['workflow_info'],
 				'sidebar'              => $a['sidebar'],
 				'step_highlight'       => $a['step_highlight'],
-				'display_back_link'    => $a['display_back_link'],
+				'back_link'            => $a['back_link'],
+				'back_link_text'       => $a['back_link_text'],
+				'back_link_url'        => $a['back_link_url'],
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5370,7 +5370,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'     => true,
 				'sidebar'           => true,
 				'step_highlight'    => true,
-				'display_back_link' => true,
+				'display_back_link' => false,
 			);
 
 			return $defaults;
@@ -5423,6 +5423,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'        => $a['workflow_info'],
 				'sidebar'              => $a['sidebar'],
 				'step_highlight'       => $a['step_highlight'],
+				'display_back_link'    => $a['display_back_link'],
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3201,7 +3201,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					<div id="submitcomment" class="submitbox">
 						<div id="minor-publishing" class="gravityflow-status-box">
 							<?php
-
+							
 							$this->maybe_display_entry_detail_workflow_info( $current_step, $form, $entry, $args );
 							$this->maybe_display_entry_detail_step_status( $current_step, $form, $entry, $args );
 
@@ -5351,25 +5351,26 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 */
 		public function get_shortcode_defaults() {
 			$defaults = array(
-				'page'             => 'inbox',
-				'form'             => null,
-				'form_id'          => null,
-				'entry_id'         => null,
-				'fields'           => array(),
-				'display_all'      => null,
-				'actions_column'   => false,
-				'allow_anonymous'  => false,
-				'title'            => '',
-				'id_column'        => true,
-				'submitter_column' => true,
-				'step_column'      => true,
-				'status_column'    => true,
-				'timeline'         => true,
-				'last_updated'     => false,
-				'step_status'      => true,
-				'workflow_info'    => true,
-				'sidebar'          => true,
-				'step_highlight'   => true,
+				'page'              => 'inbox',
+				'form'              => null,
+				'form_id'           => null,
+				'entry_id'          => null,
+				'fields'            => array(),
+				'display_all'       => null,
+				'actions_column'    => false,
+				'allow_anonymous'   => false,
+				'title'             => '',
+				'id_column'         => true,
+				'submitter_column'  => true,
+				'step_column'       => true,
+				'status_column'     => true,
+				'timeline'          => true,
+				'last_updated'      => false,
+				'step_status'       => true,
+				'workflow_info'     => true,
+				'sidebar'           => true,
+				'step_highlight'    => true,
+				'display_back_link' => true,
 			);
 
 			return $defaults;

--- a/includes/class-gravityview-detail-link.php
+++ b/includes/class-gravityview-detail-link.php
@@ -74,7 +74,7 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 	private function add_hooks() {
 		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_entry_default_field' ), 10, 3 );
 		add_filter( 'gravityview_field_entry_value_workflow_detail_link', array( $this, 'modify_entry_value_workflow_detail_link' ), 10, 4 );
-		add_filter( 'gravityflow_back_link_entry_detail', array( $this, 'modify_entry_detail_back_link' ), 10, 2 );
+		add_filter( 'gravityflow_back_link_url_entry_detail', array( $this, 'modify_entry_detail_back_link' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-gravityview-detail-link.php
+++ b/includes/class-gravityview-detail-link.php
@@ -132,7 +132,7 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 
 		$url = Gravity_Flow_Common::get_workflow_url( $query_args, $page_id );
 
-		if( $page_id != 'admin' ) {
+		if ( $page_id != 'admin' ) {
 			global $post;
 			$url .= '&gvp=' . $post->ID;
 		}

--- a/includes/class-gravityview-detail-link.php
+++ b/includes/class-gravityview-detail-link.php
@@ -74,6 +74,7 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 	private function add_hooks() {
 		add_filter( 'gravityview_entry_default_fields', array( $this, 'add_entry_default_field' ), 10, 3 );
 		add_filter( 'gravityview_field_entry_value_workflow_detail_link', array( $this, 'modify_entry_value_workflow_detail_link' ), 10, 4 );
+		add_filter( 'gravityflow_back_link_entry_detail', array( $this, 'modify_entry_detail_back_link' ), 10, 2 );
 	}
 
 	/**
@@ -131,6 +132,11 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 
 		$url = Gravity_Flow_Common::get_workflow_url( $query_args, $page_id );
 
+		if( $page_id != 'admin' ) {
+			global $post;
+			$url .= '&gvp=' . $post->ID;
+		}
+
 		$text = $field_settings['workflow_detail_link_text'];
 
 		$output = sprintf( '<a href="%s">%s</a>', $url, $text );
@@ -169,6 +175,37 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 
 		return $add_options + $field_options;
 	}
+
+	/**
+	 * Customize the back link for pages which were accessed via Gravity View workflow detail link field.
+	 *
+	 * @param string $url       The potential back link URL.
+	 * @param array  $args      The shortcode arguments for the page where the back link is to be displayed
+	 *
+	 * @since 2.5-dev
+	 *
+	 * @return string
+	 */
+	function modify_entry_detail_back_link( $url, $args ) {
+		//Verify the back link is set as active on current page and the potential back link has querystring params
+		if ( $args['back_link'] == true && false !== strpos( $url, '?' ) ) {
+
+			//Parse the querystring to confirm the gvp param was added via the workflow detail link
+			$querystring = explode( '?', $url, 2 );
+			parse_str( end( $querystring ), $query_args );
+			if ( isset( $query_args['gvp'] ) ) {
+
+				//Confirm the gvp param is for a valid page and update the back link URL
+				$view_page = get_permalink( $query_args['gvp'] );
+				if ( $view_page !== false ) {
+					$url = $view_page;
+				}
+			}
+		}
+
+		return $url;
+	}
+
 }
 
 new Gravity_Flow_GravityView_Workflow_Detail_Link;

--- a/includes/class-gravityview-detail-link.php
+++ b/includes/class-gravityview-detail-link.php
@@ -187,15 +187,15 @@ class Gravity_Flow_GravityView_Workflow_Detail_Link extends GravityView_Field {
 	 * @return string
 	 */
 	function modify_entry_detail_back_link( $url, $args ) {
-		//Verify the back link is set as active on current page and the potential back link has querystring params
+		// Verify the back link is set as active on current page and the potential back link has querystring params
 		if ( $args['back_link'] == true && false !== strpos( $url, '?' ) ) {
 
-			//Parse the querystring to confirm the gvp param was added via the workflow detail link
+			// Parse the querystring to confirm the gvp param was added via the workflow detail link
 			$querystring = explode( '?', $url, 2 );
 			parse_str( end( $querystring ), $query_args );
 			if ( isset( $query_args['gvp'] ) ) {
 
-				//Confirm the gvp param is for a valid page and update the back link URL
+				// Confirm the gvp param is for a valid page and update the back link URL
 				$view_page = get_permalink( $query_args['gvp'] );
 				if ( $view_page !== false ) {
 					$url = $view_page;

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -276,7 +276,7 @@ class Gravity_Flow_Entry_Detail {
 	/**
 	 * Displays the back link on entry detail page if enabled.
 	 *
-	 * @since 2.5-dev
+	 * @since 2.5
 	 * 
 	 * @param array   $args    The properties for the page currently being displayed.
 	 */
@@ -296,7 +296,7 @@ class Gravity_Flow_Entry_Detail {
 		 *
 		 * Useful in cases where the access into entry detail page is not based out of gravityflow shortcode.
 		 *
-		 * @since 2.5-dev
+		 * @since 2.5
 		 *
 		 * @var string $url    The customized URL to redirect user to when clicking the back link
 		 * @var array  $args   The shortcode attributes for the current page

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -51,6 +51,7 @@ class Gravity_Flow_Entry_Detail {
 		<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_detail">
 
 			<?php
+			self::maybe_display_back_link( $args );
 			self::maybe_show_header( $form, $args );
 
 			$permission_granted = $check_view_entry_permissions ? self::is_permission_granted( $entry, $form, $current_step ) : true;
@@ -150,6 +151,7 @@ class Gravity_Flow_Entry_Detail {
 			'sidebar'              => true,
 			'step_status'          => true,
 			'workflow_info'        => true,
+			'display_back_link'    => true,
 		);
 
 		$args = array_merge( $defaults, $args );
@@ -268,6 +270,26 @@ class Gravity_Flow_Entry_Detail {
 		</div>
 		<?php
 	}
+
+	/**
+	 * Displays the workflow info on the entry detail page, if enabled.
+	 *
+	 * @param array             $args         The properties for the page currently being displayed.
+	 */
+	public static function maybe_display_back_link( $args ) {
+		$display_back_link = (bool) $args['display_back_link'];
+
+		if ( ! $display_back_link || is_admin() ) {
+			return;
+		}
+
+		$url = remove_query_arg( array( 'gworkflow_token', 'new_status', 'view', 'lid', 'id' ) );
+
+		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', $url, esc_html__( 'Return to list', 'gravityflow' ) );
+
+		return;
+	}
+
 
 	/**
 	 * Checks if the current user has permission to view the entry details.

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -151,7 +151,9 @@ class Gravity_Flow_Entry_Detail {
 			'sidebar'              => true,
 			'step_status'          => true,
 			'workflow_info'        => true,
-			'display_back_link'    => false,
+			'back_link'            => false,
+			'back_link_text'       => __( 'Return to list', 'gravityflow' ),
+			'back_link_url'        => null,
 		);
 
 		$args = array_merge( $defaults, $args );
@@ -272,22 +274,38 @@ class Gravity_Flow_Entry_Detail {
 	}
 
 	/**
-	 * Displays the workflow info on the entry detail page, if enabled.
+	 * Displays the back link on entry detail page if enabled.
 	 *
-	 * @param array             $args         The properties for the page currently being displayed.
+	 * @since 2.5-dev
+	 * 
+	 * @param array   $args    The properties for the page currently being displayed.
 	 */
 	public static function maybe_display_back_link( $args ) {
-		$display_back_link = (bool) $args['display_back_link'];
+		$back_link = (bool) $args['back_link'];
+		$back_link_text = $args['back_link_text'];
+		$back_link_url = $args['back_link_url'];
 
-		if ( ! $display_back_link || is_admin() ) {
+		if ( ! $back_link || is_admin() ) {
 			return;
 		}
 
-		$url = remove_query_arg( array( 'gworkflow_token', 'new_status', 'view', 'lid', 'id' ) );
+		$url = is_null( $back_link_url ) ? remove_query_arg( array( 'gworkflow_token', 'new_status', 'view', 'lid', 'id' ) ) : $back_link_url;
 
+		/**
+		 * Allows customization of the back link
+		 *
+		 * Useful in cases where the access into entry detail page is not based out of gravityflow shortcode.
+		 *
+		 * @since 2.5-dev
+		 *
+		 * @var string $url    The customized URL to redirect user to when clicking the back link
+		 * @var array  $args   The shortcode attributes for the current page
+		 *
+		 * @return string
+		 */
 		$url = apply_filters( 'gravityflow_back_link_entry_detail', $url, $args );
 
-		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', esc_url( $url ), esc_html__( 'Return to list', 'gravityflow' ) );
+		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', esc_url( $url ), esc_html( $back_link_text ) );
 
 		return;
 	}

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -151,7 +151,7 @@ class Gravity_Flow_Entry_Detail {
 			'sidebar'              => true,
 			'step_status'          => true,
 			'workflow_info'        => true,
-			'display_back_link'    => true,
+			'display_back_link'    => false,
 		);
 
 		$args = array_merge( $defaults, $args );
@@ -285,7 +285,9 @@ class Gravity_Flow_Entry_Detail {
 
 		$url = remove_query_arg( array( 'gworkflow_token', 'new_status', 'view', 'lid', 'id' ) );
 
-		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', $url, esc_html__( 'Return to list', 'gravityflow' ) );
+		$url = apply_filters( 'gravityflow_back_link_entry_detail', $url, $args );
+
+		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', esc_url( $url ), esc_html__( 'Return to list', 'gravityflow' ) );
 
 		return;
 	}

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -303,7 +303,7 @@ class Gravity_Flow_Entry_Detail {
 		 *
 		 * @return string
 		 */
-		$url = apply_filters( 'gravityflow_back_link_entry_detail', $url, $args );
+		$url = apply_filters( 'gravityflow_back_link_url_entry_detail', $url, $args );
 
 		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', esc_url( $url ), esc_html( $back_link_text ) );
 


### PR DESCRIPTION
This PR enables a back link to be added to the entry detail screen to return user to the inbox/status page based on shortcode. 

### Shortcode Attributes
- **back_link** - Default is false. Set to true to show the back link on entry detail page
- **back_link_text** - Default is 'Return to list'. Set a custom message per shortcode.
- **back_link_url** - Default is null. Enable non-GF shortcode pages to set a return link to their summary view.

### Filter(s)
- **gravityflow_back_link_url_entry_detail** - To allow customization of the link via code. The shortcode $args are passed as the 2nd argument allowing devs to control which scenarios they may want to customize.

### Other
- Updates the Gravity View integration of workflow_detail_link field. If the default GFlow inbox/shortcode page has the back_link=true attribute to its' shortcode, the back link will return to the current view page instead.

The shortcode attributes and filter will need documentation updates as a part of the version launch.