### PR TITLE
Resolve Assignee field type issue with extra choices due to placeholder setting

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed the workflows for GP Nested Forms child entries starting before some Gravity Perks extensions had updated the entries.
 - Fixed an issue that prevented conditional routing from correctly matching date field conditions.
+- Fixed an issue that assignee fields with placeholder text would have invalid blank selection options on user input steps.

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -141,6 +141,7 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 
 			if ( ! empty( $account_choices ) ) {
 				$users_opt_group              = new GF_Field();
+				//Placeholder set to None to prevents GFCommon::get_select_choices() adding an empty option when the view query arg is set to entry.
 				$users_opt_group->placeholder = 'None';
 				$users_opt_group->choices     = $account_choices;
 
@@ -158,6 +159,7 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 
 			if ( ! empty( $role_choices ) ) {
 				$roles_opt_group              = new GF_Field();
+				//Placeholder set to None to prevents GFCommon::get_select_choices() adding an empty option when the view query arg is set to entry.
 				$roles_opt_group->placeholder = 'None';
 				$roles_opt_group->choices     = $role_choices;
 
@@ -185,6 +187,7 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 
 				if ( ! empty( $fields_choices ) ) {
 					$fields_opt_group             = new GF_Field();
+					//Placeholder set to None to prevents GFCommon::get_select_choices() adding an empty option when the view query arg is set to entry.
 					$fields_opt_group->placeholder = 'None';
 					$fields_opt_group->choices    = $fields_choices;
 

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -140,12 +140,13 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 			$account_choices = apply_filters( 'gravityflow_assignee_field_users', $account_choices, $form_id, $this );
 
 			if ( ! empty( $account_choices ) ) {
-				$users_opt_group          = new GF_Field();
-				$users_opt_group->choices = $account_choices;
+				$users_opt_group              = new GF_Field();
+				$users_opt_group->placeholder = 'None';
+				$users_opt_group->choices     = $account_choices;
 
 				$optgroups[] = array(
 					'label'   => __( 'Users', 'gravityflow' ),
-					'choices' => GFCommon::get_select_choices( $users_opt_group, $value ),
+					'choices' => GFCommon::get_select_choices( $users_opt_group, $value, false ),
 				);
 			}
 		}
@@ -156,13 +157,14 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 			$role_choices = apply_filters( 'gravityflow_assignee_field_roles', $role_choices, $form_id, $this );
 
 			if ( ! empty( $role_choices ) ) {
-				$roles_opt_group          = new GF_Field();
-				$roles_opt_group->choices = $role_choices;
+				$roles_opt_group              = new GF_Field();
+				$roles_opt_group->placeholder = 'None';
+				$roles_opt_group->choices     = $role_choices;
 
 				$optgroups[] = array(
 					'label'   => __( 'Roles', 'gravityflow' ),
 					'key'     => 'roles',
-					'choices' => GFCommon::get_select_choices( $roles_opt_group, $value ),
+					'choices' => GFCommon::get_select_choices( $roles_opt_group, $value, false ),
 				);
 			}
 		}
@@ -182,12 +184,13 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 				$fields_choices = apply_filters( 'gravityflow_assignee_field_fields', $fields_choices, $form_id, $this );
 
 				if ( ! empty( $fields_choices ) ) {
-					$fields_opt_group          = new GF_Field();
-					$fields_opt_group->choices = $fields_choices;
+					$fields_opt_group             = new GF_Field();
+					$fields_opt_group->placeholder = 'None';
+					$fields_opt_group->choices    = $fields_choices;
 
 					$optgroups[] = array(
 						'label'   => __( 'Fields', 'gravityflow' ),
-						'choices' => GFCommon::get_select_choices( $fields_opt_group, $value ),
+						'choices' => GFCommon::get_select_choices( $fields_opt_group, $value, false ),
 					);
 				}
 			}


### PR DESCRIPTION
See [HS #8602](https://secure.helpscout.net/conversation/813686335/8602?folderId=1776095)

**Issue:**
Assignee workflow field, adds a blank entry in the list of assignees (users, roles and fields) when a 'Placeholder' text is added. If this blank value is selected as assignee, the user with the alphabetical priority of 'Name' will be assigned.

![image](https://user-images.githubusercontent.com/4549984/55204216-84711280-51a4-11e9-81c1-1b8175c542d9.png)

**Steps to replicate the issue:**
- Create a form with an Assignee field and add a placeholder text under Appearance -> Placeholder.
- Add a 'User Input' workflow step. 
- Make the Assignee field editable and assign the step to yourself.
- Publish and Submit the form
- The Assignee field will include blank options as first in Users choice block, Roles choice block and Fields choice block.
- Checkout the fix-assignee-placeholder branch and reload the user input step.
- Note that the blank options are not available.