### PR TITLE
Skip APC processing when post already exists for feed

### DIFF
--- a/includes/steps/class-step-feed-post-creation.php
+++ b/includes/steps/class-step-feed-post-creation.php
@@ -62,6 +62,55 @@ class Gravity_Flow_Step_Feed_Post_Creation extends Gravity_Flow_Step_Feed_Add_On
 
 		return $this->_class_name;
 	}
+
+	/**
+	 * Processes the given feed for the add-on.
+	 *
+	 * @since 2.5.6
+	 *
+	 * @param array $feed The add-on feed properties.
+	 *
+	 * @return bool Is feed processing complete?
+	 */
+	public function process_feed( $feed ) {
+		$post_id = $this->get_existing_post_id( (int) $feed['id'] );
+
+		if ( ! empty( $post_id ) ) {
+			$this->log_debug( sprintf( '%s() - post #%d already exists for this feed.', __METHOD__, $post_id ) );
+		} else {
+			parent::process_feed( $feed );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the ID of the post previously created by the current feed.
+	 *
+	 * @since 2.5.6
+	 *
+	 * @param int $feed_id The current feed ID.
+	 *
+	 * @return int|null
+	 */
+	public function get_existing_post_id( $feed_id ) {
+		/** @var GF_Advanced_Post_Creation $add_on */
+		$add_on = $this->get_add_on_instance();
+
+		$post_ids = gform_get_meta( $this->get_entry_id(), $add_on->get_slug() . '_post_id' );
+
+		if ( is_array( $post_ids ) ) {
+			foreach ( $post_ids as $id ) {
+				$post_feed_id = (int) rgar( $id, 'feed_id' );
+				if ( $post_feed_id === $feed_id ) {
+					return $id['post_id'];
+				}
+			}
+		}
+
+		return null;
+	}
+
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Post_Creation() );


### PR DESCRIPTION
re: [HS#9454](https://secure.helpscout.net/conversation/865456769/9454?folderId=1113535)

Updates the Post Creation step to skip feed processing if a post has already been created by the APC feed; fixes an issue where duplicate posts are created when the workflow or step is restarted.

## Testing Instructions
- Create a form with an Advanced Post Creation feed
- Add a Post Creation step
- Submit form
- Go to the Posts page and find the post was created
- Go to the Status page and restart the workflow
- Go to the Posts page find a duplicate post was created
- Update to this branch
- Repeat test and find the duplicate post is not created