### PR TITLE
Add license check throttling

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4314,11 +4314,15 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 *
 		 * @param string $value The license key.
 		 *
-		 * @return array|object
+		 * @return array|object|false
 		 */
 		public function check_license( $value = '' ) {
 			if ( empty( $value ) ) {
 				$value = $this->get_app_setting( 'license_key' );
+			}
+
+			if ( empty( $value ) ) {
+				return false;
 			}
 
 			// Static cache to prevent multiple requests for the same license key.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8088,11 +8088,17 @@ AND m.meta_value='queued'";
 			} else {
 				$license_details = get_transient( 'gravityflow_license_details' );
 				if ( ! $license_details ) {
+					$last_check = get_option( 'gravityflow_last_license_check' );
+					if ( $last_check > time() - 5 * MINUTE_IN_SECONDS ) {
+						return;
+					}
+
 					$license_key     = defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ? GRAVITY_FLOW_LICENSE_KEY : '';
 					$license_details = $this->check_license( $license_key );
 					if ( $license_details ) {
 						$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 						set_transient( 'gravityflow_license_details', $license_details, $expiration );
+						update_option( 'gravityflow_last_license_check', time() );
 					}
 				}
 			}

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -431,7 +431,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			$license_details = get_transient( $transient_key );
 			if ( ! $license_details ) {
 				$last_check = get_option( 'gravityflow_last_license_check' );
-				if ( $last_check > time() - 2 * MINUTE_IN_SECONDS ) {
+				if ( $last_check > time() - 5 * MINUTE_IN_SECONDS ) {
 					return;
 				}
 				$license_details = $this->check_license();

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -426,7 +426,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			$license_details = get_transient( $transient_key );
 			if ( ! $license_details ) {
 				$last_check = get_option( 'gravityflow_last_license_check' );
-				if ( $last_check > time() - 2 * MINUTE_IN_SECONDS ) {
+				if ( $last_check > time() - 5 * MINUTE_IN_SECONDS ) {
 					return;
 				}
 				$license_details = $this->check_license();

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -393,6 +393,11 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 */
 	public function action_admin_notices() {
 
+		if ( ! ( $this->edd_item_name || $this->edd_item_id ) ) {
+			// Only display the admin notice for official extensions.
+			return;
+		}
+
 		if ( is_multisite() && ! is_main_site() ) {
 			return;
 		}
@@ -420,10 +425,15 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		} else {
 			$license_details = get_transient( $transient_key );
 			if ( ! $license_details ) {
+				$last_check = get_option( 'gravityflow_last_license_check' );
+				if ( $last_check > time() - 2 * MINUTE_IN_SECONDS ) {
+					return;
+				}
 				$license_details = $this->check_license();
 				if ( $license_details ) {
 					$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 					set_transient( $transient_key, $license_details, $expiration );
+					update_option( 'gravityflow_last_license_check', time() );
 				}
 			}
 		}

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -255,6 +255,11 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		if ( empty( $value ) ) {
 			$value = $this->get_app_setting( 'license_key' );
 		}
+
+		if ( empty( $value ) ) {
+			return false;
+		}
+
 		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
 		$response        = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 
@@ -426,7 +431,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			$license_details = get_transient( $transient_key );
 			if ( ! $license_details ) {
 				$last_check = get_option( 'gravityflow_last_license_check' );
-				if ( $last_check > time() - 5 * MINUTE_IN_SECONDS ) {
+				if ( $last_check > time() - 2 * MINUTE_IN_SECONDS ) {
 					return;
 				}
 				$license_details = $this->check_license();

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -398,6 +398,11 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	 */
 	public function action_admin_notices() {
 
+		if ( ! ( $this->edd_item_name || $this->edd_item_id ) ) {
+			// Only display the admin notice for official extensions.
+			return;
+		}
+
 		if ( is_multisite() && ! is_main_site() ) {
 			return;
 		}
@@ -425,10 +430,15 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		} else {
 			$license_details = get_transient( $transient_key );
 			if ( ! $license_details ) {
+				$last_check = get_option( 'gravityflow_last_license_check' );
+				if ( $last_check > time() - 5 * MINUTE_IN_SECONDS ) {
+					return;
+				}
 				$license_details = $this->check_license();
 				if ( $license_details ) {
 					$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 					set_transient( $transient_key, $license_details, $expiration );
+					update_option( 'gravityflow_last_license_check', time() );
 				}
 			}
 		}

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -261,6 +261,11 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		if ( empty( $value ) ) {
 			$value = $this->get_app_setting( 'license_key' );
 		}
+
+		if ( empty( $value ) ) {
+			return false;
+		}
+
 		$item_name_or_id = empty( $this->edd_item_id ) ? $this->edd_item_name : $this->edd_item_id;
 		$response        = gravity_flow()->perform_edd_license_request( 'check_license', $value, $item_name_or_id );
 


### PR DESCRIPTION
Ensures that only one license check is made on each request. Also excludes third-party extensions from the admin notices.