### PR TITLE
Fix schedule date field settings

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
 - Fixed an issue with due date column of inbox shortcode displaying a default value when no step settings had been defined.
 - Fixed an issue with the inbox incorrectly highlighting some entries as overdue.
 - Fixed the workflow stalling on the Dropbox step when there are no files to process.
+- Fixed an issue with the display of schedule date field settings.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2284,7 +2284,7 @@ PRIMARY KEY  (id)
 						),
 					);
 
-					printf( $date_field_label, $this->settings_text( $delay_offset_field, false ), $this->settings_select( $unit_field, false ), $this->settings_select( $before_after_field ), $this->settings_select( $schedule_date_fields ) );
+					printf( $date_field_label, $this->settings_text( $delay_offset_field, false ), $this->settings_select( $unit_field, false ), $this->settings_select( $before_after_field, false ), $this->settings_select( $schedule_date_fields, false ) );
 
 					?>
 				</div>


### PR DESCRIPTION
This PR adds missing echo parameter to 2 of the calls to settings_select during step settings definition which was causes the before/after and date-field selector to display twice. Appears to be introduced via #208.

![image](https://user-images.githubusercontent.com/4549984/56175990-8110c000-5fc7-11e9-88be-e937ee6021b2.png)