### PR TITLE
Add filter gravityflow_entry_url_inbox_table to support partial entries

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
+- Added filter gravityflow_entry_url_inbox_table to allow customization of the link from inbox.
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -217,6 +217,20 @@ class Gravity_Flow_Inbox {
 		$link      = "<a href='%s'>%s</a>";
 
 		/**
+		 * Allows the entry URL to be modified for each of the entries in the inbox table.
+		 *
+		 * @since 2.5.6
+		 *
+		 * @param string $url_entry The entry URL.
+		 * @param string $entry     The current entry.
+		 * @param string $args      The inbox page arguments.
+		 * @param array  $form      The form object for the current entry.
+		 *
+		 * @return string
+		 */
+		$url_entry = apply_filters( 'gravityflow_entry_url_inbox_table', $url_entry, $entry, $args, $form );
+
+		/**
 		 * Allows the entry link to be modified for each of the entries in the inbox table.
 		 *
 		 * @since 1.9.2
@@ -225,6 +239,8 @@ class Gravity_Flow_Inbox {
 		 * @param string $url_entry The entry URL.
 		 * @param string $entry     The current entry.
 		 * @param string $args      The inbox page arguments.
+		 *
+		 * @return string
 		 */
 		$link = apply_filters( 'gravityflow_entry_link_inbox_table', $link, $url_entry, $entry, $args );
 


### PR DESCRIPTION
Refer to [HS#9627](https://secure.helpscout.net/conversation/877194159/9627?folderId=1776095)

The existing gravityflow_entry_link_inbox_table filter allows customization of the href tag (to add  target="_new" for example) but not to modify the URL which the links in inbox will send users to without adding parameters to it and/or repeating much of the display_entry_row function (violating D-R-Y principles).

Amongst other use cases, the new gravityflow_entry_url_inbox_table filter of this PR makes it possible to have partial entries link back to the initial form instead of an entry detail view - very useful when a form has multiple pages and many fields for initial submission.

**Testing Instructions**

- Activate partial entries add-on of Gravity Forms
- Setup a form to enable partial entries including workflow
- Submit a partial entry of the form
- Include the following into your functions.php file
```
add_filter( 'gravityflow_entry_url_inbox_table', 'customize_entry_url', 10, 4 );
function customize_entry_url( $url_entry, $entry, $args, $form ) {
    if ( isset( $entry['resume_url'] ) &&  $entry['resume_url'] != '') {
		$url_entry = $entry['resume_url'];
	}
	return $url_entry;
}
```
- Test that the inbox link sends you to the initial form rather then entry detail page


