### PR TITLE
Fix import message showing when form has no feeds

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5840,12 +5840,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 				if ( isset( $form['feeds']['gravityflow'] ) ) {
 					$this->import_gravityflow_feeds( $form['feeds']['gravityflow'], $form['id'] );
+					$gravityflow_feeds_imported = ! empty( $form['feeds']['gravityflow'] ) ? true : $gravityflow_feeds_imported;
 					unset( $form['feeds']['gravityflow'] );
 					if ( empty( $form['feeds'] ) ) {
 						unset( $form['feeds'] );
 					}
 					GFAPI::update_form( $form );
-					$gravityflow_feeds_imported = true;
 				}
 			}
 


### PR DESCRIPTION
### Description
This PR resolves an issue where the Gravity Flow import message appears upon importing a form when the form object contains the `gravityflow` feeds array but does not have any feeds.

### Testing Instructions
1. Export two forms, separately, while running Gravity Flow: One with a Gravity Flow feed, one without
1. On `master` branch, import the form with a feed. The import message should appear.
1. On `master` branch, import the form without a feed. The import message should appear.
1. On `fix-import-message` branch, import the form with a feed. The import message should appear.
1. On `fix-import-message` branch, import the form without a feed. The import message should not appear.
