### PR TITLE
Fix inbox excess entries page size limit

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
 - Fixed the Gravity Perks Nested Forms Add-On integration not delaying the workflow for child entries created before the parent form is submitted.
 - Fixed an issue where Conditional Routing based on what values a Multiuser field contains could lead to extra users being set as step assignees.
 - Fixed conditional assignee routing using the post category field.
+- Fixed the inbox page excess entries indicator displaying a limit of 150 when the page size has been changed using the gravityflow_inbox_paging filter.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -61,10 +61,12 @@ class Gravity_Flow_Inbox {
 			</table>
 
 			<?php
-			if ( $total_count > 150 ) {
+			$page_size = (int) rgar( Gravity_Flow_API::get_inbox_paging( $args ), 'page_size', 20 );
+
+			if ( $total_count > $page_size ) {
 				echo '<br />';
 				echo '<div class="excess_entries_indicator">';
-				printf( '(Showing 150 of %d)', absint( $total_count ) );
+				printf( '(Showing %d of %d)', $page_size, absint( $total_count ) );
 				echo '</div>';
 			}
 		} else {


### PR DESCRIPTION
re: [HS#7586](https://secure.helpscout.net/conversation/748963379/7586?folderId=1113535)

Fixes an issue where the inbox page excess entries indicator continues to display the limit as 150 when the page size has been changed using the gravityflow_inbox_paging filter.

## Testing
- Without the filter check that the Gravity Flow default limit of 150 is displayed
- Add the filter setting a custom limit and then check that the limit is updated on the inbox page
  ```
  add_filter( 'gravityflow_inbox_paging', function() {
      return array( 'offset' => 0, 'page_size' => 30 );
  } ); 
  ```
- Add the filter without the page_size arg and then check that a limit of 20 is displayed which matches the default page size used by GFAPI::get_entries()
  ```
  add_filter( 'gravityflow_inbox_paging', function() {
      return array( 'offset' => 0 );
  } ); 
  ```