### PR TITLE
Update user input step number field display with zero value

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
+- Fixed number field display on user input steps when the field contained 0 value.

--- a/includes/pages/class-entry-editor.php
+++ b/includes/pages/class-entry-editor.php
@@ -613,7 +613,7 @@ class Gravity_Flow_Entry_Editor {
 		$display_value = apply_filters( 'gform_entry_field_value', $display_value, $field, $this->entry, $this->form );
 
 		if ( $this->display_empty_fields ) {
-			if ( empty( $display_value ) || $display_value === '0' ) {
+			if ( rgblank( $display_value ) ) {
 				$display_value = '&nbsp;';
 			}
 			$display_value = sprintf( '<div class="gravityflow-field-value">%s<div>', $display_value );


### PR DESCRIPTION
Refer to [HS#9694](https://secure.helpscout.net/conversation/884090820/9694?folderId=1776095#)

*Issue:*
With the current version of gravity flow, when a numeric field has a 0 value and is selected for display (not edit) a blank value is being shown regardless of 'show empty field' selection.

*Resolution*
Change logic that numeric fields use to be based on rgblank GForms common function.

*Test instructions*
- Starting on the master branch
- Create a form with at least 1 number field and one other field type.
- Add a user input workflow step that keeps the number field as a display field (not edit).
- Submit an entry and specify 0 in the number field.
- Go to workflow inbox for the user input step.
- Verify that blank is shown for number field.
- Switch to this branch/PR and reload page
- Verify that the 0 does display as expected.