### PR TITLE
Release entries from a Sliced Invoices step when invoice status updated manually

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue when Sliced Invoices status was manually updated to paid, entries weren't released from Sliced Invoices steps.

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -317,8 +317,27 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 		}
 	}
 
+	/**
+	 * Hook function to detect manual invoice status change.
+	 *
+	 * @since 2.5.3
+	 *
+	 * @param int    $object_id  Object ID.
+	 * @param array  $terms      An array of object terms.
+	 * @param array  $tt_ids     An array of term taxonomy IDs.
+	 * @param string $taxonomy   Taxonomy slug.
+	 */
+	public static function invoice_status_manual_update( $object_id, $terms, $tt_ids, $taxonomy ) {
+		if ( function_exists( 'run_sliced_invoices' ) && $taxonomy === 'invoice_status' ) {
+			self::invoice_status_update( $object_id, $terms[0] );
+		}
+	}
+
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Sliced_Invoices() );
 
 add_action( 'sliced_invoice_status_update', array( 'Gravity_Flow_Step_Feed_Sliced_Invoices', 'invoice_status_update' ), 10, 2 );
+
+// Detect manual invoice status update.
+add_action( 'set_object_terms', array( 'Gravity_Flow_Step_Feed_Sliced_Invoices', 'invoice_status_manual_update' ), 10, 4 );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -340,4 +340,5 @@ Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Sliced_Invoices() );
 add_action( 'sliced_invoice_status_update', array( 'Gravity_Flow_Step_Feed_Sliced_Invoices', 'invoice_status_update' ), 10, 2 );
 
 // Detect manual invoice status update.
-add_action( 'set_object_terms', array( 'Gravity_Flow_Step_Feed_Sliced_Invoices', 'invoice_status_manual_update' ), 10, 4 );
+// Set priority to 30 because Sliced Invoices triggers `set_object_terms` with priority 20.
+add_action( 'set_object_terms', array( 'Gravity_Flow_Step_Feed_Sliced_Invoices', 'invoice_status_manual_update' ), 30, 4 );

--- a/includes/steps/class-step-feed-slicedinvoices.php
+++ b/includes/steps/class-step-feed-slicedinvoices.php
@@ -329,7 +329,14 @@ class Gravity_Flow_Step_Feed_Sliced_Invoices extends Gravity_Flow_Step_Feed_Add_
 	 */
 	public static function invoice_status_manual_update( $object_id, $terms, $tt_ids, $taxonomy ) {
 		if ( function_exists( 'run_sliced_invoices' ) && $taxonomy === 'invoice_status' ) {
-			self::invoice_status_update( $object_id, $terms[0] );
+			if ( rgar( $terms, 'term_id' ) ) {
+				$term   = get_term( $terms['term_id'] );
+				$status = $term->slug;
+			} else {
+				$status = $terms[0];
+			}
+
+			self::invoice_status_update( $object_id, $status );
 		}
 	}
 


### PR DESCRIPTION
re:[HS#8805](https://secure.helpscout.net/conversation/824853488/8805?folderId=2308452)

This PR fixes an issue that a Sliced Invoices step cannot be released when the status is manually updated to Paid.

Currently we depend on the hook action `sliced_invoice_status_update` to release entries from a Sliced Invoices step. But it is only called when payments are made by the PayPal gateway, thus manually updating invoice status cannot trigger the workflow step at all.

## Testing instructions
1. Reproduce the issue based on the ticket notes.
2. Switch to this branch, the entries should be released as expected.