### PR TITLE
Don't show all fields to administrators in workflow entry detail page

### DIFF
--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -869,14 +869,12 @@ class Gravity_Flow_Entry_Detail {
 
 		$is_assignee = $current_step ? $current_step->is_user_assignee() : false;
 
-		if ( ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
-			if ( ! $is_assignee ) {
-				if ( $current_step ) {
-					// Display fields from current step after a POST, otherwise use the start step settings.
-					$display_fields_step = isset( $_POST ) ? $current_step : gravity_flow()->get_workflow_start_step( $form_id, $entry );
-				} else {
-					$display_fields_step = gravity_flow()->get_workflow_complete_step( $form_id, $entry );
-				}
+		if ( ! $is_assignee ) {
+			if ( $current_step ) {
+				// Display fields from current step after a POST, otherwise use the start step settings.
+				$display_fields_step = isset( $_POST ) ? $current_step : gravity_flow()->get_workflow_start_step( $form_id, $entry );
+			} else {
+				$display_fields_step = gravity_flow()->get_workflow_complete_step( $form_id, $entry );
 			}
 		}
 


### PR DESCRIPTION
Re: [HS#9348](https://secure.helpscout.net/conversation/858975495/9348?folderId=1113498)

This PR fixes an issue where administrators can see ALL fields in the workflow entry detail page, even they are not assignees of the current step.

## Testing instructions
1. Test with the test form from Subrato in the ticket.
2. With the `master` branch, you'll see all fields when you're an admin; with this branch you can only see the display fields.