### PR TITLE
Delay triggering child workflow on parent submission until after perks have updated the entry

### DIFF
--- a/includes/integrations/class-gp-nested-forms.php
+++ b/includes/integrations/class-gp-nested-forms.php
@@ -241,7 +241,7 @@ class Gravity_Flow_GP_Nested_Forms {
 			'filter_gravityflow_is_delayed_pre_process_workflow'
 		) );
 
-		add_action( 'gform_entry_created', array( $this, 'action_entry_created' ), 8, 2 );
+		add_action( 'gform_after_submission', array( $this, 'action_after_submission' ), 10, 2 );
 
 		$this->maybe_add_detail_page_hooks();
 	}
@@ -623,7 +623,7 @@ class Gravity_Flow_GP_Nested_Forms {
 	 * @param array $entry The parent entry.
 	 * @param array $form The parent form.
 	 */
-	public function action_entry_created( $entry, $form ) {
+	public function action_after_submission( $entry, $form ) {
 		if ( gp_nested_forms()->is_nested_form_submission() ) {
 			return;
 		}


### PR DESCRIPTION
re: [HS#7446](https://secure.helpscout.net/conversation/734794694/7446?folderId=1113535#thread-2100372024)

Delays triggering the workflow for child submissions by switching from the gform_entry_created hook to the gform_after_submission hook. This resolves a timing issue where the workflow was being triggered before perks such as Nested Forms and Unique ID have updated the child entry on the gform_entry_created (NF) and gform_entry_post_save (UID) hooks.

Test forms and instructions in the ticket note from Subrato