### PR TITLE
Fix Notification Step with multi-user field assignee(s)

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with notification step not identifying all users in a multi-user field for notification.

--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -376,41 +376,55 @@ class Gravity_Flow_Assignee {
 		$assignee_type = $this->get_type();
 		$assignee_id   = $this->get_id();
 
-		if ( $assignee_type == 'email' ) {
-			$email                = $assignee_id;
-			$notification['id']   = 'workflow_step_' . $this->step->get_id() . '_email_' . $email;
-			$notification['name'] = $notification['id'];
-			$notification['to']   = $email;
-			$message              = $this->replace_variables( $message );
-			// Call $this->step->replace_variables() for backwards compatibility
-			$notification['message'] = $this->step->replace_variables( $message, $this );
-			$this->step->send_notification( $notification );
+		switch ( $assignee_type ) {
+			case 'email':
+				$email                = $assignee_id;
+				$notification['id']   = 'workflow_step_' . $this->step->get_id() . '_email_' . $email;
+				$notification['name'] = $notification['id'];
+				$notification['to']   = $email;
+				$message              = $this->replace_variables( $message );
+				// Call $this->step->replace_variables() for backwards compatibility
+				$notification['message'] = $this->step->replace_variables( $message, $this );
+				$this->step->send_notification( $notification );
 
-			return;
+				return;
+
+			case 'role':
+				$users = get_users( array( 'role' => $assignee_id ) );
+				break;
+
+			case 'assignee_multi_user_field':
+				$entry = $this->step->get_entry();
+				if ( isset( $entry[ $assignee_id ] ) ) {
+					$user_ids = json_decode( $entry[ $assignee_id ] );
+					$users    = get_users( array( 'include' => $user_ids ) );
+				}
+				break;
+
+			default:
+				$users = get_users( array( 'include' => array( $assignee_id ) ) );
 		}
 
-		if ( $assignee_type == 'role' ) {
-			$users = get_users( array( 'role' => $assignee_id ) );
-		} else {
-			$users = get_users( array( 'include' => array( $assignee_id ) ) );
-		}
+		if ( isset( $users ) ) {
 
-		$this->step->log_debug( __METHOD__ . sprintf( '() sending notifications to %d users', count( $users ) ) );
+			$this->step->log_debug( __METHOD__ . sprintf( '() sending notifications to %d users', count( $users ) ) );
 
-		$user_assignee_args = array(
-			'type' => $assignee_type,
-			'id'   => $assignee_id,
-		);
-		foreach ( $users as $user ) {
-			$user_assignee_args['user'] = $user;
-			$user_assignee              = Gravity_Flow_Assignees::create( $user_assignee_args, $this->step );
-			$notification['id']         = 'workflow_step_' . $this->step->get_id() . '_user_' . $user->ID;
-			$notification['name']       = $notification['id'];
-			$notification['to']         = $user->user_email;
-			$message                    = $user_assignee->replace_variables( $message );
-			// Call $this->step->replace_variables() for backwards compatibility
-			$notification['message'] = $this->step->replace_variables( $message, $user_assignee );
-			$this->step->send_notification( $notification );
+			$user_assignee_args = array(
+				'type' => $assignee_type,
+				'id'   => $assignee_id,
+			);
+
+			foreach ( $users as $user ) {
+				$user_assignee_args['user'] = $user;
+				$user_assignee              = Gravity_Flow_Assignees::create( $user_assignee_args, $this->step );
+				$notification['id']         = 'workflow_step_' . $this->step->get_id() . '_user_' . $user->ID;
+				$notification['name']       = $notification['id'];
+				$notification['to']         = $user->user_email;
+				$message                    = $user_assignee->replace_variables( $message );
+				// Call $this->step->replace_variables() for backwards compatibility
+				$notification['message'] = $this->step->replace_variables( $message, $user_assignee );
+				$this->step->send_notification( $notification );
+			}
 		}
 	}
 

--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -395,7 +395,7 @@ class Gravity_Flow_Assignee {
 
 			case 'assignee_multi_user_field':
 				$entry = $this->step->get_entry();
-				if ( isset( $entry[ $assignee_id ] ) ) {
+				if ( ! empty( $entry[ $assignee_id ] ) ) {
 					$user_ids = json_decode( $entry[ $assignee_id ] );
 					$users    = get_users( array( 'include' => $user_ids ) );
 				}


### PR DESCRIPTION
[See HS#8868](https://secure.helpscout.net/conversation/829212605/8868?folderId=1113492)

If a notification step has a multi-user field set as the assignee and entry contains multiple selections the current version will not deliver a notification to the multiple users selected.

**To Test**
* Create a form with one (or more multi-user workflow fields)
* Create a notification step with the multi-user fields as assignee
* Submit an entry and check email delivery (mailhog in local)
* Note that not all expected recipients received the notification
* Switch to fix-multiuser-field-notification branch and repeat notification step
* Receive all expected notifications
