### PR TITLE
Add filter gravityflow_next_step

### DIFF
--- a/change_log_temp.txt
+++ b/change_log_temp.txt
@@ -7,3 +7,4 @@
 - Added filter gravityflow_back_link_url_entry_detail to allow customization of back link on entry detail page.
 - Added filter gravityflow_search_criteria_status to allow status page to filter on multiple field criteria.
 - Added shortcode security settings.
+- Added the filter gravityflow_next_step to allow customization of the next step for workflow processing (example - restart a completed user input step for new assignees to action)

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3346,14 +3346,14 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			$scheduled_timestamp = $current_step->get_schedule_timestamp();
 
 			switch ( $current_step->schedule_type ) {
-				case 'date' :
+				case 'date':
 					$scheduled_date = $current_step->schedule_date;
 					break;
-				case 'date_field' :
+				case 'date_field':
 					$scheduled_date_str = date( 'Y-m-d H:i:s', $scheduled_timestamp );
 					$scheduled_date     = get_date_from_gmt( $scheduled_date_str );
 					break;
-				case 'delay' :
+				case 'delay':
 				default:
 					$scheduled_date_str = date( 'Y-m-d H:i:s', $scheduled_timestamp );
 					$scheduled_date     = get_date_from_gmt( $scheduled_date_str );
@@ -3399,10 +3399,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 						<div id="minor-publishing" style="padding:10px;">
 							<?php wp_nonce_field( 'gravityflow_admin_action', '_gravityflow_admin_action_nonce' ); ?>
 							<select id="gravityflow-admin-action" name="gravityflow_admin_action">
-								<option value=""><?php esc_html_e( 'Select an action', 'gravityflow' ) ?></option>
+								<option value=""><?php esc_html_e( 'Select an action', 'gravityflow' ); ?></option>
 								<?php echo $this->get_admin_action_select_options( $current_step, $steps, $form, $entry ); ?>
 							</select>
-							<input type="submit" class="button " name="_gravityflow_admin_action" value="<?php esc_html_e( 'Apply', 'gravityflow' ) ?>"/>
+							<input type="submit" class="button " name="_gravityflow_admin_action" value="<?php esc_html_e( 'Apply', 'gravityflow' ); ?>"/>
 
 						</div>
 					</div>
@@ -3453,7 +3453,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					if ( ! $current_step || ( $current_step && $current_step->get_id() != $step_id ) ) {
 						$choices[] = array(
 							'label' => $step->get_name(),
-							'value' => 'send_to_step|' . $step->get_id()
+							'value' => 'send_to_step|' . $step->get_id(),
 						);
 					}
 				}
@@ -3543,13 +3543,13 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Returns the next step for the supplied entry.
 		 *
-		 * @param Gravity_Flow_Step $step The current step. Defaults to false.
+		 * @param Gravity_Flow_Step $step The current step.
 		 * @param array             $entry The current entry.
 		 * @param array             $form  The current form.
 		 *
 		 * @return bool|Gravity_Flow_Step
 		 */
