### PR TITLE
Fix issue with counts in view bar not checking gravityflow_form_ids_status

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,4 +3,5 @@
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.
 - Fixed number field display on user input steps when the field contained 0 value.
 - Fixed delayed Zapier steps send duplicate content from the first entry in queue.
+- Fixed when gravityflow_form_ids_status executes to ensure entry counts + pagination counts match filtering form IDs.
 - Added Merge Tag selector to Outgoing Webhook step settings for raw request body.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -123,9 +123,9 @@ class Gravity_Flow_Status {
 				printf( '<input type="hidden" name="%s" value="%s"/>', $hidden_field, $hidden_field_value );
 			}
 
+			$table->prepare_items();
 			$table->views();
 			$table->filters();
-			$table->prepare_items();
 			?>
 		</form>
 		<form id="gravityflow-status-list" method="POST" action="">
@@ -1485,7 +1485,18 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$form_clause = is_array( $args['form-id'] ) ? $wpdb->prepare( ' AND l.form_id IN (%s)', join( ',', $args['form-id'] ) ) : $wpdb->prepare(' AND l.form_id=%d', absint( $args['form-id'] ) );
 		} else {
 			$form_ids = $this->get_workflow_form_ids();
-
+			/**
+			* Allows form id(s) to be adjusted to define which forms' entries are displayed in status table.
+			* 
+			* Return an array of form ids for use with GFAPI.
+			*
+			* @since 2.2.3
+			* 
+			* @param array   $form_ids        The form ids
+			* @param array   $search_criteria The search criteria
+			*/
+			$form_ids = apply_filters( 'gravityflow_form_ids_status', $form_ids, $this->get_search_criteria() );
+			
 			if ( empty( $form_ids ) ) {
 				$results            = new stdClass();
 				$results->total     = 0;
@@ -1739,6 +1750,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		$this->set_pagination_args( $this->pagination_args );
 
+		$this->total_count = $total_count;
 		$this->items = $entries;
 	}
 


### PR DESCRIPTION
See [HS#10496](https://secure.helpscout.net/conversation/931195708/10496?folderId=1776095)

This PR fixes an issue where the issue counts (All/Pending/Complete/Cancelled) would not have correct tallies if the gravityflow_form_ids_status filter was applied. It updates the order that status table prepare_items, views and filters are called as well as ensuring the class $total_count parameter is set earlier in logic for other functions to reference.

**Testing Instructions**
- Use the hooked filter below (updating for form IDs in your test environment.
- Note that the complete, pending, etc counts still show the values as if filter did not apply.
- Switch to this branch.
- Verify that the counts do match.
- Test with other column customizations.

```
add_filter( 'gravityflow_form_ids_status', 'sh_status_form_ids_explicit', 10, 2 );
function sh_status_form_ids_explicit( $form_ids, $search_criteria ) {
	//Adjust array to your desired form IDs.
	$form_ids = array ( 42, 43 );
	return $form_ids;
}
```
