### PR TITLE
Fix delayed Zapier steps send duplicate content from the first entry in queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli
+FROM php:7.2-cli-stretch
 
 MAINTAINER Steve Henty steve@gravityflow.io
 

--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.
 - Fixed number field display on user input steps when the field contained 0 value.
+- Fixed delayed Zapier steps send duplicate content from the first entry in queue.

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -84,6 +84,10 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 		$form  = $this->get_form();
 		$entry = $this->get_entry();
 
+		// If the step is delayed, there might be several entries to be processed at the same time,
+		// don't use the stored body, or the first entry in queue will be used as the body for all entries.
+		add_filter( 'gform_zapier_use_stored_body', '__return_false' );
+
 		if ( method_exists( 'GFZapier', 'process_feed' ) ) {
 			GFZapier::process_feed( $feed, $entry, $form );
 		} else {

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -84,10 +84,6 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 		$form  = $this->get_form();
 		$entry = $this->get_entry();
 
-		// If the step is delayed, there might be several entries to be processed at the same time,
-		// don't use the stored body, or the first entry in queue will be used as the body for all entries.
-		add_filter( 'gform_zapier_use_stored_body', '__return_false' );
-
 		if ( method_exists( 'GFZapier', 'process_feed' ) ) {
 			GFZapier::process_feed( $feed, $entry, $form );
 		} else {


### PR DESCRIPTION
re:[HS#9536](https://secure.helpscout.net/conversation/868343234/9536?folderId=1113497)

This PR fixes an issue that delayed Zapier steps send duplicate content from the first entry in queue, when there are multiple scheduled entries.

## Testing instructions
Please reproduce the error as the ticket described, and it will be fixed with this branch.