### PR TITLE
Fix order summary on user input steps without product fields

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,1 @@
--Fixed scenario where user input steps would not show the product order summary table when step setting was selected
+- Fixed an issue with the user input step where the product order summary table does is not displayed unless a product field is included in the display fields.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+-Fixed scenario where user input steps would not show the product order summary table when step setting was selected

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -770,9 +770,7 @@ class Gravity_Flow_Entry_Detail {
 				</td>
 			</tr>
 			<?php
-			if ( $entry_editor->has_product_fields || $current_step->display_order_summary ) {
-				self::maybe_show_products_summary( $form, $entry, $current_step );
-			}
+			self::maybe_show_products_summary( $form, $entry, $current_step );
 			?>
 		</tbody>
 		<?php
@@ -960,7 +958,7 @@ class Gravity_Flow_Entry_Detail {
 			}
 		}
 
-		if ( $format == 'table' && ( $has_product_fields || $current_step->display_order_summary ) ) {
+		if ( $format == 'table' ) {
 			self::maybe_show_products_summary( $form, $entry, $current_step );
 		}
 

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -770,7 +770,7 @@ class Gravity_Flow_Entry_Detail {
 				</td>
 			</tr>
 			<?php
-			if ( $entry_editor->has_product_fields ) {
+			if ( $entry_editor->has_product_fields || $current_step->display_order_summary ) {
 				self::maybe_show_products_summary( $form, $entry, $current_step );
 			}
 			?>
@@ -960,7 +960,7 @@ class Gravity_Flow_Entry_Detail {
 			}
 		}
 
-		if ( $has_product_fields && $format == 'table' ) {
+		if ( $format == 'table' && ( $has_product_fields || $current_step->display_order_summary ) ) {
 			self::maybe_show_products_summary( $form, $entry, $current_step );
 		}
 


### PR DESCRIPTION
Refer to [HS#9207](https://secure.helpscout.net/conversation/851721997/9207?folderId=1776095#)

User Input steps cannot currently display the order summary without having a product field edit/display. The step settings already include option whether to display Order Summary.
![image](https://user-images.githubusercontent.com/4549984/59139608-2c077f80-8962-11e9-88c3-ab045adb603b.png)

This PR checks whether that is set as an additional reason to display the Order Summary.

See HS#9207 for test form/instructions.
