### PR TITLE
Fix display_all for users that can gravityflow_status_view_all

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5917,7 +5917,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 				$app_settings = $this->get_app_settings();
 
-				if ( $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) ) {
+				if ( $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
 
 					$a['display_all'] = false;
 				}
@@ -5976,7 +5976,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 					if ( rgget( 'view' ) || ! empty( $entry_id ) ) {
 						$html .= $this->get_shortcode_status_page_detail( $a );
-					} elseif ( is_user_logged_in() || ( $a['display_all'] && $a['display_all'] ) ) {
+					} elseif ( is_user_logged_in() || ( $a['display_all'] && $a['allow_anonymous'] ) ) {
 						$html .= $this->get_shortcode_status_page( $a );
 					}
 			}


### PR DESCRIPTION
This PR fixes an issue with the status shortcode where the `display_all` attribute is forced to `false` when the user can `gravityflow_status_view_all`. This occurs when the `allow_display_all_attribute` setting is not enabled in the security settings.

It also fixes a typo in the check for the status page attributes.