### PR TITLE
Fix webhook raw merge tags

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed the workflows for GP Nested Forms child entries starting before some Gravity Perks extensions had updated the entries.
+- Fixed the outgoing webhook for steps with raw request body defined to have merge tag values properly escaped.

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -811,7 +811,7 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 	* @return string
 	*/
 	function filter_gform_merge_tag_webhook_raw_encode( $value, $merge_tag, $modifier, $field, $raw_value ) {
-		$value = preg_replace( '/(?<!\\\\)[\"]/', '\\"', $value );
+		$value = substr( json_encode( $value ), 1, -1 );
 		return $value;
 	}
 

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -600,7 +600,10 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 		$this->log_debug( __METHOD__ . '() - log body setting ' . $this->body . ' :: ' . $this->raw_body );
 		if ( $this->body == 'raw' ) {
 			$body = $this->raw_body;
+			add_filter( 'gform_merge_tag_filter', array( $this, 'filter_gform_merge_tag_webhook_raw_encode' ), 40, 5 );
 			$body = GFCommon::replace_variables( $body, $this->get_form(), $entry, false, false, false, 'text' );
+			remove_filter( 'gform_merge_tag_filter', array( $this, 'filter_gform_merge_tag_webhook_raw_encode' ), 40 );
+
 			$this->log_debug( __METHOD__ . '() - got body after replace vars: ' . $body );
 		} elseif ( in_array( $method, array( 'POST', 'PUT', 'PATCH' ) ) ) {
 			$body = $this->get_request_body();
@@ -792,6 +795,24 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 		do_action( 'gravityflow_post_webhook', $response, $args, $entry, $this );
 
 		return $step_status;
+	}
+
+	/**
+	* Ensure gform_merge_tag contents to be passed to the outgoing webhook are properly escaped.
+	*
+	* @since 2.4.5
+	*
+	* @param string              $value       The current merge tag value after initial tag conversion.
+	* @param string              $merge_tag   The merge tag being executed.
+	* @param string              $modifier    The string containing any modifiers for this merge tag.
+	* @param GF_Field            $field       The current field.
+	* @param mixed               $raw_value   The raw value submitted for this field.
+	*
+	* @return string
+	*/
+	function filter_gform_merge_tag_webhook_raw_encode( $value, $merge_tag, $modifier, $field, $raw_value ) {
+		$value = preg_replace( '/(?<!\\\\)[\"]/', '\\"', $value );
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
See [HS#8371](https://secure.helpscout.net/conversation/798625291/8371?folderId=1776095)

When the outgoing webhook step setting Request Body to Raw Request and merge tags were used within the body, any JSON reserved characters ( : " / tab, etc) would not be properly encoded and would not result in the expected data being sent.

Using a late hook to gform_merge_tag_filter this branch/PR ensures that any uses of merge tags have their values json_encoded prior to the webhook being sent.

**Test Instructions**
- Create an outgoing webhook step with Request Body set to Raw and use {:1} or other merge tags in the body
- Submit a form that has JSON reserved characters in the field of merge tag use
- Capture the API outgoing value and [validate the JSON format](https://jsonlint.com/)
- Switch to this branch and re-perform the test. Note that the validation of JSON will pass.
- Consider whether it would funny (or not) as a programmer to name your child JSON instead of Jason