-		public function get_next_step( $step = false, $entry, $form ) {
+		public function get_next_step( $step, $entry, $form ) {
 			$current_step = $step;
 			$keep_looking = true;
 
@@ -3572,8 +3572,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				if ( $next_step_id == 'next' ) {
 					$step = $this->get_next_step_in_list( $form, $step, $entry, $steps );
 					$keep_looking = false;
-				} 
-				
+				}
+
 				if ( ! in_array( $next_step_id, array( 'complete', 'next' ) ) ) {
 					$step = $this->get_step( $next_step_id, $entry );
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3557,7 +3557,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			while ( $keep_looking && $step ) {
 
 				if ( ! $step instanceof Gravity_Flow_Step ) {
-					$step = false;
+					$next_step_id = $step = false;
 				} else {
 					$next_step_id = $step->get_next_step_id();
 				}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3623,19 +3623,36 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				$steps = $this->get_steps( $form_id, $entry );
 			}
 			$current_step_id = $current_step->get_id();
+			$next_potential_step = false;
 			$next_step = false;
+			
 			foreach ( $steps as $step ) {
-				if ( $next_step ) {
+				if ( $next_potential_step ) {
 					if ( $step->is_active() && $step->is_condition_met( $form ) ) {
-						return $step;
+						$next_step = $step;
+						break;
 					}
 				}
 
-				if ( $next_step == false && $current_step_id == $step->get_id() ) {
-					$next_step = true;
+				if ( $next_potential_step == false && $current_step_id == $step->get_id() ) {
+					$next_potential_step = true;
 				}
 			}
-			return false;
+			/**
+			 * Allows the next step in workflow to be customized.
+			 *
+			 * Return the next step (or false)
+			 *
+			 * @since 2.5
+			 *
+			 * @param Gravity_Flow_Step|bool $step         The next step.
+			 * @param Gravity_Flow_Step      $current_step The current step.
+			 * @param array                  $entry        The current entry array.
+			 * @param array                  $form         The current form array.
+			 * @param array                  $steps        The steps for current form.
+			 */
+			$step = apply_filters( 'gravityflow_next_step', $next_step, $current_step, $entry, $steps );
+			return $step;
 		}
 
 		/**

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3558,12 +3558,13 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 				if ( ! $step instanceof Gravity_Flow_Step ) {
 					$step = false;
+				} else {
+					$next_step_id = $step->get_next_step_id();
 				}
-
-				$next_step_id = $step->get_next_step_id();
 
 				if ( $next_step_id == 'complete' ) {
 					$step = false;
+					$keep_looking = false;
 				}
 
 				if ( $next_step_id == 'next' ) {

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3643,7 +3643,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			 *
 			 * Return the next step (or false)
 			 *
-			 * @since 2.5
+			 * @since 2.4.3
 			 *
 			 * @param Gravity_Flow_Step|bool $step         The next step.
 			 * @param Gravity_Flow_Step      $current_step The current step.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3552,8 +3552,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		public function get_next_step( $step = false, $entry, $form ) {
 			$current_step = $step;
 			$keep_looking = true;
+
 			$form_id = absint( $form['id'] );
-			$steps = $this->get_steps( $form_id, $entry );
+			$steps   = $this->get_steps( $form_id, $entry );
+
 			while ( $keep_looking && $step ) {
 
 				if ( ! $step instanceof Gravity_Flow_Step ) {
@@ -3587,6 +3589,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					}
 				}
 			}
+
 			/**
 			 * Allows the next step in workflow to be customized.
 			 *
@@ -3601,6 +3604,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			 * @param array                  $steps        The steps for current form.
 			 */
 			$step = apply_filters( 'gravityflow_next_step', $step, $current_step, $entry, $steps );
+
 			return $step;
 		}
 


### PR DESCRIPTION
Refer to HS#7755

**Issue** 
Provide method for customisation of the next step a workflow will process. Example scenario is  a successfully completed user input step needs to restart the same step in order to trigger different assignee's (based on value changes of current step)

**Closest Alternatives**
- gravityflow_post_process_workflow is too late in workflow cycle to trigger change
- gravityflow_step_complete would allow the GFlow $api->restart_step to modify $entry meta to indicate a successful restart, however it would require use of a custom event (via wp_schedule_single_event) and still not prevent the next ordered workflow step or notification from starting. An additional refresh of the entry during process_workflow does not modify the active step / next step logic enough for this approach either.

**Testing Instructions**
- Create a workflow with multiple steps
- Use this branch and a modified version of the following snippet to have next step be identified as current step.

```
add_filter( 'gravityflow_next_step', 'sh_restart_next_step_workflow', 10,  4 );
function sh_custom_next_step_workflow( $next_step, $current_step, $entry, $steps ) {
	//Modify step ID to match your test scenario
	if ( $next_step != false && $current_step->get_id() == 84 ) {
		//Additional logic would go here to determine if/how $next_step should be modified
		$next_step = $current_step;
	}

	return $next_step;
}
```