### PR TITLE
Add the new Constant Contact step

### DIFF
--- a/includes/steps/class-step-feed-constantcontact.php
+++ b/includes/steps/class-step-feed-constantcontact.php
@@ -6,7 +6,7 @@
  * @subpackage  Classes/Gravity_Flow_Step_Feed_ConstantContact
  * @copyright   Copyright (c) 2015-2019, Steven Henty S.L.
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
- * @since       2.5
+ * @since       2.4.5
  */
 
 if ( ! class_exists( 'GFForms' ) ) {
@@ -32,7 +32,7 @@ class Gravity_Flow_Step_Feed_ConstantContact extends Gravity_Flow_Step_Feed_Add_
 	 * @since 2.5
 	 * @var string
 	 */
-	protected $_class_name = 'GFConstantContact';
+	protected $_class_name = 'GF_ConstantContact';
 
 	/**
 	 * Returns the step label.

--- a/includes/steps/class-step-feed-constantcontact.php
+++ b/includes/steps/class-step-feed-constantcontact.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Gravity Flow Step Feed Constant Contact
+ *
+ * @package     GravityFlow
+ * @subpackage  Classes/Gravity_Flow_Step_Feed_ConstantContact
+ * @copyright   Copyright (c) 2015-2019, Steven Henty S.L.
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       2.5
+ */
+
+if ( ! class_exists( 'GFForms' ) ) {
+	die();
+}
+
+/**
+ * Class Gravity_Flow_Step_Feed_ConstantContact
+ */
+class Gravity_Flow_Step_Feed_ConstantContact extends Gravity_Flow_Step_Feed_Add_On {
+
+	/**
+	 * The step type.
+	 *
+	 * @since 2.5
+	 * @var string
+	 */
+	public $_step_type = 'constantcontact';
+
+	/**
+	 * The name of the class used by the add-on.
+	 *
+	 * @since 2.5
+	 * @var string
+	 */
+	protected $_class_name = 'GFConstantContact';
+
+	/**
+	 * Returns the step label.
+	 *
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return 'Constant Contact';
+	}
+
+	/**
+	 * Returns the feed name.
+	 *
+	 * @since 2.5
+	 *
+	 * @param array $feed The Emma feed properties.
+	 *
+	 * @return string
+	 */
+	public function get_feed_label( $feed ) {
+		$label = $feed['meta']['feed_name'];
+
+		return $label;
+	}
+
+}
+
+Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_ConstantContact() );

--- a/includes/steps/class-step-feed-constantcontact.php
+++ b/includes/steps/class-step-feed-constantcontact.php
@@ -45,21 +45,6 @@ class Gravity_Flow_Step_Feed_ConstantContact extends Gravity_Flow_Step_Feed_Add_
 		return 'Constant Contact';
 	}
 
-	/**
-	 * Returns the feed name.
-	 *
-	 * @since 2.5
-	 *
-	 * @param array $feed The Emma feed properties.
-	 *
-	 * @return string
-	 */
-	public function get_feed_label( $feed ) {
-		$label = $feed['meta']['feed_name'];
-
-		return $label;
-	}
-
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_ConstantContact() );


### PR DESCRIPTION
This PR adds support for the Gravity Forms Constant Contact add-on.

## Testing instructions
1. Setup a Constant Contact feed.
2. Add a Constant Contact step in your workflow. Better to put an Approval step before it.
3. Submit the form, make sure the contact only gets added AFTER the Approval step.