### PR TITLE
Add extension license key constant

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8146,7 +8146,7 @@ AND m.meta_value='queued'";
 						break;
 				}
 
-				$message .= ' ' . esc_html__( 'This means you&rsquo;re missing out on security fixes, updates and support!', 'gravityflow' );
+				$message .= ' ' . esc_html__( "This means you're missing out on security fixes, updates and support.", 'gravityflow' );
 
 				$url = 'https://gravityflow.io/?utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice#pricing';
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8100,6 +8100,9 @@ AND m.meta_value='queued'";
 					$license_key     = defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ? GRAVITY_FLOW_LICENSE_KEY : '';
 					$license_details = $this->check_license( $license_key );
 					if ( $license_details ) {
+						if ( defined( 'GRAVITY_FLOW_LICENSE_KEY' ) && $license_details->license == 'site_inactive' ) {
+							$license_details = $this->activate_license( GRAVITY_FLOW_LICENSE_KEY );
+						}
 						$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 						set_transient( 'gravityflow_license_details', $license_details, $expiration );
 						update_option( 'gravityflow_last_license_check', time() );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8114,7 +8114,7 @@ AND m.meta_value='queued'";
 
 			if ( $license_status != 'valid' ) {
 
-				$add_buttons = ! defined( 'GRAVITY_FLOW_LICENSE_KEY' ) || ! is_multisite();
+				$add_buttons = ! is_multisite();
 
 				$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings' );
 
@@ -8151,7 +8151,7 @@ AND m.meta_value='queued'";
 				$url = 'https://gravityflow.io/?utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice#pricing';
 
 				// Show a different notice on settings page for inactive licenses (hide the buttons)
-				if ( $add_buttons && ! $this->is_app_settings() ) {
+				if ( ! defined( 'GRAVITY_FLOW_LICENSE_KEY' ) && $add_buttons && ! $this->is_app_settings() ) {
 					$message .= '<br /><br />' . esc_html__( '%sActivate your license%s or %sget a license here%s', 'gravityflow' );
 					$message = sprintf( $message, '<a href="' . esc_url( $primary_button_link ) . '" class="button button-primary">', '</a>', '<a href="' . esc_url( $url ) . '" class="button button-secondary">', '</a>' );
 				}

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -514,7 +514,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			}
 
 			// Show a different notice on settings page for inactive licenses (hide the buttons)
-			if ( $add_buttons && ! $this->is_extension_settings() ) {
+			if ( ! $this->license_key && $add_buttons && ! $this->is_extension_settings() ) {
 				$message .= '<br /><br />' . esc_html__( '%sActivate your license%s or %sget a license here%s', 'gravityflow' );
 				$message = sprintf( $message, '<a href="' . esc_url( $primary_button_link ) . '" class="button button-primary">', '</a>', '<a href="' . esc_url( $url ) . '" class="button button-secondary">', '</a>' );
 			}

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -47,7 +47,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 *
 	 * @var string
 	 */
-	//public $license_key = '';
+	public $license_key = '';
 
 	/**
 	 * If the extensions minimum requirements are met add the general hooks.

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -39,6 +39,17 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	public $edd_item_id = '';
 
 	/**
+	 * Holds the license key for the current installation.
+	 *
+	 * Set with a constant e.g. GRAVITY_FLOW_EXTENSION_LICENSE_KEY
+	 *
+	 * @since 2.2.5
+	 *
+	 * @var string
+	 */
+	//public $license_key = '';
+
+	/**
 	 * If the extensions minimum requirements are met add the general hooks.
 	 */
 	public function init() {
@@ -253,7 +264,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 */
 	public function check_license( $value = '' ) {
 		if ( empty( $value ) ) {
-			$value = $this->get_app_setting( 'license_key' );
+			$value = $this->license_key ? $this->license_key : $this->get_app_setting( 'license_key' );
 		}
 
 		if ( empty( $value ) ) {
@@ -436,6 +447,9 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 				}
 				$license_details = $this->check_license();
 				if ( $license_details ) {
+					if ( $this->license_key && $license_details->license == 'site_inactive' ) {
+						$license_details = $this->activate_license( $this->license_key );
+					}
 					$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 					set_transient( $transient_key, $license_details, $expiration );
 					update_option( 'gravityflow_last_license_check', time() );

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -115,6 +115,15 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 */
 	public function app_settings_tabs( $settings_tabs ) {
 
+		if ( $this->license_key ) {
+			$app_settings = $this->app_settings_fields();
+			$fields = ! empty( $app_settings[0]['fields'] ) ? $app_settings[0]['fields'] : array();
+			if ( is_array( $fields ) && count( $fields ) == 1 ) {
+				// This extension only has a license key setting but the license key is already set to we don't need the settings tab;
+				return $settings_tabs;
+			}
+		}
+
 		$settings_tabs[] = array(
 			'name'     => $this->_slug,
 			'label'    => $this->get_short_title(),

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -505,7 +505,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 					break;
 			}
 
-			$message .= ' ' . esc_html__( 'This means you&rsquo;re missing out on security fixes, updates and support!', 'gravityflow' );
+			$message .= ' ' . esc_html__( "This means you're missing out on security fixes, updates and support.", 'gravityflow' );
 
 			if ( ! empty( $this->edd_item_id ) ) {
 				$url = 'https://gravityflow.io/?p=' . $this->edd_item_id . '&utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -117,9 +117,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 		if ( $this->license_key ) {
 			$app_settings = $this->app_settings_fields();
-			$fields = ! empty( $app_settings[0]['fields'] ) ? $app_settings[0]['fields'] : array();
-			if ( is_array( $fields ) && count( $fields ) == 1 ) {
-				// This extension only has a license key setting but the license key is already set to we don't need the settings tab;
+			if ( empty( $app_settings ) ) {
 				return $settings_tabs;
 			}
 		}
@@ -215,6 +213,10 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	 * @return array
 	 */
 	public function app_settings_fields() {
+		if ( $this->license_key ) {
+			return array();
+		}
+
 		return array(
 			array(
 				'title'  => $this->get_short_title(),

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -517,7 +517,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 			}
 
 			// Show a different notice on settings page for inactive licenses (hide the buttons)
-			if ( $add_buttons && ! $this->is_extension_settings() ) {
+			if ( ! $this->license_key && $add_buttons && ! $this->is_extension_settings() ) {
 				$message .= '<br /><br />' . esc_html__( '%sActivate your license%s or %sget a license here%s', 'gravityflow' );
 				$message = sprintf( $message, '<a href="' . esc_url( $primary_button_link ) . '" class="button button-primary">', '</a>', '<a href="' . esc_url( $url ) . '" class="button button-secondary">', '</a>' );
 			}

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -39,6 +39,17 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	public $edd_item_id = '';
 
 	/**
+	 * Holds the license key for the current installation.
+	 *
+	 * Set with a constant e.g. GRAVITY_FLOW_EXTENSION_LICENSE_KEY
+	 *
+	 * @since 2.2.5
+	 *
+	 * @var string
+	 */
+	public $license_key = '';
+
+	/**
 	 * If the extensions minimum requirements are met add the general hooks.
 	 */
 	public function init() {
@@ -259,7 +270,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	 */
 	public function check_license( $value = '' ) {
 		if ( empty( $value ) ) {
-			$value = $this->get_app_setting( 'license_key' );
+			$value = $this->license_key ? $this->license_key : $this->get_app_setting( 'license_key' );
 		}
 
 		if ( empty( $value ) ) {
@@ -441,6 +452,9 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 				}
 				$license_details = $this->check_license();
 				if ( $license_details ) {
+					if ( $this->license_key && $license_details->license == 'site_inactive' ) {
+						$license_details = $this->activate_license( $this->license_key );
+					}
 					$expiration = DAY_IN_SECONDS + rand( 0, DAY_IN_SECONDS );
 					set_transient( $transient_key, $license_details, $expiration );
 					update_option( 'gravityflow_last_license_check', time() );

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -508,7 +508,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 					break;
 			}
 
-			$message .= ' ' . esc_html__( 'This means you&rsquo;re missing out on security fixes, updates and support!', 'gravityflow' );
+			$message .= ' ' . esc_html__( "This means you're missing out on security fixes, updates and support.", 'gravityflow' );
 
 			if ( ! empty( $this->edd_item_id ) ) {
 				$url = 'https://gravityflow.io/?p=' . $this->edd_item_id . '&utm_source=admin_notice&utm_medium=admin&utm_content=' . $license_status . '&utm_campaign=Admin%20Notice';

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -115,6 +115,15 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	 */
 	public function app_settings_tabs( $settings_tabs ) {
 
+		if ( $this->license_key ) {
+			$app_settings = $this->app_settings_fields();
+			$fields = ! empty( $app_settings[0]['fields'] ) ? $app_settings[0]['fields'] : array();
+			if ( is_array( $fields ) && count( $fields ) == 1 ) {
+				// This extension only has a license key setting but the license key is already set to we don't need the settings tab;
+				return $settings_tabs;
+			}
+		}
+
 		$settings_tabs[] = array(
 			'name'     => $this->_slug,
 			'label'    => $this->get_short_title(),

--- a/includes/wizard/class-installation-wizard.php
+++ b/includes/wizard/class-installation-wizard.php
@@ -55,18 +55,14 @@ class Gravity_Flow_Installation_Wizard {
 	 * @return array
 	 */
 	public function get_sorted_step_names() {
-		$steps = array(
+		return array(
+			'license_key',
 			'gravity_forms',
 			'updates',
 			'updates',
 			'pages',
 			'complete',
 		);
-
-		if ( ! defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ) {
-			array_unshift( $steps, 'license_key' );
-		}
-		return $steps;
 	}
 
 	/**

--- a/includes/wizard/class-installation-wizard.php
+++ b/includes/wizard/class-installation-wizard.php
@@ -55,14 +55,18 @@ class Gravity_Flow_Installation_Wizard {
 	 * @return array
 	 */
 	public function get_sorted_step_names() {
-		return array(
-			'license_key',
+		$steps = array(
 			'gravity_forms',
 			'updates',
 			'updates',
 			'pages',
 			'complete',
 		);
+
+		if ( ! defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ) {
+			array_unshift( $steps, 'license_key' );
+		}
+		return $steps;
 	}
 
 	/**

--- a/includes/wizard/steps/class-iw-step-license-key.php
+++ b/includes/wizard/steps/class-iw-step-license-key.php
@@ -37,44 +37,58 @@ class Gravity_Flow_Installation_Wizard_Step_License_Key extends Gravity_Flow_Ins
 	 */
 	public function display() {
 
-		if ( ! $this->license_key && defined( 'GRAVITY_FLOW_LICENSE_KEY' ) ) {
-			$this->license_key = GRAVITY_FLOW_LICENSE_KEY;
-		}
 
-		?>
-		<p>
-			<?php echo sprintf( esc_html__( 'Enter your Gravity Flow License Key below. Your key unlocks access to automatic updates and support. You can find your key in your purchase confirmation email or by logging into your account area on the %sGravity Flow%s site.', 'gravityflow' ), '<a href="http://www.gravityflow.io/account">', '</a>' ); ?>
-		</p>
-		<div>
-			<input type="text" class="regular-text" id="license_key"
-			       value="<?php echo esc_attr( $this->license_key ); ?>" name="license_key"
-			       placeholder="<?php esc_attr_e( 'Enter Your License Key', 'gravityflow' ); ?>"/>
+		if ( defined( 'GRAVITY_FLOW_LICENSE_KEY' ) && GRAVITY_FLOW_LICENSE_KEY ) {
+
+			?>
+			<p>
+				<?php esc_html_e( 'Your license key has already been set.', 'gravityflow' ); ?>
+			</p>
+
 			<?php
+
 			$key_error = $this->validation_message( 'license_key', false );
 			if ( $key_error ) {
 				echo $key_error;
 			}
-			?>
-		</div>
 
-		<?php
-		$message = $this->validation_message( 'accept_terms', false );
-		if ( $message || $key_error || $this->accept_terms ) {
+		} else {
 			?>
 			<p>
-				<?php esc_html_e( "If you don't enter a valid license key, you will not be able to update Gravity Flow when important bug fixes and security enhancements are released. This can be a serious security risk for your site.", 'gravityflow' ); ?>
+				<?php echo sprintf( esc_html__( 'Enter your Gravity Flow License Key below. Your key unlocks access to automatic updates and support. You can find your key in your purchase confirmation email or by logging into your account area on the %sGravity Flow%s site.', 'gravityflow' ), '<a href="http://www.gravityflow.io/account">', '</a>' ); ?>
 			</p>
 			<div>
-				<label>
-					<input type="checkbox" id="accept_terms" value="1" <?php checked( 1, $this->accept_terms ); ?>
-					       name="accept_terms"/>
-					<?php esc_html_e( 'I understand the risks', 'gravityflow' ); ?> <span
-							class="gfield_required">*</span>
-				</label>
-				<?php echo $message ?>
+				<input type="text" class="regular-text" id="license_key"
+					   value="<?php echo esc_attr( $this->license_key ); ?>" name="license_key"
+					   placeholder="<?php esc_attr_e( 'Enter Your License Key', 'gravityflow' ); ?>"/>
+				<?php
+				$key_error = $this->validation_message( 'license_key', false );
+				if ( $key_error ) {
+					echo $key_error;
+				}
+				?>
 			</div>
+
 			<?php
+			$message = $this->validation_message( 'accept_terms', false );
+			if ( $message || $key_error || $this->accept_terms ) {
+				?>
+				<p>
+					<?php esc_html_e( "If you don't enter a valid license key, you will not be able to update Gravity Flow when important bug fixes and security enhancements are released. This can be a serious security risk for your site.", 'gravityflow' ); ?>
+				</p>
+				<div>
+					<label>
+						<input type="checkbox" id="accept_terms" value="1" <?php checked( 1, $this->accept_terms ); ?>
+							   name="accept_terms"/>
+						<?php esc_html_e( 'I understand the risks', 'gravityflow' ); ?> <span
+								class="gfield_required">*</span>
+					</label>
+					<?php echo $message ?>
+				</div>
+				<?php
+			}
 		}
+
 	}
 
 	/**
@@ -95,7 +109,7 @@ class Gravity_Flow_Installation_Wizard_Step_License_Key extends Gravity_Flow_Ins
 
 		$this->is_valid_key = true;
 
-		$license_key = $this->license_key;
+		$license_key = defined( 'GRAVITY_FLOW_LICENSE_KEY' ) && GRAVITY_FLOW_LICENSE_KEY ? GRAVITY_FLOW_LICENSE_KEY : $this->license_key;
 
 		if ( empty ( $license_key ) ) {
 			$message = esc_html__( 'Please enter a valid license key.', 'gravityflow' ) . '</span>';


### PR DESCRIPTION
1. Activate the site if the constant is set for core and extensions.
2. Hide the license key settings for extensions if the license key constant is set.
3. Hide the settings tab for extensions if there are no settings on the tab.
4. HIde the license key step if the constant is defined.

Test with the following PRs:
https://github.com/gravityflow/gravityflowchecklists/pull/16
https://github.com/gravityflow/gravityflowflowchart/pull/3
https://github.com/gravityflow/gravityflowpdf/pull/7