### PR TITLE
Outgoing Webhook - Add merge tag selector to raw body step setting

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,3 +3,4 @@
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.
 - Fixed number field display on user input steps when the field contained 0 value.
 - Fixed delayed Zapier steps send duplicate content from the first entry in queue.
+- Added Merge Tag selector to Outgoing Webhook step settings for raw request body.

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -228,7 +228,7 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 					'name'  => 'raw_body',
 					'label' => esc_html__( 'Raw Body', 'gravityflow' ),
 					'type'  => 'textarea',
-					'class' => 'fieldwidth-3 fieldheight-2',
+					'class' => 'fieldwidth-1 fieldheight-1 merge-tag-support',
 					'save_callback' => array( $this, 'save_callback_raw_body' ),
 				);
 			} else {


### PR DESCRIPTION
See [HS#10091](https://secure.helpscout.net/conversation/909527249/10091?folderId=1776095)

Adds the merge tag drop-down to the right side of raw body step setting for Outgoing Webhook, making it much easier to build the raw request with field and custom data values. It also increases the size of the raw body field to better support cases involving large/nested JSON structures.

![image](https://user-images.githubusercontent.com/4549984/62415501-a407c400-b5f8-11e9-8042-d53068559e28.png)

**Steps to test**

- Create an outgoing webhook step
- Use the new merge tag dropdown