### PR TITLE
Fix issue with GFlow API get_timeline

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Fixed an issue where Conditional Routing based on what values a Multiuser field contains could lead to extra users being set as step assignees.
 - Fixed conditional assignee routing using the post category field.
 - Fixed the inbox page excess entries indicator displaying a limit of 150 when the page size has been changed using the gravityflow_inbox_paging filter.
+- Fixed an issue where the API function get_timeline would not return all expected timeline values

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -273,7 +273,9 @@ class Gravity_Flow_API {
 	 * @return string
 	 */
 	public function get_timeline( $entry ) {
-		return gravity_flow()->get_timeline( $entry );
+
+		return Gravity_Flow_Common::get_timeline( $entry );
+
 	}
 
 	/**

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -220,6 +220,8 @@ class Gravity_Flow_Common {
 	 *
 	 * @since 1.7.1-dev
 	 *
+	 * @param array $entry The entry to display timeline of.
+	 *
 	 * @return string
 	 */
 	public static function get_timeline( $entry = false ) {
@@ -259,7 +261,7 @@ class Gravity_Flow_Common {
 	 *
 	 * @return string
 	 */
-	static function format_note( $note_value, $display_name, $date ) {
+	public static function format_note( $note_value, $display_name, $date ) {
 		$separator = $display_name && $date ? ': ' : '';
 
 		return sprintf( "%s%s%s\n%s", $display_name, $separator, $date, $note_value );

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -216,6 +216,56 @@ class Gravity_Flow_Common {
 	}
 
 	/**
+	 * Get the content which will replace the {workflow_timeline} merge tag and response for Gravity Flow API get_timeline.
+	 *
+	 * @since 1.7.1-dev
+	 *
+	 * @return string
+	 */
+	public static function get_timeline( $entry = false ) {
+
+		if ( empty( $entry ) ) {
+			return '';
+		}
+
+		$notes = Gravity_Flow_Common::get_timeline_notes( $entry );
+
+		if ( empty( $notes ) ) {
+			return '';
+		}
+
+		$return = array();
+
+		foreach ( $notes as $note ) {
+			$step = Gravity_Flow_Common::get_timeline_note_step( $note );
+			$name = Gravity_Flow_Common::get_timeline_note_display_name( $note, $step );
+			$date = Gravity_Flow_Common::format_date( $note->date_created, '', false, true );
+
+			$return[] = Gravity_Flow_Common::format_note( $note->value, $name, $date );
+		}
+
+		return implode( "\n\n", $return );
+
+	}
+
+	/**
+	 * Format a note for output.
+	 *
+	 * @since 1.7.1-dev
+	 *
+	 * @param string $note_value   The note value.
+	 * @param string $display_name The note display name.
+	 * @param string $date         The note creation date.
+	 *
+	 * @return string
+	 */
+	static function format_note( $note_value, $display_name, $date ) {
+		$separator = $display_name && $date ? ': ' : '';
+
+		return sprintf( "%s%s%s\n%s", $display_name, $separator, $date, $note_value );
+	}
+
+	/**
 	 * Get the timeline notes for the current entry.
 	 *
 	 * @since 1.7.1-dev

--- a/includes/merge-tags/class-merge-tag-workflow-note.php
+++ b/includes/merge-tags/class-merge-tag-workflow-note.php
@@ -77,7 +77,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 						$name = $a['display_name'] ? self::get_assignee_display_name( $note['assignee_key'] ) : '';
 						$date = $a['display_date'] ? Gravity_Flow_Common::format_date( $note['timestamp'], '', false, true ) : '';
 
-						$replacement_array[] = self::format_note( $note['value'], $name, $date );
+						$replacement_array[] = Gravity_Flow_Common::format_note( $note['value'], $name, $date );
 					}
 
 					$replacement = $this->format_value( implode( "\n\n", $replacement_array ) );

--- a/includes/merge-tags/class-merge-tag-workflow-note.php
+++ b/includes/merge-tags/class-merge-tag-workflow-note.php
@@ -163,23 +163,6 @@ class Gravity_Flow_Merge_Tag_Workflow_Note extends Gravity_Flow_Merge_Tag {
 	}
 
 	/**
-	 * Format a note for output.
-	 *
-	 * @since 1.7.1-dev
-	 *
-	 * @param string $note_value   The note value.
-	 * @param string $display_name The note display name.
-	 * @param string $date         The note creation date.
-	 *
-	 * @return string
-	 */
-	protected function format_note( $note_value, $display_name, $date ) {
-		$separator = $display_name && $date ? ': ' : '';
-
-		return sprintf( "%s%s%s\n%s", $display_name, $separator, $date, $note_value );
-	}
-
-	/**
 	 * Get the assignee display name.
 	 *
 	 * @since 1.7.1-dev

--- a/includes/merge-tags/class-merge-tag-workflow-timeline.php
+++ b/includes/merge-tags/class-merge-tag-workflow-timeline.php
@@ -59,46 +59,13 @@ class Gravity_Flow_Merge_Tag_Workflow_Timeline extends Gravity_Flow_Merge_Tag_Wo
 
 		if ( is_array( $matches ) && isset( $matches[0] ) ) {
 			$full_tag = $matches[0][0];
-			$timeline = $this->get_timeline();
+			$timeline = Gravity_Flow_Common::get_timeline( $this->entry );
 			$text     = str_replace( $full_tag, $this->format_value( $timeline ), $text );
 		}
 
 		return $text;
 	}
 
-	/**
-	 * Get the content which will replace the {workflow_timeline} merge tag.
-	 *
-	 * @since 1.7.1-dev
-	 *
-	 * @return string
-	 */
-	protected function get_timeline() {
-
-		if ( empty( $this->entry ) ) {
-			return '';
-		}
-
-		$entry = $this->entry;
-
-		$notes = Gravity_Flow_Common::get_timeline_notes( $entry );
-
-		if ( empty( $notes ) ) {
-			return '';
-		}
-
-		$return = array();
-
-		foreach ( $notes as $note ) {
-			$step = Gravity_Flow_Common::get_timeline_note_step( $note );
-			$name = Gravity_Flow_Common::get_timeline_note_display_name( $note, $step );
-			$date = Gravity_Flow_Common::format_date( $note->date_created, '', false, true );
-
-			$return[] = $this->format_note( $note->value, $name, $date );
-		}
-
-		return implode( "\n\n", $return );
-	}
 }
 
 Gravity_Flow_Merge_Tags::register( new Gravity_Flow_Merge_Tag_Workflow_Timeline );

--- a/includes/merge-tags/class-merge-tags.php
+++ b/includes/merge-tags/class-merge-tags.php
@@ -52,7 +52,6 @@ class Gravity_Flow_Merge_Tags {
 			throw new Exception( 'The name property must be set' );
 		}
 
-
 		self::$class_names[ $merge_tag->name ] = get_class( $merge_tag );
 	}
 


### PR DESCRIPTION
See HS#7892
A call to $api->get_timeline results in an undefined method error.

This PR resolves that issue by bringing functions from Gravity_Flow_Merge_Tag_Workflow_Timeline up to Gravity_Flow_Common to enable the api call to use them as well.

**To Test:**
* Add the following to a theme template page or other appropriate location.
* Modify form ID / entry ID to match your test environment
* Run with master branch and receive an undefined method error
* Switch to 7892-get-timeline branch and note that error is resolved.

```
$form_id = 11;
$entry_id = 14;

$entry = GFAPI::get_entry( $entry_id );
$api = new Gravity_Flow_API( $form_id );

$timeline = $api->get_timeline( $entry );
echo '<h1>API Timeline</h1>' . str_replace( "\n", "<br/>", $timeline );
$merge_tag = GFCommon::replace_variables( '{workflow_timeline}', $form_id, $entry );
echo '<h1>Merge Tag Timeline</h1>' . $merge_tag;
```