### PR TITLE
Enhance the security of the Update User step

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1569,6 +1569,8 @@ PRIMARY KEY  (id)
 
 			if ( $current_step ) {
 				$required_capabilities = $current_step->get_required_capabilities();
+				// Checking ALL required capabilities, one by one.
+                // In this way, we can also match the "gform_full_access" cap with other Gravity Form or Gravity Flow caps.
 				foreach ( $required_capabilities as $cap ) {
 					if ( ! $this->current_user_can_any( $cap ) ) {
 						GFCommon::add_error_message( esc_html__( "You don't have sufficient permissions to update the step settings.", 'gravityflow' ) );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1570,7 +1570,7 @@ PRIMARY KEY  (id)
 			if ( $current_step ) {
 				$required_capabilities = $current_step->get_required_capabilities();
 				foreach ( $required_capabilities as $cap ) {
-					if ( ! current_user_can( $cap ) ) {
+					if ( ! $this->current_user_can_any( $cap ) ) {
 						GFCommon::add_error_message( esc_html__( "You don't have sufficient permissions to update the step settings.", 'gravityflow' ) );
 
 						return false;

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1548,6 +1548,9 @@ PRIMARY KEY  (id)
 
 		/**
 		 * Sets the _assignee_settings_md5 class property on feed validation, if there are entries on this step.
+         *
+         * @since 2.5     Add new checks for step required capabilities.
+         * @since unknown
 		 *
 		 * @param array  $field         The field properties.
 		 * @param string $field_setting The field value.
@@ -1562,6 +1565,17 @@ PRIMARY KEY  (id)
 			if ( $current_step_id ) {
 				$current_step = $this->get_step( $current_step_id );
 				$entry_count = $current_step->entry_count();
+			}
+
+			if ( $current_step ) {
+				$required_capabilities = $current_step->get_required_capabilities();
+				foreach ( $required_capabilities as $cap ) {
+					if ( ! current_user_can( $cap ) ) {
+						GFCommon::add_error_message( esc_html__( "You don't have sufficient permissions to update the step settings.", 'gravityflow' ) );
+
+						return false;
+					}
+				}
 			}
 
 			$assignee_settings = array();

--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -286,9 +286,13 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 
 		if ( ! $user ) {
 			$this->log_debug( __METHOD__ . '(): user not found. Bailing.' );
+			$this->add_note( sprintf( esc_html__( '%s: User not found.', 'gravityflow' ), $this->get_name() ) );
+		} elseif ( is_multisite() && ! is_user_member_of_blog( $user->ID, get_current_blog_id() ) ) {
+			$this->log_debug( __METHOD__ . '(): user is not a member of the current site. Bailing.' );
+			$this->add_note( sprintf( esc_html__( '%s: User is not a member of the current site.', 'gravityflow' ), $this->get_name() ) );
+		} else {
+			$this->set_user_properties( $user );
 		}
-
-		$this->set_user_properties( $user );
 
 		return true;
 	}

--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -249,13 +249,29 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 	}
 
 	/**
+	 * Get required capabilities for the step.
+	 *
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public function get_required_capabilities() {
+		$required_capabilities = parent::get_required_capabilities();
+
+		// To update user, we require the workflow admin having the "edit_users" cap.
+		array_push( $required_capabilities, 'edit_users' );
+
+		return $required_capabilities;
+	}
+
+	/**
 	 * Processes the step and updates the user profile if the user can be found.
 	 *
 	 * @since 2.5
 	 *
 	 * @return bool
 	 */
-	function process() {
+	public function process() {
 		$this->log_debug( __METHOD__ . '(): starting' );
 
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -445,6 +445,15 @@ abstract class Gravity_Flow_Step extends stdClass {
 	}
 
 	/**
+	 * Get required capabilities for the step.
+	 *
+	 * @since 2.5
+	 */
+	public function get_required_capabilities() {
+		return array( 'gravityflow_create_steps' );
+	}
+
+	/**
 	 * Returns the ID of the Form object for the step.
 	 *
 	 * @return int


### PR DESCRIPTION
This PR adds a multisite validation in the Update User step that before updating the user data, we check if the user is a member of the current site. Their data won't be updated if they are not members of the current site, and an entry note will be added to address it.

Also, we add a new method `get_required_capabilities()` in the `Gravity_Flow_Step` class. When saving step settings, we will check if the current user has all required capabilities. We then add a new required capability "edit_users" for the Update User step. So now users without the "edit_users" cap, can only view the step but will not be able to update the step.

We also add entry notes when the user cannot be found at all.

## Testing instructions
1. Testing form: [gravityforms-export-2019-03-30.json.zip](https://github.com/gravityflow/gravityflow/files/3025419/gravityforms-export-2019-03-30.json.zip)
2. Test with a multisite network. Better to set different users in different blogs.
3. When submitting the form, mess up the "User" dropdown by changing the option value in DOM. Switch the user id to a user on another subsite.
4. We expect the user cannot be updated and we see an entry note declares that.
5. Try to use plugins like "Members" to assign required Gravity Forms caps and also the "gravityflow_create_steps" cap for the "Editor" role.
6. Log in as an Editor user, try to add/edit workflow steps. You should be able to update all steps except the Update User step.