### PR TITLE
Change from line breaks to CSS for back link display

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
+- Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -375,6 +375,10 @@ td.gravityflow-order-summary{
     list-style-type: decimal;
 }
 
+.gravityflow-back-link-container {
+    margin-bottom: 2em;
+}
+
 span.gf_admin_page_formid {
     background-color: #d4662c;
     border: medium none;
@@ -415,6 +419,9 @@ table#gravityflow-inbox tbody tr{
 }
 
 @media print {
+
+    .gravityflow-back-link-container { display: none; }
+
     .gravityflow-dicussion-item-hidden {
         display:block !important;
     }

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -327,7 +327,7 @@ class Gravity_Flow_Entry_Detail {
 		 */
 		$url = apply_filters( 'gravityflow_back_link_url_entry_detail', $url, $args );
 
-		printf( '<a class="back-link" href="%s">%s</a><br/><br/>', esc_url( $url ), esc_html( $back_link_text ) );
+		printf( '<div class="gravityflow-back-link-container"><a class="back-link" href="%s">%s</a></div>', esc_url( $url ), esc_html( $back_link_text ) );
 
 		return;
 	}


### PR DESCRIPTION
Re: [HS#9416](https://secure.helpscout.net/conversation/862798240/9416?folderId=1776095)

This PR addresses a display issue with back links on entry detail page that prevented themes from customizing the spacing. It changes from using 2 line breaks following the $url built and filtered through gravityflow_back_link_url_entry_detail to a new div class - gravityflow-back-link-container - with a 2em bottom margin.

To test it change between master and this branch to see the markup differences with same visual result.