### PR TITLE
Fix PHP notice when loading feed message with AJAX 

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -9,3 +9,4 @@
 - Fixed an issue with the Status shortcode where users with the gravityflow_status_view_all capability don't see all entries when the shortcode security settings are set to disallow the display_all attribute.
 - Fixed validation issue in Assignee, User and Multi-User fields.
 - Fixed an issue with the confirmation page for users with the gravityflow_status_view_all capability when transitioning steps.
+- Fixed a PHP notice when loading feed message with AJAX.

--- a/includes/steps/class-steps.php
+++ b/includes/steps/class-steps.php
@@ -75,7 +75,7 @@ class Gravity_Flow_Steps {
 	 * @return Gravity_Flow_Step | bool
 	 */
 	public static function create( $feed, $entry = null ) {
-		$step_type = $feed['meta']['step_type'];
+		$step_type = rgar( $feed['meta'], 'step_type' );
 
 		if ( empty( $step_type ) || ! isset( self::$_steps[ $step_type ] ) ) {
 			return false;


### PR DESCRIPTION
This PR fixes a PHP notice when loading feed message with AJAX.

## Screenshots
<img width="1132" alt="Screenshot 2019-05-12 22 54 59" src="https://user-images.githubusercontent.com/12166/57583992-045efc00-7509-11e9-83bc-c93e0a554c94.png">

## Testing instructions
1. Add a few steps in a form.
2. Activate Gravity Flow PDF Generator extension, create a PDF feed. When loading the feed settings page, your debug tool should yield a PHP notice, as the screenshot shows. 