### PR TITLE
Fix date-field based conditional routing

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed the workflows for GP Nested Forms child entries starting before some Gravity Perks extensions had updated the entries.
+- Fixed an issue that prevented conditional routing from correctly matching date field conditions.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7667,30 +7667,38 @@ AND m.meta_value='queued'";
 			}
 
 			switch ( $source_field->type ) {
-
 				case 'workflow_multi_user':
 					if ( in_array( $target_value, $field_value, true ) ) {
 						return true;
 					}
 					break;
-				
 				case 'date':
-					if( $operation == '>' && strtotime( $field_value ) > strtotime( $target_value ) ) {
+					if ( class_exists( 'GP_Conditional_Logic_Dates' ) ) {
+						return $is_match;
+					}
+
+					$field_value = strtotime( $field_value );
+
+					if ( is_numeric( $target_value ) ) {
+						$target_value = (int)$target_value;
+					} else {
+						$target_value = strtotime( $target_value );
+					}
+					
+					if ( $operation == '>' && $field_value > $target_value ) {
 						return true;
 					}
-					if( $operation == '<' && strtotime( $field_value ) < strtotime( $target_value ) ) {
+					if ( $operation == '<' && $field_value < $target_value ) {
 						return true;
 					}
-					if( $operation == 'is' && strtotime( $field_value ) == strtotime( $target_value ) ) {
+					if ( $operation == 'is' && $field_value == $target_value ) {
 						return true;
 					}
-					if( $operation == 'isnot' && strtotime( $field_value ) != strtotime( $target_value ) ) {
+					if ( $operation == 'isnot' && $field_value != $target_value ) {
 						return true;
 					}
 					break;
-					
 			}
-
 			return false;
 		}
 
@@ -7712,7 +7720,7 @@ AND m.meta_value='queued'";
 		 */
 		public function replace_variables( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format ) {
 
-			if ( strpos( $text, '{' ) === false  || empty( $entry ) ) {
+			if ( strpos( $text, '{' ) === false || empty( $entry ) ) {
 				return $text;
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7651,6 +7651,13 @@ AND m.meta_value='queued'";
 		 *
 		 * @since 2.4.1
 		 *
+		 * @param bool   $is_match     Does the target field’s value match with the rule value?
+		 * @param string $field_value  The field value to use with the comparison.
+		 * @param string $target_value The value from the conditional routing rule to use with the comparison.
+		 * @param string $operation    The conditional routing rule operator.
+		 * @param object $source_field The field object for the source of the field value.
+		 * @param array  $rule         The current rule object.
+		 *
 		 * @return bool
 		 */
 		public function filter_gform_is_value_match( $is_match, $field_value, $target_value, $operation, $source_field, $rule ) {


### PR DESCRIPTION
See [8206](https://secure.helpscout.net/conversation/788830995/8206?folderId=1776095)

This PR resolves an issue with conditional routing for step assignees involving date fields which were not being correctly evaluated and would return false in many cases they should not.

**Test Instructions**

- Create a form with a date field
- Create a step which uses conditional routing and the date field for condition (all operators supported)
- Verify the expected assignee is assigned to the step.
- While the field format is yyyy-mm-dd through the use of strtotime for evaluation the majority of date formats which users might input into the routing field will also evaluate correctly.

This PR also renames the function hooked to gform_is_value_match (to filter_gform_is_value_match) to allow more field-specific comparisons in the future and corrects the since tag to when it was added to 2.4.1.