### PR TITLE
Add filter to gform_is_value_match for multiuser field values

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.
+- Fixed an issue where Conditional Routing based on what values a Multiuser field contains could lead to extra users being set as step assignees.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -194,7 +194,7 @@ if ( class_exists( 'GFForms' ) ) {
 			add_filter( 'gform_enqueue_scripts', array( $this, 'filter_gform_enqueue_scripts' ), 10, 2 );
 			add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_variables' ), 10, 7 );
 
-			add_filter( 'gform_is_value_match', array( $this, 'filter_value_match_multiuser'), 10, 6 );
+			add_filter( 'gform_is_value_match', array( $this, 'filter_value_match_multiuser' ), 10, 6 );
 
 			add_action( 'gform_entry_created', array( $this, 'action_entry_created' ), 8, 2 );
 			add_action( 'gform_register_init_scripts', array( $this, 'filter_gform_register_init_scripts' ), 10, 3 );
@@ -7643,21 +7643,21 @@ AND m.meta_value='queued'";
 
 		/**
 		 * Determines if a multiuser field is being used for conditional routing and has an exact value match of user ID
-		 * 
+		 *
 		 * @since 2.5
 		 *
 		 * @return bool
 		 */
 		public function filter_value_match_multiuser( $is_match, $field_value, $target_value, $operation, $source_field, $rule ) {
-			
-			if ( $source_field->type !== 'workflow_multi_user' ) {
+
+			if ( ! $source_field || $source_field->type !== 'workflow_multi_user' ) {
 				return $is_match;
 			}
 
-			if( in_array( $target_value, $field_value, true ) ) {
+			if ( in_array( $target_value, $field_value, true ) ) {
 				return true;
 			}
-			
+
 			return false;
 		}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -194,6 +194,8 @@ if ( class_exists( 'GFForms' ) ) {
 			add_filter( 'gform_enqueue_scripts', array( $this, 'filter_gform_enqueue_scripts' ), 10, 2 );
 			add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_variables' ), 10, 7 );
 
+			add_filter( 'gform_is_value_match', array( $this, 'filter_value_match_multiuser'), 10, 6 );
+
 			add_action( 'gform_entry_created', array( $this, 'action_entry_created' ), 8, 2 );
 			add_action( 'gform_register_init_scripts', array( $this, 'filter_gform_register_init_scripts' ), 10, 3 );
 			add_action( 'wp_login', array( $this, 'filter_wp_login' ), 10, 2 );
@@ -7637,6 +7639,26 @@ AND m.meta_value='queued'";
 			$do_action = ( $logic['logicType'] == 'all' && $match_count == sizeof( $logic['rules'] ) ) || ( $logic['logicType'] == 'any' && $match_count > 0 );
 
 			return $do_action;
+		}
+
+		/**
+		 * Determines if a multiuser field is being used for conditional routing and has an exact value match of user ID
+		 * 
+		 * @since 2.5
+		 *
+		 * @return bool
+		 */
+		public function filter_value_match_multiuser( $is_match, $field_value, $target_value, $operation, $source_field, $rule ) {
+			
+			if ( $source_field->type !== 'workflow_multi_user' ) {
+				return $is_match;
+			}
+
+			if( in_array( $target_value, $field_value, true ) ) {
+				return true;
+			}
+			
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
Refer to HS 7547

This PR resolves an issue where conditional routing with a multi-user field could lead to incorrect number of assignees being set for a step. The default GForms value match for 'contains' logic type would return true for potential route of selected User ID of 1 with a multiuser field containing selection of user ID 10.

**Testing Instructions**

- Create a form with a multiuser field
- Ensure your site has 10+ users
- Create an approval step with conditional routing for soft matching user IDs (2 & 22, 7 & 57, etc)
- Submit the form and select the larger user ID by name
- Verify that the step has been assigned to more users than is expected
- Switch to the PR branch and restart the step
- Verify that only the expected users have been set as assignee