### PR TITLE
Allow highlight value to be returned like other column values

### DIFF
--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -228,47 +228,7 @@ class Gravity_Flow_Inbox {
 		 */
 		$link = apply_filters( 'gravityflow_entry_link_inbox_table', $link, $url_entry, $entry, $args );
 
-		$step_highlight_color = '';
-		if ( array_key_exists( 'step_highlight', $columns ) && isset( $entry['workflow_step'] ) ) {
-			$step = gravity_flow()->get_step( $entry['workflow_step'] );
-			if ( $step ) {
-				if ( $step->step_highlight && $step->step_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->step_highlight_color ) ) {
-					$step_highlight_color = $step->step_highlight_color;
-				}
-			}
-		}
-
-		$due_date_highlight_color = '';
-		if ( isset( $entry['workflow_step'] ) ) {
-			$step = gravity_flow()->get_step( $entry['workflow_step'] );
-			if ( $step ) {
-				if ( $step->due_date && $step->due_date_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->due_date_highlight_color ) ) {
-					$due_date_highlight_color = $step->due_date_highlight_color;
-				}
-			}
-		}
-
-		if ( ! empty( $due_date_highlight_color ) ) {
-			$step->_entry = $entry;
-			$overdue = $step->is_overdue();
-			if ( $overdue ) {
-				$step_highlight_color = $due_date_highlight_color;
-			}
-		}
-
-		/**
-		 * Allow the Step Highlight colour to be overridden.
-		 *
-		 * @since 1.9.2
-		 *
-		 * @param string $highlight  The highlight color (hex value) of the row currently being processed.
-		 * @param int    $form['id'] The ID of form currently being processed.
-		 * @param array  $entry      The entry object for the row currently being processed.
-		 *
-		 * @return string
-		 */
-		$step_highlight_color = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
-
+		$step_highlight_color = self::get_column_value( 'step_highlight', $form, $entry, $columns );
 		if ( strlen( $step_highlight_color ) > 0 ) {
 			echo '<tr style="border-left-color: ' . $step_highlight_color . ';">';
 		} else {
@@ -299,6 +259,37 @@ class Gravity_Flow_Inbox {
 	public static function get_column_value( $id, $form, $entry, $columns ) {
 		$value = '';
 		switch ( strtolower( $id ) ) {
+            case 'step_highlight':
+	            $step_highlight_color = '';
+	            if ( array_key_exists( 'step_highlight', $columns ) && isset( $entry['workflow_step'] ) ) {
+		            $step = gravity_flow()->get_step( $entry['workflow_step'] );
+		            if ( $step ) {
+			            if ( $step->step_highlight && $step->step_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->step_highlight_color ) ) {
+				            $step_highlight_color = $step->step_highlight_color;
+			            }
+		            }
+	            }
+
+	            if ( isset( $entry['workflow_step'] ) ) {
+		            $step = gravity_flow()->get_step( $entry['workflow_step'], $entry );
+		            if ( $step && $step->due_date && $step->is_overdue() && $step->due_date_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->due_date_highlight_color )) {
+		                $step_highlight_color = $step->due_date_highlight_color;
+		            }
+	            }
+
+	            /**
+	             * Allow the Step Highlight colour to be overridden.
+	             *
+	             * @since 1.9.2
+	             *
+	             * @param string $step_highlight_color  The highlight color (hex value) of the row currently being processed.
+	             * @param int    $form['id'] The ID of form currently being processed.
+	             * @param array  $entry      The entry object for the row currently being processed.
+	             *
+	             * @return string
+	             */
+	            $value = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
+	            break;
 			case 'form_title':
 				$value = rgar( $form, 'title' );
 				break;
@@ -351,8 +342,10 @@ class Gravity_Flow_Inbox {
 				$api = new Gravity_Flow_API( $form['id'] );
 				$step = $api->get_current_step( $entry );
 				if ( $step && $step->due_date ) {
-					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
-				}
+					$value =  Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
+				} else {
+					$value = '-';
+                }
 				break;
 			default:
 				$field = GFFormsModel::get_field( $form, $id );

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -150,7 +150,7 @@ class Gravity_Flow_Inbox {
 			$columns['actions'] = '';
 		}
 
-		if ( empty( $args['form_id'] ) || is_array( $args['form_id']) ) {
+		if ( empty( $args['form_id'] ) || is_array( $args['form_id'] ) ) {
 			$columns['form_title'] = __( 'Form', 'gravityflow' );
 		}
 
@@ -259,37 +259,36 @@ class Gravity_Flow_Inbox {
 	public static function get_column_value( $id, $form, $entry, $columns ) {
 		$value = '';
 		switch ( strtolower( $id ) ) {
-            case 'step_highlight':
-	            $step_highlight_color = '';
-	            if ( array_key_exists( 'step_highlight', $columns ) && isset( $entry['workflow_step'] ) ) {
-		            $step = gravity_flow()->get_step( $entry['workflow_step'] );
-		            if ( $step ) {
-			            if ( $step->step_highlight && $step->step_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->step_highlight_color ) ) {
-				            $step_highlight_color = $step->step_highlight_color;
-			            }
-		            }
-	            }
+			case 'step_highlight':
+				$step_highlight_color = '';
+				if ( array_key_exists( 'step_highlight', $columns ) && isset( $entry['workflow_step'] ) ) {
+					$step = gravity_flow()->get_step( $entry['workflow_step'] );
+					if ( $step ) {
+						if ( $step->step_highlight && $step->step_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->step_highlight_color ) ) {
+							$step_highlight_color = $step->step_highlight_color;
+						}
+					}
+				}
 
-	            if ( isset( $entry['workflow_step'] ) ) {
-		            $step = gravity_flow()->get_step( $entry['workflow_step'], $entry );
-		            if ( $step && $step->due_date && $step->is_overdue() && $step->due_date_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->due_date_highlight_color )) {
-		                $step_highlight_color = $step->due_date_highlight_color;
-		            }
-	            }
-
-	            /**
-	             * Allow the Step Highlight colour to be overridden.
-	             *
-	             * @since 1.9.2
-	             *
-	             * @param string $step_highlight_color  The highlight color (hex value) of the row currently being processed.
-	             * @param int    $form['id'] The ID of form currently being processed.
-	             * @param array  $entry      The entry object for the row currently being processed.
-	             *
-	             * @return string
-	             */
-	            $value = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
-	            break;
+				if ( isset( $entry['workflow_step'] ) ) {
+					$step = gravity_flow()->get_step( $entry['workflow_step'], $entry );
+					if ( $step && $step->due_date && $step->is_overdue() && $step->due_date_highlight_type == 'color' && preg_match( '/^#[a-f0-9]{6}$/i', $step->due_date_highlight_color ) ) {
+						$step_highlight_color = $step->due_date_highlight_color;
+					}
+				}
+				/**
+				 * Allow the Step Highlight colour to be overridden.
+				 *
+				 * @since 1.9.2
+				 *
+				 * @param string $step_highlight_color  The highlight color (hex value) of the row currently being processed.
+				 * @param int    $form['id'] The ID of form currently being processed.
+				 * @param array  $entry      The entry object for the row currently being processed.
+				 *
+				 * @return string
+				 */
+				$value = apply_filters( 'gravityflow_step_highlight_color_inbox', $step_highlight_color, $form['id'], $entry );
+				break;
 			case 'form_title':
 				$value = rgar( $form, 'title' );
 				break;
@@ -342,10 +341,10 @@ class Gravity_Flow_Inbox {
 				$api = new Gravity_Flow_API( $form['id'] );
 				$step = $api->get_current_step( $entry );
 				if ( $step && $step->due_date ) {
-					$value =  Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
+					$value = Gravity_Flow_Common::format_date( date( 'Y-m-d H:i:s', $step->get_due_date_timestamp() ), '', true, false );
 				} else {
 					$value = '-';
-                }
+				}
 				break;
 			default:
 				$field = GFFormsModel::get_field( $form, $id );


### PR DESCRIPTION
This PR moves the step highlight logic into the same method as the other column values. This helps to separate the markup from the values for the PHP API and REST API.

**Testing instructions**
Check the highlight works as expected in both the shortcode and admin. Check the overdue highlight works as expected with and without overriding the step highlight setting.