### PR TITLE
Fix issue with inbox due date column displaying default date value

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed an issue with inbox shortcode displaying a default value for due date when no step settings had been defined.
+- Fixed an issue with calculation of a step being overdue or not based on step starting time.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,3 @@
-- Fixed an issue with due date column on inbox shortcode displaying a default value when no step settings had been defined.
+- Fixed an issue with due date column of inbox shortcode displaying a default value when no step settings had been defined.
 - Fixed an issue with due date row highlighting related to overdue calculation and step starting time.
 - Fixed the workflow stalling on the Dropbox step when there are no files to process.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with inbox shortcode displaying a default value for due date when no step settings had been defined.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,3 @@
 - Fixed an issue with due date column of inbox shortcode displaying a default value when no step settings had been defined.
-- Fixed an issue with due date row highlighting related to overdue calculation and step starting time.
+- Fixed an issue with the inbox incorrectly highlighting some entries as overdue.
 - Fixed the workflow stalling on the Dropbox step when there are no files to process.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -232,14 +232,8 @@ class Gravity_Flow_Inbox {
 		if ( array_key_exists( 'step_highlight', $columns ) && isset( $entry['workflow_step'] ) ) {
 			$step = gravity_flow()->get_step( $entry['workflow_step'] );
 			if ( $step ) {
-				$meta = $step->get_feed_meta();
-
-				if ( $meta && isset( $meta['step_highlight'] ) && $meta['step_highlight'] ) {
-					if ( isset( $meta['step_highlight_type'] ) && $meta['step_highlight_type'] == 'color' ) {
-						if ( isset( $meta['step_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['step_highlight_color'] ) ) {
-							$step_highlight_color = $meta['step_highlight_color'];
-						}
-					}
+				if ( $step->step_highlight && $step->step_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->step_highlight_color ) ) {
+					$step_highlight_color = $step->step_highlight_color;
 				}
 			}
 		}
@@ -248,12 +242,8 @@ class Gravity_Flow_Inbox {
 		if ( isset( $entry['workflow_step'] ) ) {
 			$step = gravity_flow()->get_step( $entry['workflow_step'] );
 			if ( $step ) {
-				$meta = $step->get_feed_meta();
-
-				if ( $meta && isset( $meta['due_date'], $meta['due_date_highlight_type'], $meta['due_date_highlight_color'] ) ) {
-					if ( $meta['due_date'] && $meta['due_date_highlight_type'] == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
-						$due_date_highlight_color = $meta['due_date_highlight_color'];
-					}
+				if ( $step->due_date && $step->due_date_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->due_date_highlight_color ) ) {
+					$due_date_highlight_color = $step->due_date_highlight_color;
 				}
 			}
 		}

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -360,7 +360,7 @@ class Gravity_Flow_Inbox {
 			case 'due_date':
 				$api = new Gravity_Flow_API( $form['id'] );
 				$step = $api->get_current_step( $entry );
-				if ( $step ) {
+				if ( $step && $step->due_date ) {
 					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 				}
 				break;

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -250,8 +250,8 @@ class Gravity_Flow_Inbox {
 			if ( $step ) {
 				$meta = $step->get_feed_meta();
 
-				if ( $meta && isset( $meta['due_date_highlight_type'] ) && $meta['due_date_highlight_type'] == 'color' ) {
-					if ( isset( $meta['due_date_highlight_color'] ) && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
+				if ( $meta && isset( $meta['due_date'], $meta['due_date_highlight_type'], $meta['due_date_highlight_color'] ) ) {
+					if ( $meta['due_date_highlight_type'] == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
 						$due_date_highlight_color = $meta['due_date_highlight_color'];
 					}
 				}

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -251,7 +251,7 @@ class Gravity_Flow_Inbox {
 				$meta = $step->get_feed_meta();
 
 				if ( $meta && isset( $meta['due_date'], $meta['due_date_highlight_type'], $meta['due_date_highlight_color'] ) ) {
-					if ( $meta['due_date_highlight_type'] == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
+					if ( $meta['due_date'] && $meta['due_date_highlight_type'] == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $meta['due_date_highlight_color'] ) ) {
 						$due_date_highlight_color = $meta['due_date_highlight_color'];
 					}
 				}

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1905,7 +1905,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 	public function is_overdue() {
 		$step_due_date = $this->get_due_date_timestamp();
 		$step_timestamp = $this->get_step_timestamp();
-		if ( (int) $step_due_date < (int) $step_timestamp ) {
+		if ( (int) $step_due_date < (int) time() ) {
 			return true;
 		}
 		return false;

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1899,6 +1899,8 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 	/**
 	 * Returns TRUE if this step is past the defined due date.
+	 * 
+	 * @since 2.5
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
**Issue:**
[gravityflow page="inbox" due_date="true"] would display current date for columns that did not have any due date settings defined.

Addresses [HS8792](https://secure.helpscout.net/conversation/823836949/8792/)

**Test Instructions**
* Create a form with at least one step that does not have due date settings defined.
* Add [gravityflow page="inbox" due_date="true"] to a page
* See that the due date column shows current date
* Switch to fix-due-date-default branch
* See that entry w/o due date settings have blank value in due date column
