### PR TITLE
Fix validation to Assignee, User and Multi-User fields

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed an issue when Sliced Invoices status was manually updated to paid, entries weren't released from Sliced Invoices steps.
+- Fixed validation issue in Assignee, User and Multi-User fields

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1106,7 +1106,8 @@ PRIMARY KEY  (id)
 		public function get_users_as_choices() {
 			static $choices;
 
-			$args = apply_filters( 'gravityflow_get_users_args', array( 'orderby' => array( 'display_name', 'user_login' ), 'fields' => array( 'ID', 'display_name', 'user_login' ) ) );
+			$default_args = array( 'orderby' => array( 'display_name', 'user_login' ), 'fields' => array( 'ID', 'display_name', 'user_login' ) );
+			$args = wp_parse_args( apply_filters( 'gravityflow_get_users_args', $default_args ), $default_args );
 			$key  = md5( get_current_blog_id() . '_' . serialize( $args ) );
 
 			if ( ! isset( $choices[ $key ] ) ) {
@@ -2419,7 +2420,7 @@ PRIMARY KEY  (id)
 					),
 				),
 			);
-			
+
 			$due_date_highlight_type = array(
 				'name'           => 'due_date_highlight_type',
 				'type'           => 'hidden',
@@ -2501,7 +2502,7 @@ PRIMARY KEY  (id)
 					?>
 				</div>
 				<div class="gravityflow-due-date-highlight-field-container">
-					<?php 
+					<?php
 
 					$due_date_highlight_type_setting = $this->get_setting( 'due_date_highlight_type', 'color' );
 					$due_date_highlight_color_style = ( $due_date_highlight_type_setting == 'color' ) ? '' : 'style="display:none;"';
@@ -8131,7 +8132,7 @@ AND m.meta_value='queued'";
 					} else {
 						$target_value = strtotime( $target_value );
 					}
