### PR TITLE
Adding filter gravityflow_columns_sortable_status_table

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
+- Added filter gravityflow_columns_sortable_status_table to enable customization of which columns of status table are sortable
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1209,6 +1209,17 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			}
 		}
 
+		/**
+		 * Allows the columns which are sortable to be filtered for the status table.
+		 *
+		 * @since 2.5.7
+		 *
+		 * @param array         $sortable_columns The sortable columns to be filtered
+		 * @param array         $args             The array of args for this status table.
+		 * @param WP_List_Table $this             The current WP_List_Table object.
+		 */
+		 $sortable_columns = apply_filters( 'gravityflow_columns_sortable_status_table', $sortable_columns, $args, $this );
+
 		return $sortable_columns;
 	}
 


### PR DESCRIPTION
See [HS#10486](https://secure.helpscout.net/conversation/930585557/10486?folderId=1113492)

This PR adds the filter gravityflow_columns_sortable_status_table to enable:

- Custom columns in the status table to be defined as sortable
- Remove sortable capability for default status table columns

**Testing Instructions**
- Change to the PR branch
- Use the following 2 hooked filters to add due date column and make it sortable
- Test with other column customizations

```
add_filter( 'gravityflow_columns_status_table', 'nc_gravityflow_columns_status_table', 10, 3 );
function nc_gravityflow_columns_status_table( $columns, $args, $table ) {
   $columns['due_date'] = 'Due Date';
   return $columns;
}


add_filter( 'gravityflow_columns_sortable_status_table', 'nc_gravityflow_columns_sortable', 10, 3 );
function nc_gravityflow_columns_sortable( $sortable_columns, $args, $table ) {
   $sortable_columns['due_date'] = array( 'due_date', false );

   return $sortable_columns;
}
```
