### PR TITLE
Fix filter name gravityflow_assignee_eamil_reminder_repeat_days

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Add filter gravityflow_assignee_email_reminder_repeat_days and include depreciation notice for gravityflow_assignee_eamil_reminder_repeat_days.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6797,6 +6797,8 @@ AND m.meta_value='queued'";
 									$this->log_debug( __METHOD__ . '(): not sending first reminder to ' . $assignee->get_key() . ' for entry ' . $entry['id'] . ' because a reminder was already sent: ' . get_date_from_gmt( date( 'Y-m-d H:i:s', $reminder_timestamp ), 'F j, Y H:i:s' ) );
 									if ( $current_step->resend_assignee_email_repeatEnable ) {
 										$repeat_days = absint( $current_step->resend_assignee_email_repeatValue );
+										//Depreciated Filter - See/Use gravityflow_assignee_email_reminder_repeat_days
+										$repeat_days = apply_filters( 'gravityflow_assignee_eamil_reminder_repeat_days', $repeat_days, $form, $entry, $current_step, $assignee );
 										/**
 										 * Allows the number of days between each assignee email reminder to be modified.
 										 *
@@ -6810,7 +6812,6 @@ AND m.meta_value='queued'";
 										 * @param Gravity_Flow_Step     $step        The current step.
 										 * @param Gravity_Flow_Assignee $assignee    The current assignee.
 										 */
-										$repeat_days = apply_filters( 'gravityflow_assignee_eamil_reminder_repeat_days', $repeat_days, $form, $entry, $current_step, $assignee );
 										$repeat_days = apply_filters( 'gravityflow_assignee_email_reminder_repeat_days', $repeat_days, $form, $entry, $current_step, $assignee );
 										if ( $repeat_days > 0 ) {
 											$repeat_trigger_timestamp = $reminder_timestamp + ( (int) $repeat_days * DAY_IN_SECONDS );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6802,6 +6802,8 @@ AND m.meta_value='queued'";
 										 *
 										 * Return zero to deactivate the repeat reminder.
 										 *
+										 * @deprecated 2.5.3 - Fix typo of gravityflow_assignee_eamil_reminder_repeat_days (email)
+										 * 
 										 * @param int                   $repeat_days The number of days between each reminder.
 										 * @param array                 $form        The current form.
 										 * @param array                 $entry       The current entry.
@@ -6809,6 +6811,7 @@ AND m.meta_value='queued'";
 										 * @param Gravity_Flow_Assignee $assignee    The current assignee.
 										 */
 										$repeat_days = apply_filters( 'gravityflow_assignee_eamil_reminder_repeat_days', $repeat_days, $form, $entry, $current_step, $assignee );
+										$repeat_days = apply_filters( 'gravityflow_assignee_email_reminder_repeat_days', $repeat_days, $form, $entry, $current_step, $assignee );
 										if ( $repeat_days > 0 ) {
 											$repeat_trigger_timestamp = $reminder_timestamp + ( (int) $repeat_days * DAY_IN_SECONDS );
 											if ( time() > $repeat_trigger_timestamp ) {


### PR DESCRIPTION
See [HS#8851](https://secure.helpscout.net/conversation/827940711/8851?folderId=1776095).

Filter name gravityflow_assignee_eamil_reminder_repeat_days has typo (email).

This PR:
- Adds gravityflow_assignee_email_reminder_repeat_days (no typo)
- Updates doc block to note depreciated nature of gravityflow_assignee_eamil_reminder_repeat_days