-					
+
 					if ( $operation == '>' && $field_value > $target_value ) {
 						return true;
 					}

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -122,13 +122,13 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 	public function get_account_choices( $form_id ) {
 		$account_choices = array();
 
-		$args = array(
+		$default_args = array(
 			'orderby' => array( 'display_name', 'user_login' ),
 			'fields'  => array( 'ID', 'display_name', 'user_login' ),
 			'role'    => $this->gravityflowUsersRoleFilter,
 		);
 
-		$args     = apply_filters( 'gravityflow_get_users_args_assignee_field', $args, $form_id, $this );
+		$args     = wp_parse_args( apply_filters( 'gravityflow_get_users_args_assignee_field', $default_args, $form_id, $this ), $default_args );
 		$accounts = get_users( $args );
 		foreach ( $accounts as $account ) {
 			$account_choices[] = array( 'value' => 'user_id|' . $account->ID, 'text' => $account->display_name );

--- a/includes/fields/class-field-assignee-select.php
+++ b/includes/fields/class-field-assignee-select.php
@@ -441,7 +441,7 @@ class Gravity_Flow_Field_Assignee_Select extends GF_Field_Select {
 
 			$values = $this->get_choices_values( $include_users, $include_roles, $include_fields );
 
-			if ( ! in_array( $value, $values, true ) ) {
+			if ( ! in_array( $value, $values ) ) {
 				$this->failed_validation  = true;
 				$this->validation_message = esc_html__( 'Invalid selection. Please select one of the available choices.', 'gravityflow' );
 			}

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -297,7 +297,7 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 			$values = wp_list_pluck( $this->get_users_as_choices(), 'value' );
 
 			foreach ( (array) $value as $_value ) {
-				if ( ! in_array( $_value, $values, true ) ) {
+				if ( ! in_array( $_value, $values ) ) {
 					$this->failed_validation  = true;
 					$this->validation_message = esc_html__( 'Invalid selection. Please select one of the available choices.', 'gravityflow' );
 

--- a/includes/fields/class-field-multi-user.php
+++ b/includes/fields/class-field-multi-user.php
@@ -111,13 +111,13 @@ class Gravity_Flow_Field_Multi_User extends GF_Field_MultiSelect {
 	public function get_users_as_choices() {
 		$form_id = $this->formId;
 
-		$args = array(
+		$default_args = array(
 			'orderby' => array( 'display_name', 'user_login' ),
 			'fields'  => array( 'ID', 'display_name', 'user_login' ),
 			'role'    => $this->gravityflowUsersRoleFilter,
 		);
 
-		$args            = apply_filters( 'gravityflow_get_users_args_user_field', $args, $form_id, $this );
+		$args            = wp_parse_args( apply_filters( 'gravityflow_get_users_args_user_field', $default_args, $form_id, $this ), $default_args );
 		$accounts        = get_users( $args );
 		$account_choices = array();
 		foreach ( $accounts as $account ) {

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -257,7 +257,7 @@ class Gravity_Flow_Field_User extends GF_Field_Select {
 		if ( ! empty( $value ) ) {
 			$values = wp_list_pluck( $this->get_users_as_choices(), 'value' );
 
-			if ( ! in_array( $value, $values, true ) ) {
+			if ( ! in_array( $value, $values ) ) {
 				$this->failed_validation  = true;
 				$this->validation_message = esc_html__( 'Invalid selection. Please select one of the available choices.', 'gravityflow' );
 			}

--- a/includes/fields/class-field-user.php
+++ b/includes/fields/class-field-user.php
@@ -107,13 +107,13 @@ class Gravity_Flow_Field_User extends GF_Field_Select {
 	public function get_users_as_choices() {
 		$form_id = $this->formId;
 
-		$args = array(
+		$default_args = array(
 			'orderby' => array( 'display_name', 'user_login' ),
 			'fields'  => array( 'ID', 'display_name', 'user_login' ),
 			'role'    => $this->gravityflowUsersRoleFilter,
 		);
 
-		$args            = apply_filters( 'gravityflow_get_users_args_user_field', $args, $form_id, $this );
+		$args            = wp_parse_args( apply_filters( 'gravityflow_get_users_args_user_field', $default_args, $form_id, $this ), $default_args );
 		$accounts        = get_users( $args );
 		$account_choices = array();
 		foreach ( $accounts as $account ) {


### PR DESCRIPTION
re:[HS#8901](https://secure.helpscout.net/conversation/831361590/8901/), [HS#8868](https://secure.helpscout.net/conversation/829212605/8868?folderId=2308452)

This PR fixes an issue introduced by PR #239 that form submissions with Assignee, User or Multi-User fields fail at validation.

When tracking down the issue we realized that if people set custom arguments for `get_users()`, without specifying the `fields` key in the array, the function returns user IDs as "integer," otherwise it returns them as "string," thus using "strict" check for `in_array()` comparison makes validation fail.

## Testing instructions
1. Create a form with Assignee, User and Multi-User fields.
2. Use the following legacy snippets to alter arguments for `get_users()`:
```
add_filter( 'gravityflow_get_users_args', 'sh_gravityflow_get_users_args');

function sh_gravityflow_get_users_args( $args ) {
	return array( 'number' => 10, 'orderby' => 'display_name' );
}

add_filter( 'gravityflow_get_users_args_assignee_field', 'sh_gravityflow_get_users_args_assignee_field');

function sh_gravityflow_get_users_args_assignee_field( $args ) {
	return array( 'number' => 10, 'orderby' => 'display_name' );
}

add_filter( 'gravityflow_get_users_args_user_field', 'sh_gravityflow_get_users_args_user_field', 10, 3 );  

function sh_gravityflow_get_users_args_user_field( $args, $form_id, $field ) { 	
	return array( 'number' => 10, 'orderby' => 'display_name' ); 
}
```
3. with the `master` branch, the validation would fail. Switch to this branch and the submission will pass.