### PR TITLE
Search criteria

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.
+- Added the filter gravityflow_search_criteria_status to allow status page to filter on multiple field criteria

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1600,6 +1600,18 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		$search_criteria = $this->get_search_criteria();
 
+		/**
+		 * Allows search_criteria to be adjusted to define which forms' entries are displayed in status table.
+		 * 
+		 * Return an array of search_criteria for use with GFAPI.
+		 *
+		 * @since 2.4.1-dev
+		 * 
+		 * @param array   $search_criteria The search criteria
+		 * @param object  $this            The Status Table object
+		 */
+		$search_criteria = apply_filters( 'gravityflow_search_criteria_status', $search_criteria, $this );
+
 		$orderby = ( ! empty( $_REQUEST['orderby'] ) ) ? $_REQUEST['orderby'] : 'date_created';
 
 		$order = ( ! empty( $_REQUEST['order'] ) ) ? $_REQUEST['order'] : 'desc';

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1608,9 +1608,8 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		 * @since 2.4.1-dev
 		 * 
 		 * @param array   $search_criteria The search criteria
-		 * @param object  $this            The Status Table object
 		 */
-		$search_criteria = apply_filters( 'gravityflow_search_criteria_status', $search_criteria, $this );
+		$search_criteria = apply_filters( 'gravityflow_search_criteria_status', $search_criteria );
 
 		$orderby = ( ! empty( $_REQUEST['orderby'] ) ) ? $_REQUEST['orderby'] : 'date_created';
 

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1602,11 +1602,11 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		/**
 		 * Allows search_criteria to be adjusted to define which forms' entries are displayed in status table.
-		 * 
+		 *
 		 * Return an array of search_criteria for use with GFAPI.
 		 *
-		 * @since 2.4.1-dev
-		 * 
+		 * @since 2.5
+		 *
 		 * @param array   $search_criteria The search criteria
 		 */
 		$search_criteria = apply_filters( 'gravityflow_search_criteria_status', $search_criteria );


### PR DESCRIPTION
(Re-submit of PR #198 based off develop branch)
Refer to HS# 7384 and #7455

Add gravityflow_search_criteria_status filter to allow multi-field search criteria to be executed on the status page. Note that in order for it to filter the GFAPI get_entries request, the gravityflow_form_ids_status filter (or UI selection of matching form) must be used to define a single form id.

Example Code to trigger the filter to apply only on a front-end page /status/:
```

add_filter( 'gravityflow_search_criteria_status', 'status_search_criteria_control', 10, 1);
function status_search_criteria_control( $criteria ) {
	
	if( false !== strpos( $_SERVER['REQUEST_URI'], '/status/' ) ) {
		$criteria['field_filters']['mode'] = 'any';
		$criteria['field_filters'][] = array(
			'key'     => '5',
			'operator' => 'is',
			'value'    => '1234',
		);
		$criteria['field_filters'][] = array(
			'key'     => '5',
			'operator' => 'is',
			'value'    => '5678',
		);
	}
	return $criteria;
}
add_filter( 'gravityflow_form_ids_status', 'status_form_id_control', 10, 2);
function status_form_id_control( $form_ids, $criteria ) {
	if( false !== strpos( $_SERVER['REQUEST_URI'], '/status/' ) ) {
		$form_ids = array( 13 );
	}
	return $form_ids;
}
```