### PR TITLE
Add due date step setting

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1289,20 +1289,20 @@ PRIMARY KEY  (id)
 				}
 				$status_options = $step_class->get_status_config();
 
-				if ( $step_class->supports_duedate() ) {
+				if ( $step_class->supports_due_date() ) {
 					$final_status_choices = array();
 
 					foreach ( $status_options as $status_option ) {
 						$final_status_choices[] = array( 'label' => $status_option['status_label'], 'value' => $status_option['status'] );
 					}
 
-					$final_status_choices[] = array( 'label' => esc_html__( 'Due date', 'gravityflow' ), 'value' => 'duedate' );
+					$final_status_choices[] = array( 'label' => esc_html__( 'Due date', 'gravityflow' ), 'value' => 'due_date' );
 
 					$step_settings['fields'][] = array(
-						'name' => 'duedate',
+						'name' => 'due_date',
 						'label' => esc_html__( 'Due date', 'gravityflow' ),
-						'tooltip' => esc_html__( 'Enable the due date setting to allow this step to highlight upcoming due dates. Once past the due date the entry will be highlighted to show  it has past the due date.', 'gravityflow' ),
-						'type'       => 'duedate',
+						'tooltip' => esc_html__( 'Enable the due date setting to allow entries to be highlighted when they have passed their due dates. A notification can also be configured to be sent for overdue entries.', 'gravityflow' ),
+						'type'       => 'due_date',
 						'status_choices' => $final_status_choices,
 					);
 				}
@@ -2021,27 +2021,28 @@ PRIMARY KEY  (id)
 		 *
 		 * @param array $field The field properties.
 		 */
-		public function settings_duedate( $field ) {
+		public function settings_due_date( $field ) {
 
 			$form = $this->get_current_form();
 
-			$duedate = array(
-				'name' => 'duedate',
+			$due_date = array(
+				'name' => 'due_date',
 				'type' => 'checkbox',
 				'choices' => array(
 					array(
-						'label' => esc_html__( 'Set due date', 'gravityflow' ),
-						'name' => 'duedate',
+						'label' => esc_html__( 'Schedule due date', 'gravityflow' ),
+						'name' => 'due_date',
 					),
 				),
 			);
 
-			$duedate_type = array(
-				'name' => 'duedate_type',
-				'type' => 'radio',
-				'horizontal' => true,
+			$due_date_type = array(
+				'name'          => 'due_date_type',
+				'type'          => 'radio',
+				'horizontal'    => true,
 				'default_value' => 'delay',
-				'choices' => array(
+				'required'      => true,
+				'choices'       => array(
 					array(
 						'label' => esc_html__( 'Delay', 'gravityflow' ),
 						'value' => 'delay',
@@ -2058,43 +2059,46 @@ PRIMARY KEY  (id)
 			$date_field_choices = array();
 
 			if ( ! empty( $date_fields ) ) {
-				$duedate_type['choices'][] = array(
+				$due_date_type['choices'][] = array(
 					'label' => esc_html__( 'Date Field', 'gravityflow' ),
 					'value' => 'date_field',
 				);
-
 
 				foreach ( $date_fields  as $date_field ) {
 					$date_field_choices[] = array( 'value' => $date_field->id, 'label' => GFFormsModel::get_label( $date_field ) );
 				}
 			}
 
-			$duedate_date_fields = array(
-				'name' => 'duedate_date_field',
-				'label' => esc_html__( 'Due Date Field', 'gravityflow' ),
-				'choices' => $date_field_choices,
+			$due_date_date_fields = array(
+				'name'     => 'due_date_date_field',
+				'label'    => esc_html__( 'Due Date Field', 'gravityflow' ),
+				'choices'  => $date_field_choices,
 			);
 
-			$duedate_date = array(
-				'id' => 'duedate_date',
-				'name' => 'duedate_date',
+			$due_date_date = array(
+				'id'          => 'due_date_date',
+				'name'        => 'due_date_date',
 				'placeholder' => 'yyyy-mm-dd',
-				'class' => 'datepicker datepicker_with_icon ymd_dash',
-				'label' => esc_html__( 'Due Date', 'gravityflow' ),
-				'type' => 'text',
+				'class'       => 'datepicker datepicker_with_icon ymd_dash',
+				'label'       => esc_html__( 'Due Date', 'gravityflow' ),
+				'type'        => 'text',
+				'required'    => true,
+
 			);
 
 			$delay_offset_field = array(
-				'name' => 'duedate_delay_offset',
-				'class' => 'small-text',
-				'label' => esc_html__( 'Due Date', 'gravityflow' ),
-				'type' => 'text',
+				'name'      => 'due_date_delay_offset',
+				'class'     => 'small-text',
+				'required'  => true,
+				'label'     => esc_html__( 'Due Date', 'gravityflow' ),
+				'type'      => 'text',
 			);
 
 			$unit_field = array(
-				'name' => 'duedate_delay_unit',
+				'name' => 'due_date_delay_unit',
 				'label' => esc_html__( 'Due Date', 'gravityflow' ),
 				'default_value' => 'hours',
+				'required'      => true,
 				'choices' => array(
 					array(
 						'label' => esc_html__( 'Minute(s)', 'gravityflow' ),
@@ -2116,56 +2120,57 @@ PRIMARY KEY  (id)
 			);
 
 			
-			$duedate_highlight = array(
-				'name'     => 'duedate_highlight',
+			$due_date_highlight = array(
+				'name'     => 'due_date_highlight',
 				'type'     => 'checkbox',
 				'choices'  => array(
 					array(
 						'label'         => esc_html__( 'Highlight overdue entries', 'gravityflow' ),
-						'name'          => 'duedate_highlight',
+						'name'          => 'due_date_highlight',
 					),
 				),
 			);
 			
-			$duedate_highlight_type = array(
-				'name'           => 'duedate_highlight_type',
+			$due_date_highlight_type = array(
+				'name'           => 'due_date_highlight_type',
 				'type'           => 'hidden',
 				'default_value'  => 'color',
 				'required'       => true,
 			);
 
-			$duedate_highlight_color = array(
-				'name'                => 'duedate_highlight_color',
-				'id'                  => 'duedate_highlight_color',
-				'class'               => 'small-text',
-				'label'               => esc_html__( 'Color', 'gravityflow' ),
-				'type'                => 'text',
-				'default_value'       => '#dd3333',
+			$due_date_highlight_color = array(
+				'name'          => 'due_date_highlight_color',
+				'id'            => 'due_date_highlight_color',
+				'class'         => 'small-text',
+				'label'         => esc_html__( 'Color', 'gravityflow' ),
+				'type'          => 'text',
+				'default_value' => '#dd3333',
+				'required'      => true,
 			);
-			
-			$this->settings_checkbox( $duedate );
 
-			$enabled = $this->get_setting( 'duedate', false );
-			$duedate_type_setting = $this->get_setting( 'duedate_type', 'delay' );
-			$duedate_style = $enabled ? '' : 'style="display:none;"';
-			$duedate_date_style = ( $duedate_type_setting == 'date' ) ? '' : 'style="display:none;"';
-			$duedate_delay_style = ( $duedate_type_setting == 'delay' ) ? '' : 'style="display:none;"';
-			$duedate_date_fields_style = ( $duedate_type_setting == 'date_field' ) ? '' : 'style="display:none;"';
+			$this->settings_checkbox( $due_date );
+
+			$enabled = $this->get_setting( 'due_date', false );
+			$due_date_type_setting = $this->get_setting( 'due_date_type', 'delay' );
+			$due_date_style = $enabled ? '' : 'style="display:none;"';
+			$due_date_date_style = ( $due_date_type_setting == 'date' ) ? '' : 'style="display:none;"';
+			$due_date_delay_style = ( $due_date_type_setting == 'delay' ) ? '' : 'style="display:none;"';
+			$due_date_date_fields_style = ( $due_date_type_setting == 'date_field' ) ? '' : 'style="display:none;"';
 
 			?>
-			<div class="gravityflow-duedate-settings" <?php echo $duedate_style; ?> >
-				<div class="gravityflow-duedate-type-container" class="gravityflow-sub-setting">
-					<?php $this->settings_radio( $duedate_type ); ?>
+			<div class="gravityflow-due-date-settings" <?php echo $due_date_style; ?> >
+				<div class="gravityflow-due-date-type-container" class="gravityflow-sub-setting">
+					<?php $this->settings_radio( $due_date_type ); ?>
 				</div>
-				<div class="gravityflow-duedate-date-container" <?php echo $duedate_date_style; ?> >
+				<div class="gravityflow-due-date-date-container" <?php echo $due_date_date_style; ?> >
 					<?php
 					esc_html_e( 'This step has a due date on', 'gravityflow' );
 					echo '&nbsp;';
-					$this->settings_text( $duedate_date );
+					$this->settings_text( $due_date_date );
 					?>
 					<input type="hidden" id="gforms_calendar_icon_expiration_date" class="gform_hidden" value="<?php echo GFCommon::get_base_url() . '/images/calendar.png'; ?>" />
 				</div>
-				<div class="gravityflow-duedate-delay-container" <?php echo $duedate_delay_style; ?> class="gravityflow-sub-setting">
+				<div class="gravityflow-due-date-delay-container" <?php echo $due_date_delay_style; ?> class="gravityflow-sub-setting">
 					<?php
 					esc_html_e( 'This step has a due date on', 'gravityflow' );
 					echo '&nbsp;';
@@ -2175,18 +2180,18 @@ PRIMARY KEY  (id)
 					esc_html_e( 'after the workflow step has started.' );
 					?>
 				</div>
-				<div class="gravityflow-duedate-date-field-container" <?php echo $duedate_date_fields_style ?>>
+				<div class="gravityflow-due-date-date-field-container" <?php echo $due_date_date_fields_style; ?>>
 					<?php
 					esc_html_e( 'Due date for this step', 'gravityflow' );
 					echo '&nbsp;';
-					$delay_offset_field['name'] = 'duedate_date_field_offset';
+					$delay_offset_field['name'] = 'due_date_date_field_offset';
 					$delay_offset_field['default_value'] = '0';
 					$this->settings_text( $delay_offset_field );
-					$unit_field['name'] = 'duedate_date_field_offset_unit';
+					$unit_field['name'] = 'due_date_date_field_offset_unit';
 					$this->settings_select( $unit_field );
 					echo '&nbsp;';
 					$before_after_field = array(
-						'name' => 'duedate_date_field_before_after',
+						'name' => 'due_date_date_field_before_after',
 						'label' => esc_html__( 'Due Date', 'gravityflow' ),
 						'default_value' => 'after',
 						'choices' => array(
@@ -2202,27 +2207,26 @@ PRIMARY KEY  (id)
 					);
 					$this->settings_select( $before_after_field );
 
-					$this->settings_select( $duedate_date_fields );
+					$this->settings_select( $due_date_date_fields );
 
 					?>
 				</div>
+				<div class="gravityflow-due-date-highlight-field-container">
+					<?php 
+					$this->settings_checkbox( $due_date_highlight );
 
-				<div class="gravityflow-duedate-date-field-container">
-					<?php //$this->settings_step_highlight( $duedate_highlight ); 
-					$this->settings_checkbox( $duedate_highlight );
-
-					$enabled = $this->get_setting( 'duedate_highlight', false );
-					$duedate_highlight_style = $enabled ? '' : 'style="display:none;"';
-					$duedate_highlight_type_setting = $this->get_setting( 'duedate_highlight_type', 'color' );
-					$duedate_highlight_color_style = ( $duedate_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';
+					$enabled = $this->get_setting( 'due_date_highlight', false );
+					$due_date_highlight_style = $enabled ? '' : 'style="display:none;"';
+					$due_date_highlight_type_setting = $this->get_setting( 'due_date_highlight_type', 'color' );
+					$due_date_highlight_color_style = ( $due_date_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';
 					?>
-					<div class="gravityflow-duedate-highlight-settings" <?php echo $duedate_highlight_style; ?> >
-						<div class="gravityflow-duedate-highlight-type-container">
-							<?php $this->settings_hidden( $duedate_highlight_type ); ?>
+					<div class="gravityflow-due-date-highlight-settings" <?php echo $due_date_highlight_style; ?> >
+						<div class="gravityflow-due-date-highlight-type-container">
+							<?php $this->settings_hidden( $due_date_highlight_type ); ?>
 						</div>
-						<div class="gravityflow-duedate-highlight-color-container" <?php echo $duedate_highlight_color_style; ?> >
+						<div class="gravityflow-due-date-highlight-color-container" <?php echo $due_date_highlight_color_style; ?> >
 							<?php
-							$this->settings_text( $duedate_highlight_color );
+							$this->settings_text( $due_date_highlight_color );
 							?>
 						</div>
 					</div>
@@ -2230,29 +2234,29 @@ PRIMARY KEY  (id)
 			</div>
 			<script>
 				(function($) {
-					$( '#duedate' ).click(function(){
-						$('.gravityflow-duedate-settings').slideToggle();
+					$( '#due_date' ).click(function(){
+						$('.gravityflow-due-date-settings').slideToggle();
 					});
-					$( '#duedate_type0' ).click(function(){
-						$('.gravityflow-duedate-date-container').hide();
-						$('.gravityflow-duedate-delay-container').show();
-						$('.gravityflow-duedate-date-field-container').hide();
+					$( '#due_date_type0' ).click(function(){
+						$('.gravityflow-due-date-date-container').hide();
+						$('.gravityflow-due-date-delay-container').show();
+						$('.gravityflow-due-date-date-field-container').hide();
 					});
-					$( '#duedate_type1' ).click(function(){
-						$('.gravityflow-duedate-date-container').show();
-						$('.gravityflow-duedate-delay-container').hide();
-						$('.gravityflow-duedate-date-field-container').hide();
+					$( '#due_date_type1' ).click(function(){
+						$('.gravityflow-due-date-date-container').show();
+						$('.gravityflow-due-date-delay-container').hide();
+						$('.gravityflow-due-date-date-field-container').hide();
 					});
-					$( '#duedate_type2' ).click(function(){
-						$('.gravityflow-duedate-delay-container').hide();
-						$('.gravityflow-duedate-date-container').hide();
-						$('.gravityflow-duedate-date-field-container').show();
+					$( '#due_date_type2' ).click(function(){
+						$('.gravityflow-due-date-delay-container').hide();
+						$('.gravityflow-due-date-date-container').hide();
+						$('.gravityflow-due-date-date-field-container').show();
 					});
-					$( '#duedate_highlight' ).click(function(){
-						$('.gravityflow-duedate-highlight-settings').slideToggle();
+					$( '#due_date_highlight' ).click(function(){
+						$('.gravityflow-due-date-highlight-settings').slideToggle();
 					});
 					$(document).ready(function () {
-						$("#duedate_highlight_color").wpColorPicker();
+						$("#due_date_highlight_color").wpColorPicker();
 					});
 				})(jQuery);
 			</script>

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1290,20 +1290,11 @@ PRIMARY KEY  (id)
 				$status_options = $step_class->get_status_config();
 
 				if ( $step_class->supports_due_date() ) {
-					$final_status_choices = array();
-
-					foreach ( $status_options as $status_option ) {
-						$final_status_choices[] = array( 'label' => $status_option['status_label'], 'value' => $status_option['status'] );
-					}
-
-					$final_status_choices[] = array( 'label' => esc_html__( 'Due date', 'gravityflow' ), 'value' => 'due_date' );
-
 					$step_settings['fields'][] = array(
 						'name' => 'due_date',
 						'label' => esc_html__( 'Due date', 'gravityflow' ),
 						'tooltip' => esc_html__( 'Enable the due date setting to allow entries to be highlighted when they have passed their due dates. A notification can also be configured to be sent for overdue entries.', 'gravityflow' ),
 						'type'       => 'due_date',
-						'status_choices' => $final_status_choices,
 					);
 				}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3523,11 +3523,19 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			}
 
 			if ( false !== $current_step && $current_step instanceof Gravity_Flow_Step
+			     && $current_step->supports_due_date() && $current_step->due_date
+			) {
+				$gflow_due_date_date = Gravity_Flow_Common::format_date( $current_step->get_due_date_timestamp(), $date_format, false, true );
+				printf( '<br /><br />%s: %s', esc_html__( 'Due Date', 'gravityflow' ), $gflow_due_date_date );
+			}
+
+			if ( false !== $current_step && $current_step instanceof Gravity_Flow_Step
 			     && $current_step->supports_expiration() && $current_step->expiration
 			) {
-				$glfow_date = Gravity_Flow_Common::format_date( $current_step->get_expiration_timestamp(), $date_format, false, true );
-				printf( '<br /><br />%s: %s', esc_html__( 'Expires', 'gravityflow' ), $glfow_date );
+				$gflow_expiry_date = Gravity_Flow_Common::format_date( $current_step->get_expiration_timestamp(), $date_format, false, true );
+				printf( '<br /><br />%s: %s', esc_html__( 'Expires', 'gravityflow' ), $gflow_expiry_date );
 			}
+			
 
 			/**
 			 * Allows content to be added in the workflow box below the workflow status info.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4791,6 +4791,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'show_header'          => true,
 				'timeline'             => true,
 				'step_highlight'       => true,
+				'due_date'             => false,
 			);
 
 			$args = array_merge( $defaults, $args );
@@ -5628,6 +5629,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'    => true,
 				'sidebar'          => true,
 				'step_highlight'   => true,
+				'due_date'         => false,
 			);
 
 			return $defaults;
@@ -5680,6 +5682,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'workflow_info'        => $a['workflow_info'],
 				'sidebar'              => $a['sidebar'],
 				'step_highlight'       => $a['step_highlight'],
+				'due_date'             => $a['due_date'],
 			);
 
 			ob_start();
@@ -5763,6 +5766,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'step_status'        => $a['step_status'],
 				'workflow_info'      => $a['workflow_info'],
 				'sidebar'            => $a['sidebar'],
+				'due_date'           => $a['due_date'],
 			);
 
 			if ( isset( $a['form'] ) ) {

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -207,9 +207,10 @@ tr#gaddon-setting-row-step_type label > span > i {
 .gravityflow-expiration-type-container,
 .gravityflow-expiration-delay-container,
 .gravityflow-expiration-date-container,
-.gravityflow-duedate-type-container,
-.gravityflow-duedate-delay-container,
-.gravityflow-duedate-date-container{
+.gravityflow-due-date-type-container,
+.gravityflow-due-date-delay-container,
+.gravityflow-due-date-date-container,
+.gravityflow-due-date-highlight-color-container{
     margin: 10px 0 10px 0;
 }
 

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -206,7 +206,10 @@ tr#gaddon-setting-row-step_type label > span > i {
 .gravityflow-schedule-date-container,
 .gravityflow-expiration-type-container,
 .gravityflow-expiration-delay-container,
-.gravityflow-expiration-date-container{
+.gravityflow-expiration-date-container,
+.gravityflow-duedate-type-container,
+.gravityflow-duedate-delay-container,
+.gravityflow-duedate-date-container{
     margin: 10px 0 10px 0;
 }
 

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -358,7 +358,7 @@ class Gravity_Flow_Inbox {
 			case 'due_date':
 				$api = new Gravity_Flow_API( $form['id'] );
 				$step = $api->get_current_step( $entry );
-				if ( $step ) {
+				if ( $step && $step->due_date ) {
 					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 				}
 				break;

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -105,6 +105,7 @@ class Gravity_Flow_Inbox {
 			'field_ids'            => $field_ids,
 			'detail_base_url'      => admin_url( 'admin.php?page=gravityflow-inbox&view=entry' ),
 			'last_updated'         => false,
+			'due_date'             => false,
 			'step_highlight'       => true,
 		);
 
@@ -164,6 +165,10 @@ class Gravity_Flow_Inbox {
 
 		if ( $args['last_updated'] ) {
 			$columns['last_updated'] = __( 'Last Updated', 'gravityflow' );
+		}
+
+		if ( $args['due_date'] ) {
+			$columns['due_date'] = __( 'Due Date', 'gravityflow' );
 		}
 
 		/**
@@ -347,6 +352,14 @@ class Gravity_Flow_Inbox {
 				$value = rgar( $entry, 'payment_status' );
 				if ( gravity_flow()->is_gravityforms_supported( '2.4' ) ) {
 					$value = GFCommon::get_entry_payment_status_text( $value );
+				}
+				break;
+
+			case 'due_date':
+				$api = new Gravity_Flow_API( $form['id'] );
+				$step = $api->get_current_step( $entry );
+				if ( $step ) {
+					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, true );
 				}
 				break;
 			default:

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -237,6 +237,28 @@ class Gravity_Flow_Inbox {
 			}
 		}
 
+		$due_date_highlight_color = '';
+		if ( isset( $entry['workflow_step'] ) ) {
+			$step = gravity_flow()->get_step( $entry['workflow_step'] );
+			if ( $step ) {
+				$meta = $step->get_feed_meta();
+
+				if ( $meta && isset( $meta['due_date_highlight'] ) && $meta['due_date_highlight'] ) {
+					if ( isset( $meta['due_date_highlight_type'] ) && $meta['due_date_highlight_type'] == 'color' ) {
+						if ( isset( $meta['due_date_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
+							$due_date_highlight_color = $meta['due_date_highlight_color'];
+						}
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $due_date_highlight_color ) && ! empty( $due_date_highlight_color ) ) {
+			$step_highlight_color = $due_date_highlight_color;
+		} elseif ( ! empty( $due_date_highlight_color ) ) {
+			$step_highlight_color = $due_date_highlight_color;
+		}
+
 		/**
 		 * Allow the Step Highlight colour to be overridden.
 		 *

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -359,7 +359,7 @@ class Gravity_Flow_Inbox {
 				$api = new Gravity_Flow_API( $form['id'] );
 				$step = $api->get_current_step( $entry );
 				if ( $step ) {
-					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, true );
+					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 				}
 				break;
 			default:

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1051,12 +1051,13 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		if ( $step_id > 0 ) {
 			$step = gravity_flow()->get_step( $step_id );
 			$step->_entry = $item;
-			if ( $step ) {
+			if ( $step && $step->due_date ) {
 				$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
+				$link  = "<a href='#'>$value</a>";
+				$output = $link;
+			} else {
+				$output = '<span class="gravityflow-empty">&dash;</span>';
 			}
-
-			$link  = "<a href='#'>$value</a>";
-			$output = $link;
 		} else {
 			$output = '<span class="gravityflow-empty">&dash;</span>';
 		}

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1051,8 +1051,9 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		if ( $step_id > 0 ) {
 			$step      = gravity_flow()->get_step( $step_id );
 			if ( $step ) {
-				$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, true );
+				$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 			}
+			
 			$link  = "<a href='#'>$value</a>";
 			$output = $link;
 		} else {

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -67,6 +67,7 @@ class Gravity_Flow_Status {
 			'status_column'        => true,
 			'last_updated'         => false,
 			'filter_hidden_fields' => array(),
+			'due_date'             => false,
 		);
 	}
 
@@ -335,6 +336,15 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	public $last_updated;
 
 	/**
+	 * Should the due date column be displayed?
+	 *
+	 * @since 2.5
+	 *
+	 * @var bool
+	 */
+	public $due_date;
+
+	/**
 	 * A cache of previously retrieved forms.
 	 *
 	 * @var array
@@ -371,6 +381,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			'step_column'        => true,
 			'status_column'      => true,
 			'last_updated'       => false,
+			'due_date'           => false,
 		);
 
 		$args = wp_parse_args( $args, $default_args );
@@ -406,6 +417,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$this->submitter_column = $args['submitter_column'];
 		$this->status_column = $args['status_column'];
 		$this->last_updated = $args['last_updated'];
+		$this->due_date = $args['due_date'];
 	}
 
 	/**
@@ -1030,6 +1042,27 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Outputs the current step due date.
+	 *
+	 * @param array $item The current entry.
+	 */
+	public function column_due_date( $item ) {
+		$step_id = rgar( $item, 'workflow_step' );
+		if ( $step_id > 0 ) {
+			$step      = gravity_flow()->get_step( $step_id );
+			if ( $step ) {
+				$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, true );
+			}
+			$link  = "<a href='#'>$value</a>";
+			$output = $link;
+		} else {
+			$output = '<span class="gravityflow-empty">&dash;</span>';
+		}
+
+		echo $output;
+	}
+
+	/**
 	 * Outputs the entry payment status.
 	 *
 	 * @since 2.2.4-dev
@@ -1189,6 +1222,10 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		if ( $this->last_updated ) {
 			$columns['workflow_timestamp'] = esc_html__( 'Last Updated', 'gravityflow' );
+		}
+
+		if ( $this->due_date ) {
+			$columns['due_date'] = esc_html__( 'Due Date', 'gravityflow' );
 		}
 
 		/**

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -2042,6 +2042,17 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 					}
 				} else {
 					switch ( $column_key ) {
+						case 'due_date':
+							$step_id = rgar( $item, 'workflow_step' );
+							if ( $step_id > 0 ) {
+								$step = gravity_flow()->get_step( $step_id );
+								$step->_entry = $item;
+								if ( $step && $step->due_date ) {
+									$col_val = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
+								}
+							}
+							break;
+
 						case 'duration':
 							if ( $item['workflow_final_status'] == 'pending' ) {
 								$duration     = time() - strtotime( $item['date_created'] );

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1049,11 +1049,12 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 	public function column_due_date( $item ) {
 		$step_id = rgar( $item, 'workflow_step' );
 		if ( $step_id > 0 ) {
-			$step      = gravity_flow()->get_step( $step_id );
+			$step = gravity_flow()->get_step( $step_id );
+			$step->_entry = $item;
 			if ( $step ) {
 				$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 			}
-			
+
 			$link  = "<a href='#'>$value</a>";
 			$output = $link;
 		} else {

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -146,6 +146,17 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	}
 
 	/**
+	 * Indicates this step supports due date.
+	 *
+	 * @since 2.5
+	 *
+	 * @return bool
+	 */
+	public function supports_duedate() {
+		return true;
+	}
+
+	/**
 	 * Indicates this step supports expiration.
 	 *
 	 * @return bool
@@ -316,6 +327,21 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 				) ),
 			);
 
+		}
+
+		if ( $this->get_setting( 'duedate' ) ) {
+			$notification_tabs['tabs'][] = array(
+				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
+				'id'     => 'tab_duedate_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'name_prefix'      => 'duedate',
+					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
+					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
+					'send_to_fields'   => true,
+					'resend_field'     => false,
+				) ),
+			);
 		}
 
 		$settings['fields'][] = $notification_tabs;
@@ -920,6 +946,16 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	 */
 	public function send_revert_notification() {
 		$this->maybe_send_notification( 'revert' );
+	}
+
+	/**
+	 * Triggers sending of the due date notification.
+	 *
+	 * @since 2.5
+	 *
+	 */
+	public function send_duedate_notification() {
+		$this->maybe_send_notification( 'duedate' );
 	}
 
 	/**

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -152,7 +152,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	 *
 	 * @return bool
 	 */
-	public function supports_duedate() {
+	public function supports_due_date() {
 		return true;
 	}
 
@@ -329,15 +329,15 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 
 		}
 
-		if ( $this->get_setting( 'duedate' ) ) {
+		if ( $this->get_setting( 'due_date' ) ) {
 			$notification_tabs['tabs'][] = array(
-				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
-				'id'     => 'tab_duedate_notification',
+				'label'  => __( 'Overdue Email', 'gravityflow' ),
+				'id'     => 'tab_due_date_notification',
 				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'duedate',
+					'name_prefix'      => 'due_date',
 					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
 					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
-					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} should be completed as soon as possible.', 'gravityflow' ),
 					'send_to_fields'   => true,
 					'resend_field'     => false,
 				) ),
@@ -954,8 +954,8 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 	 * @since 2.5
 	 *
 	 */
-	public function send_duedate_notification() {
-		$this->maybe_send_notification( 'duedate' );
+	public function send_due_date_notification() {
+		$this->maybe_send_notification( 'due_date' );
 	}
 
 	/**

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -329,21 +329,6 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 
 		}
 
-		if ( $this->get_setting( 'due_date' ) ) {
-			$notification_tabs['tabs'][] = array(
-				'label'  => __( 'Overdue Email', 'gravityflow' ),
-				'id'     => 'tab_due_date_notification',
-				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'due_date',
-					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
-					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
-					'default_message'  => __( 'Entry {entry_id} should be completed as soon as possible.', 'gravityflow' ),
-					'send_to_fields'   => true,
-					'resend_field'     => false,
-				) ),
-			);
-		}
-
 		$settings['fields'][] = $notification_tabs;
 		$settings['fields'][] = $note_mode_setting;
 

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -52,6 +52,17 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	}
 
 	/**
+	 * Indicates this step supports due date.
+	 *
+	 * @since 2.5
+	 *
+	 * @return bool
+	 */
+	public function supports_duedate() {
+		return true;
+	}
+
+	/**
 	 * Indicates this step can expire without user input.
 	 *
 	 * @return bool
@@ -155,6 +166,56 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			}
 		}
 
+		$notification_tabs = array(
+			array(
+				'label'  => __( 'Assignee Email', 'gravityflow' ),
+				'id'     => 'tab_assignee_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'checkbox_default_value' => true,
+					'default_message'        => __( 'A new entry requires your input.', 'gravityflow' ),
+				) ),
+			),
+			array(
+				'label'  => __( 'In Progress Email', 'gravityflow' ),
+				'id'     => 'tab_in_progress_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'name_prefix'      => 'in_progress',
+					'checkbox_label'   => __( 'Send email when the step is in progress.', 'gravityflow' ),
+					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is updated but the step is not completed.', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} has been updated and remains in progress.', 'gravityflow' ),
+					'send_to_fields'   => true,
+					'resend_field'     => false,
+				) ),
+			),
+			array(
+				'label'  => __( 'Complete Email', 'gravityflow' ),
+				'id'     => 'tab_complete_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'name_prefix'      => 'complete',
+					'checkbox_label'   => __( 'Send email when the step is complete.', 'gravityflow' ),
+					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is updated completing the step.', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} has been updated completing the step.', 'gravityflow' ),
+					'send_to_fields'   => true,
+					'resend_field'     => false,
+				) ),
+			),
+		);
+
+		if ( $this->get_setting( 'duedate' ) ) {
+			$notification_tabs[] = array(
+				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
+				'id'     => 'tab_duedate_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'name_prefix'      => 'duedate',
+					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
+					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
+					'send_to_fields'   => true,
+					'resend_field'     => false,
+				) ),
+			);
+		}
+
 		$settings2 = array(
 			array(
 				'name'     => 'highlight_editable_fields',
@@ -215,42 +276,24 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 					),
 				),
 			),
-			$settings_api->get_setting_notification_tabs( array(
-				array(
-					'label'  => __( 'Assignee Email', 'gravityflow' ),
-					'id'     => 'tab_assignee_notification',
-					'fields' => $settings_api->get_setting_notification( array(
-						'checkbox_default_value' => true,
-						'default_message'        => __( 'A new entry requires your input.', 'gravityflow' ),
-					) ),
-				),
-				array(
-					'label'  => __( 'In Progress Email', 'gravityflow' ),
-					'id'     => 'tab_in_progress_notification',
-					'fields' => $settings_api->get_setting_notification( array(
-						'name_prefix'      => 'in_progress',
-						'checkbox_label'   => __( 'Send email when the step is in progress.', 'gravityflow' ),
-						'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is updated but the step is not completed.', 'gravityflow' ),
-						'default_message'  => __( 'Entry {entry_id} has been updated and remains in progress.', 'gravityflow' ),
-						'send_to_fields'   => true,
-						'resend_field'     => false,
-					) ),
-				),
-				array(
-					'label'  => __( 'Complete Email', 'gravityflow' ),
-					'id'     => 'tab_complete_notification',
-					'fields' => $settings_api->get_setting_notification( array(
-						'name_prefix'      => 'complete',
-						'checkbox_label'   => __( 'Send email when the step is complete.', 'gravityflow' ),
-						'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is updated completing the step.', 'gravityflow' ),
-						'default_message'  => __( 'Entry {entry_id} has been updated completing the step.', 'gravityflow' ),
-						'send_to_fields'   => true,
-						'resend_field'     => false,
-					) ),
-				),
-			) ),
+			$settings_api->get_setting_notification_tabs( $notification_tabs ),
 			$settings_api->get_setting_confirmation_messasge( esc_html__( 'Thank you.', 'gravityflow' ) ),
 		);
+
+		if ( $this->get_setting( 'duedate' ) ) {
+			$notification_tabs['tabs'][] = array(
+				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
+				'id'     => 'tab_duedate_notification',
+				'fields' => $settings_api->get_setting_notification( array(
+					'name_prefix'      => 'duedate',
+					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
+					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
+					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
+					'send_to_fields'   => true,
+					'resend_field'     => false,
+				) ),
+			);
+		}
 
 		$settings['fields'] = array_merge( $settings['fields'], $settings2 );
 

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -201,21 +201,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			),
 		);
 
-		if ( $this->get_setting( 'due_date' ) ) {
-			$notification_tabs[] = array(
-				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
-				'id'     => 'tab_due_date_notification',
-				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'due_date',
-					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
-					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
-					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
-					'send_to_fields'   => true,
-					'resend_field'     => false,
-				) ),
-			);
-		}
-
 		$settings2 = array(
 			array(
 				'name'     => 'highlight_editable_fields',
@@ -279,21 +264,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			$settings_api->get_setting_notification_tabs( $notification_tabs ),
 			$settings_api->get_setting_confirmation_messasge( esc_html__( 'Thank you.', 'gravityflow' ) ),
 		);
-
-		if ( $this->get_setting( 'due_date' ) ) {
-			$notification_tabs['tabs'][] = array(
-				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
-				'id'     => 'tab_due_date_notification',
-				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'due_date',
-					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
-					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
-					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
-					'send_to_fields'   => true,
-					'resend_field'     => false,
-				) ),
-			);
-		}
 
 		$settings['fields'] = array_merge( $settings['fields'], $settings2 );
 

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -58,7 +58,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	 *
 	 * @return bool
 	 */
-	public function supports_duedate() {
+	public function supports_due_date() {
 		return true;
 	}
 
@@ -201,12 +201,12 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			),
 		);
 
-		if ( $this->get_setting( 'duedate' ) ) {
+		if ( $this->get_setting( 'due_date' ) ) {
 			$notification_tabs[] = array(
 				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
-				'id'     => 'tab_duedate_notification',
+				'id'     => 'tab_due_date_notification',
 				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'duedate',
+					'name_prefix'      => 'due_date',
 					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
 					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
 					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),
@@ -280,12 +280,12 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			$settings_api->get_setting_confirmation_messasge( esc_html__( 'Thank you.', 'gravityflow' ) ),
 		);
 
-		if ( $this->get_setting( 'duedate' ) ) {
+		if ( $this->get_setting( 'due_date' ) ) {
 			$notification_tabs['tabs'][] = array(
 				'label'  => __( 'Past Due Date Email', 'gravityflow' ),
-				'id'     => 'tab_duedate_notification',
+				'id'     => 'tab_due_date_notification',
 				'fields' => $settings_api->get_setting_notification( array(
-					'name_prefix'      => 'duedate',
+					'name_prefix'      => 'due_date',
 					'checkbox_label'   => __( 'Send email when the entry is past its due date', 'gravityflow' ),
 					'checkbox_tooltip' => __( 'Enable this setting to send an email when the entry is past its due date.', 'gravityflow' ),
 					'default_message'  => __( 'Entry {entry_id} should be completed', 'gravityflow' ),

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -717,6 +717,47 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 *
 	 * @return bool|int
 	 */
+	public function get_duedate_timestamp() {
+		if ( ! $this->duedate ) {
+			return false;
+		}
+
+		switch ( $this->duedate_type ) {
+			case 'date':
+				$duedate_timestamp = $this->get_timestamp_date( 'duedate' );
+				break;
+
+			case 'date_field':
+				$duedate_timestamp = $this->get_timestamp_date_field( 'duedate' );
+				break;
+
+			case 'delay':
+			default:
+				$duedate_timestamp = $this->get_timestamp_delay( 'duedate' );
+		}
+
+		/**
+		 * Allows the due date timestamp to be overridden.
+		 *
+		 * @since 2.5
+		 *
+		 * @param int               $duedate_timestamp The current expiration timestamp (UTC).
+		 * @param string            $expiration_type      The type of expiration defined in step settings.
+		 * @param Gravity_Flow_Step $this                 The current step.
+		 *
+		 * @return int
+		 */
+		$duedate_timestamp = apply_filters( 'gravityflow_step_duedate_timestamp', $duedate_timestamp, $this->duedate_type, $this );
+
+		return $duedate_timestamp;
+	}
+
+
+	/**
+	 * Returns the expiration timestamp calculated from the expiration settings.
+	 *
+	 * @return bool|int
+	 */
 	public function get_expiration_timestamp() {
 		if ( ! $this->expiration ) {
 			return false;
@@ -753,11 +794,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the date based expiration or schedule.
+	 * Returns the timestamp for the date based expiration or schedule or duedate.
 	 *
 	 * @since 2.3.2
 	 *
-	 * @param string $setting_type The setting type: expiration or schedule.
+	 * @param string $setting_type The setting type: expiration or schedule or duedate.
 	 *
 	 * @return bool|int
 	 */
@@ -775,7 +816,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the date field based expiration or schedule.
+	 * Returns the timestamp for the date field based expiration or schedule or duedate.
 	 *
 	 * @since 2.3.2
 	 *
@@ -828,11 +869,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the delay based expiration or schedule.
+	 * Returns the timestamp for the delay based expiration or schedule or duedate.
 	 *
 	 * @since 2.3.2
 	 *
-	 * @param string $setting_type The setting type: expiration or schedule.
+	 * @param string $setting_type The setting type: expiration or schedule or duedate.
 	 *
 	 * @return bool|int
 	 */
@@ -2004,6 +2045,17 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 		gravity_flow()->log_event( 'step', $step_event, $this->get_form_id(), $this->get_entry_id(), $step_status, $this->get_id(), $duration );
 
+	}
+
+	/**
+	 * Override to indicate if the current step supports due date.
+	 *
+	 * @since 2.5
+	 *
+	 * @return bool
+	 */
+	public function supports_duedate() {
+		return false;
 	}
 
 	/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -717,23 +717,23 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 *
 	 * @return bool|int
 	 */
-	public function get_duedate_timestamp() {
-		if ( ! $this->duedate ) {
+	public function get_due_date_timestamp() {
+		if ( ! $this->due_date ) {
 			return false;
 		}
 
-		switch ( $this->duedate_type ) {
+		switch ( $this->due_date_type ) {
 			case 'date':
-				$duedate_timestamp = $this->get_timestamp_date( 'duedate' );
+				$due_date_timestamp = $this->get_timestamp_date( 'due_date' );
 				break;
 
 			case 'date_field':
-				$duedate_timestamp = $this->get_timestamp_date_field( 'duedate' );
+				$due_date_timestamp = $this->get_timestamp_date_field( 'due_date' );
 				break;
 
 			case 'delay':
 			default:
-				$duedate_timestamp = $this->get_timestamp_delay( 'duedate' );
+				$due_date_timestamp = $this->get_timestamp_delay( 'due_date' );
 		}
 
 		/**
@@ -741,15 +741,15 @@ abstract class Gravity_Flow_Step extends stdClass {
 		 *
 		 * @since 2.5
 		 *
-		 * @param int               $duedate_timestamp The current expiration timestamp (UTC).
+		 * @param int               $due_date_timestamp The current expiration timestamp (UTC).
 		 * @param string            $expiration_type      The type of expiration defined in step settings.
 		 * @param Gravity_Flow_Step $this                 The current step.
 		 *
 		 * @return int
 		 */
-		$duedate_timestamp = apply_filters( 'gravityflow_step_duedate_timestamp', $duedate_timestamp, $this->duedate_type, $this );
+		$due_date_timestamp = apply_filters( 'gravityflow_step_due_date_timestamp', $due_date_timestamp, $this->due_date_type, $this );
 
-		return $duedate_timestamp;
+		return $due_date_timestamp;
 	}
 
 
@@ -794,11 +794,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the date based expiration or schedule or duedate.
+	 * Returns the timestamp for the date based expiration or schedule or due date.
 	 *
 	 * @since 2.3.2
 	 *
-	 * @param string $setting_type The setting type: expiration or schedule or duedate.
+	 * @param string $setting_type The setting type: expiration or schedule or due date.
 	 *
 	 * @return bool|int
 	 */
@@ -816,11 +816,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the date field based expiration or schedule or duedate.
+	 * Returns the timestamp for the date field based expiration or schedule or due date.
 	 *
 	 * @since 2.3.2
 	 *
-	 * @param string $setting_type The setting type: expiration or schedule.
+	 * @param string $setting_type The setting type: expiration or schedule or due date.
 	 *
 	 * @return bool|int
 	 */
@@ -869,11 +869,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the timestamp for the delay based expiration or schedule or duedate.
+	 * Returns the timestamp for the delay based expiration or schedule or due date.
 	 *
 	 * @since 2.3.2
 	 *
-	 * @param string $setting_type The setting type: expiration or schedule or duedate.
+	 * @param string $setting_type The setting type: expiration or schedule or due date.
 	 *
 	 * @return bool|int
 	 */
@@ -2054,7 +2054,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 *
 	 * @return bool
 	 */
-	public function supports_duedate() {
+	public function supports_due_date() {
 		return false;
 	}
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -893,16 +893,16 @@ abstract class Gravity_Flow_Step extends stdClass {
 		$timestamp = $this->get_step_timestamp();
 
 		switch ( $this->{$setting_type . '_delay_unit'} ) {
-			case 'minutes' :
+			case 'minutes':
 				$timestamp += ( MINUTE_IN_SECONDS * $this->{$setting_type . '_delay_offset'} );
 				break;
-			case 'hours' :
+			case 'hours':
 				$timestamp += ( HOUR_IN_SECONDS * $this->{$setting_type . '_delay_offset'} );
 				break;
-			case 'days' :
+			case 'days':
 				$timestamp += ( DAY_IN_SECONDS * $this->{$setting_type . '_delay_offset'} );
 				break;
-			case 'weeks' :
+			case 'weeks':
 				$timestamp += ( WEEK_IN_SECONDS * $this->{$setting_type . '_delay_offset'} );
 				break;
 		}

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -133,6 +133,8 @@ abstract class Gravity_Flow_Step extends stdClass {
 			$this->_meta[ $name ] = '';
 		}
 
+		$test = $this->_meta;
+
 		return $this->_meta[ $name ];
 	}
 
@@ -713,11 +715,14 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
-	 * Returns the expiration timestamp calculated from the expiration settings.
+	 * Returns the due date timestamp calculated from the due date settings.
+	 *
+	 * @since 2.5
 	 *
 	 * @return bool|int
 	 */
 	public function get_due_date_timestamp() {
+
 		if ( ! $this->due_date ) {
 			return false;
 		}
@@ -732,8 +737,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 				break;
 
 			case 'delay':
-			default:
 				$due_date_timestamp = $this->get_timestamp_delay( 'due_date' );
+				break;
+
+			default:
+				return false;
 		}
 
 		/**

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -287,7 +287,7 @@
 
 		};
 
-		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert', 'due_date'];
+		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert'];
 
 		for (var i = 0; i < notificationTabs.length; i++) {
 			GravityFlowFeedSettings.initNotificationTab(notificationTabs[i]);
@@ -326,8 +326,7 @@
 
 		var $revertSetting = $('#revertenable');
 		if ( !$revertSetting.prop("checked")) {
-			$('#tabs-notification_tabs').tabs('disable', 4);
-
+			$('#tabs-notification_tabs').tabs('disable', 3);
 		}
 
 		$revertSetting.change(function () {

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -287,7 +287,7 @@
 
 		};
 
-		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert', 'duedate'];
+		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert', 'due_date'];
 
 		for (var i = 0; i < notificationTabs.length; i++) {
 			GravityFlowFeedSettings.initNotificationTab(notificationTabs[i]);

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -287,7 +287,7 @@
 
 		};
 
-		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert'];
+		var notificationTabs = ['assignee', 'rejection', 'approval', 'in_progress', 'complete', 'revert', 'duedate'];
 
 		for (var i = 0; i < notificationTabs.length; i++) {
 			GravityFlowFeedSettings.initNotificationTab(notificationTabs[i]);
@@ -326,7 +326,7 @@
 
 		var $revertSetting = $('#revertenable');
 		if ( !$revertSetting.prop("checked")) {
-			$('#tabs-notification_tabs').tabs('disable', 3);
+			$('#tabs-notification_tabs').tabs('disable', 4);
 
 		}
 


### PR DESCRIPTION
*WIP* This PR will be ready for review when:

- [x] Step support due date setting w/ sub-options by delay, date or date field and highlighting.
- [x] Inbox highlights entries past due (taking precedence over step highlighting)
- [x] Inbox and Status shortcodes support optional due_date column
- [x] Entry detail screen displays due date in workflow info box
- [x] Status Export supports due date column output - via [gravityflow_columns_status_table](https://docs.gravityflow.io/article/161-gravityflowcolumnsstatustable)
- [ ] New acceptance test covers inbox highlight and entry detail workflow info verifying sub-options.


