### PR TITLE
Fix PHP 7.3 warning due to continue

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
+- Fixed a PHP 7.3 compatability warning related to entry detail screen display.

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -929,7 +929,7 @@ class Gravity_Flow_Entry_Detail {
 					}
 
 					if ( ! $display_field ) {
-						continue;
+						continue 2;
 					}
 
 					$value         = RGFormsModel::get_lead_field_value( $entry, $field );


### PR DESCRIPTION
See [HS#9727](https://secure.helpscout.net/conversation/884389675/9727?folderId=1776095) and [PHP 7.3 backward breaking change log](https://www.php.net/manual/en/migration73.incompatible.php).

"continue statements targeting switch control flow structures will now generate a warning"

The continue triggering warning is within the fields loop for entry detail display.
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in [local path]\gravityflow\includes\pages\class-entry-detail.php on line 932

**Steps to reproduce:**
- Run a version of PHP 7.3.X
- Set up a form with user input workflow with at least 1 display field and 1 editable field
- Access the workflow step with appropriate error logging or debugging active.
- See error message
- Switch to this branch code base
- Access the page again and you will not receive the warning (note in some local environments the warning may be a one-off unless you restart PHP service).
