### PR TITLE
Fix "roles" aren't added to users in the "Update User" step

### DIFF
--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -212,7 +212,7 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 					'tooltip'  => sprintf( '<h6>%s</h6> %s', esc_html__( 'Roles', 'gravityflow' ), esc_html__( 'Select how the user\'s roles should be updated.', 'gravityflow' ) ),
 				),
 				array(
-					'name'       => 'roles',
+					'name'       => 'roles[]',
 					'label'      => esc_html__( 'Select Roles', 'gravityflow' ),
 					'type'       => 'select',
 					'multiple'   => 'multiple',


### PR DESCRIPTION
This PR fixes an issue reported in this ticket: [HS#8531](https://secure.helpscout.net/conversation/808963392/8531?folderId=2308452), that "Update User" workflow step does not seem to be updating roles.

## Testing instructions
To replicate the issue :
1. Import and publish the attached form.
2. Edit and assign the 'Approval' step to a user of your choice.
3. Configure the 'update user' step as shown here.
4. Submit the form and Approve the entry. The new role will not be added to the user.

With this PR, you'll have to update the "Update User" step to get the settings updated. Then restart the workflow or submit new entries, it would then work as expected. 