### PR TITLE
Fix notice when evaluating conditional routing

### DIFF
--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1994,7 +1994,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		} else {
 			$source_field   = GFFormsModel::get_field( $form, $field_id );
 			$field_value    = empty( $entry ) ? GFFormsModel::get_field_value( $source_field, array() ) : GFFormsModel::get_lead_field_value( $entry, $source_field );
-			if ( $source_field->type == 'post_category' ) {
+			if ( $source_field && $source_field->type == 'post_category' ) {
 				// Post category values are in the format [name]:[id] e.g. cat-1:1 but GFFormsModel::is_value_match() expects just the category ID.
 				$ary                   = explode( ':', $routing_rule['value'] );
 				$routing_rule['value'] = $ary[1];


### PR DESCRIPTION
This PR fixes a PHP notice when evaluating conditional routing.

**Testing instructions**
To reproduce, set up conditional routing to use any field as part of a condition. Submit an entry and open the entry in the workflow detail page.

