### PR TITLE
Add forms attribute to submit shortcode

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5052,9 +5052,19 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Renders the submit page.
 		 *
-		 * @param bool $admin_ui Indicates if this is the admin page.
+		 * @param bool $args Indicates if this is the admin page.
 		 */
-		public function submit_page( $admin_ui ) {
+		public function submit_page( $args ) {
+
+			$defaults = array(
+                'admin_ui' => true,
+                'form_ids' => null
+            );
+
+			$args = array_merge( $defaults, $args );
+
+			$admin_ui = $args['admin_ui'];
+
 			?>
 			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_submit">
 				<?php if ( $admin_ui ) :	?>
@@ -5068,13 +5078,17 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$this->toolbar();
 				endif;
 				require_once( $this->get_base_path() . '/includes/pages/class-submit.php' );
+				if ( is_array( $args['form_ids'] ) ) {
+					$published_form_ids = $args['form_ids'];
+				} else {
+					$published_form_ids = gravity_flow()->get_published_form_ids();
+				}
 				if ( isset( $_GET['id'] ) ) {
 					$form_id = absint( $_GET['id'] );
-					Gravity_Flow_Submit::form( $form_id );
+				    if ( in_array( $form_id, $published_form_ids ) ) {
+					    Gravity_Flow_Submit::form( $form_id );
+                    }
 				} else {
-
-					$published_form_ids = gravity_flow()->get_published_form_ids();
-
 					Gravity_Flow_Submit::list_page( $published_form_ids , $admin_ui );
 				}
 
@@ -5966,8 +5980,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$html .= $this->get_shortcode_inbox_page( $a );
 					break;
 				case 'submit':
+					$args = array(
+						'admin_ui' => false,
+						'form_ids' => $a['forms'] ? explode( ',', $a['forms'] ) : '',
+					);
 					ob_start();
-					$this->submit_page( false );
+					$this->submit_page( $args );
 					$html .= ob_get_clean();
 					break;
 				case 'status':
@@ -6033,6 +6051,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			$defaults = array(
 				'page'             => 'inbox',
 				'form'             => null,
+				'forms'             => null,
 				'form_id'          => null,
 				'entry_id'         => null,
 				'fields'           => array(),

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6043,7 +6043,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			$defaults = array(
 				'page'             => 'inbox',
 				'form'             => null,
-				'forms'             => null,
+				'forms'            => null,
 				'form_id'          => null,
 				'entry_id'         => null,
 				'fields'           => array(),

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5972,12 +5972,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$html .= $this->get_shortcode_inbox_page( $a );
 					break;
 				case 'submit':
-					$args = array(
-						'admin_ui' => false,
-						'form_ids' => $a['forms'] ? explode( ',', $a['forms'] ) : '',
-					);
+					$form_ids = $a['forms'] ? explode( ',', $a['forms'] ) : '';
 					ob_start();
-					$this->submit_page( $args );
+					$this->submit_page( false, $form_ids );
 					$html .= ob_get_clean();
 					break;
 				case 'status':

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5052,18 +5052,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Renders the submit page.
 		 *
-		 * @param bool $args Indicates if this is the admin page.
+		 * @param bool $admin_ui
+		 * @param null|array $form_ids
 		 */
-		public function submit_page( $args ) {
-
-			$defaults = array(
-                'admin_ui' => true,
-                'form_ids' => null
-            );
-
-			$args = array_merge( $defaults, $args );
-
-			$admin_ui = $args['admin_ui'];
+		public function submit_page( $admin_ui, $form_ids = null ) {
 
 			?>
 			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_submit">
@@ -5078,8 +5070,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$this->toolbar();
 				endif;
 				require_once( $this->get_base_path() . '/includes/pages/class-submit.php' );
-				if ( is_array( $args['form_ids'] ) ) {
-					$published_form_ids = $args['form_ids'];
+				if ( is_array( $form_ids ) && ! empty ( $form_ids )) {
+					$published_form_ids = $form_ids;
 				} else {
 					$published_form_ids = gravity_flow()->get_published_form_ids();
 				}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5052,8 +5052,11 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Renders the submit page.
 		 *
-		 * @param bool $admin_ui
-		 * @param null|array $form_ids
+		 * @since 2.6 Added the $form_ids parameter.
+		 * @since unknown
+		 *
+		 * @param bool       $admin_ui Whether to display the admin UI.
+		 * @param null|array $form_ids An array of form IDs.
 		 */
 		public function submit_page( $admin_ui, $form_ids = null ) {
 

--- a/includes/pages/class-submit.php
+++ b/includes/pages/class-submit.php
@@ -28,7 +28,7 @@ class Gravity_Flow_Submit {
 	public static function list_page( $form_ids, $is_admin ) {
 
 		if ( empty( $form_ids ) ) {
-			esc_html_e( "You haven't submitted any workflow forms yet.", 'gravityflow' );
+			esc_html_e( "No workflow forms.", 'gravityflow' );
 			return;
 		}
 


### PR DESCRIPTION
This PR adds the `forms` shortcode attribute to the submit page to allow the forms to be filtered on the submit page. e.g. [gravityflow page="submit" forms="1,2,3"]