### PR TITLE
Support step specific complex conditional logic

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -4,3 +4,4 @@
 - Fixed number field display on user input steps when the field contained 0 value.
 - Fixed delayed Zapier steps send duplicate content from the first entry in queue.
 - Added Merge Tag selector to Outgoing Webhook step settings for raw request body.
+- Added the filter gravityflow_step_conditional_logic_match to enable complex conditional logic for step execution.

--- a/change_log.txt
+++ b/change_log.txt
@@ -4,4 +4,4 @@
 - Fixed number field display on user input steps when the field contained 0 value.
 - Fixed delayed Zapier steps send duplicate content from the first entry in queue.
 - Added Merge Tag selector to Outgoing Webhook step settings for raw request body.
-- Added the filter gravityflow_step_conditional_logic_match to enable complex conditional logic for step execution.
+- Added the filter gravityflow_step_is_condition_met to enable complex conditional logic for start (or not) a given step.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8187,14 +8187,16 @@ AND m.meta_value='queued'";
 		 * Fork of GFCommon::evaluate_conditional_logic which supports evaluating logic based on entry properties.
 		 *
 		 * @since 1.7.1-dev
+		 * @since 2.5.6-dev Added the optional $step and gravityflow_step_conditional_logic_match filter
 		 *
-		 * @param array $logic The conditional logic to be evaluated.
-		 * @param array $form  The current form.
-		 * @param array $entry The current entry.
+		 * @param array $logic                  The conditional logic to be evaluated.
+		 * @param array $form                   The current form.
+		 * @param array $entry                  The current entry.
+		 * @param bool|Gravity_Flow_Step $step  The current (potential) step
 		 *
 		 * @return bool
 		 */
-		public function evaluate_conditional_logic( $logic, $form, $entry ) {
+		public function evaluate_conditional_logic( $logic, $form, $entry, $step = false ) {
 			if ( ! $logic || ! is_array( rgar( $logic, 'rules' ) ) ) {
 				return true;
 			}
@@ -8221,6 +8223,20 @@ AND m.meta_value='queued'";
 			}
 
 			$do_action = ( $logic['logicType'] == 'all' && $match_count == sizeof( $logic['rules'] ) ) || ( $logic['logicType'] == 'any' && $match_count > 0 );
+
+			if( $step != false ) {
+				/**
+				* Allows the conditional logic for the step to be customized.
+				*
+				* @since 2.5.7
+				* @param bool              $do_action Should the conditional logic pass
+				* @param array             $logic The conditional logic to be evaluated.
+				* @param array             $form  The current form.
+				* @param array             $entry The current entry.
+				* @param Gravity_Flow_Step $step  The current (potential) step
+				*/
+				$do_action = apply_filters( 'gravityflow_step_conditional_logic_match', $do_action, $logic, $form, $entry, $step );
+			}
 
 			return $do_action;
 		}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8187,16 +8187,14 @@ AND m.meta_value='queued'";
 		 * Fork of GFCommon::evaluate_conditional_logic which supports evaluating logic based on entry properties.
 		 *
 		 * @since 1.7.1-dev
-		 * @since 2.5.6-dev Added the optional $step and gravityflow_step_conditional_logic_match filter
 		 *
-		 * @param array $logic                  The conditional logic to be evaluated.
-		 * @param array $form                   The current form.
-		 * @param array $entry                  The current entry.
-		 * @param bool|Gravity_Flow_Step $step  The current (potential) step
+		 * @param array                  $logic The conditional logic to be evaluated.
+		 * @param array                  $form  The current form.
+		 * @param array                  $entry The current entry.
 		 *
 		 * @return bool
 		 */
-		public function evaluate_conditional_logic( $logic, $form, $entry, $step = false ) {
+		public function evaluate_conditional_logic( $logic, $form, $entry ) {
 			if ( ! $logic || ! is_array( rgar( $logic, 'rules' ) ) ) {
 				return true;
 			}
@@ -8223,20 +8221,6 @@ AND m.meta_value='queued'";
 			}
 
 			$do_action = ( $logic['logicType'] == 'all' && $match_count == sizeof( $logic['rules'] ) ) || ( $logic['logicType'] == 'any' && $match_count > 0 );
-
-			if( $step != false ) {
-				/**
-				* Allows the conditional logic for the step to be customized.
-				*
-				* @since 2.5.7
-				* @param bool              $do_action Should the conditional logic pass
-				* @param array             $logic The conditional logic to be evaluated.
-				* @param array             $form  The current form.
-				* @param array             $entry The current entry.
-				* @param Gravity_Flow_Step $step  The current (potential) step
-				*/
-				$do_action = apply_filters( 'gravityflow_step_conditional_logic_match', $do_action, $logic, $form, $entry, $step );
-			}
 
 			return $do_action;
 		}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8188,9 +8188,9 @@ AND m.meta_value='queued'";
 		 *
 		 * @since 1.7.1-dev
 		 *
-		 * @param array                  $logic The conditional logic to be evaluated.
-		 * @param array                  $form  The current form.
-		 * @param array                  $entry The current entry.
+		 * @param array $logic The conditional logic to be evaluated.
+		 * @param array $form  The current form.
+		 * @param array $entry The current entry.
 		 *
 		 * @return bool
 		 */

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1392,7 +1392,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		/**
 		* Allows the determination for step conditions being met to be customized.
 		*
-		* @since 2.5.7
+		* @since 2.5.6
 		* @param bool                   $condition_met Are the step condition(s) met.
 		* @param array                  $logic         The conditional logic to be evaluated.
 		* @param array                  $form          The current form.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1399,7 +1399,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		* @param array                  $entry         The current entry.
 		* @param Gravity_Flow_Step      $step          The current step.
 		*/
-		$condition_met = apply_filters( 'gravityflow_step_condition_met', $condition_met, $logic, $form, $entry, $this );
+		$condition_met = apply_filters( 'gravityflow_step_is_condition_met', $condition_met, $logic, $form, $entry, $this );
 
 		return $condition_met;
 	}

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1381,12 +1381,27 @@ abstract class Gravity_Flow_Step extends stdClass {
 		$is_condition_enabled = rgar( $feed_meta, 'feed_condition_conditional_logic' ) == true;
 		$logic                = rgars( $feed_meta, 'feed_condition_conditional_logic_object/conditionalLogic' );
 
-		if ( ! $is_condition_enabled || empty( $logic ) ) {
-			return true;
-		}
 		$entry = $this->get_entry();
 
-		return gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry, $this );
+		if ( ! $is_condition_enabled || empty( $logic ) ) {
+			$condition_met = true;
+		} else {
+			$condition_met = gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry, $this );
+		}
+
+		/**
+		* Allows the determination for step conditions being met to be customized.
+		*
+		* @since 2.5.7
+		* @param bool                   $condition_met Are the step condition(s) met.
+		* @param array                  $logic         The conditional logic to be evaluated.
+		* @param array                  $form          The current form.
+		* @param array                  $entry         The current entry.
+		* @param Gravity_Flow_Step      $step          The current step.
+		*/
+		$condition_met = apply_filters( 'gravityflow_step_condition_met', $condition_met, $logic, $form, $entry, $this );
+
+		return $condition_met;
 	}
 
 	/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1386,7 +1386,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		}
 		$entry = $this->get_entry();
 
-		return gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry );
+		return gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry, $this );
 	}
 
 	/**


### PR DESCRIPTION
See [HS#10486](https://secure.helpscout.net/conversation/932770262/10509/)

This PR adds the filter gravityflow_step_is_condition_met and customizes the logic within the is_condition_met function. Prior to this PR:
- You were limited to a single ANY (or) / ALL (and) set of conditions for enabling condition
- If you wanted to evaluate step conditions through code, you had to set a known false conditional setting in order to evaluate through [gform_is_value_match](https://docs.gravityforms.com/gform_is_value_match/).

**Test Instructions**
-Switch to the PR branch in your local environment
-Create a form with 2 workflow steps - 1 with conditional setting and 1 without
-Add the a variation of the following snippet to your functions.php file. This one assumes some step, form and field IDs but will value check a different entry field to determine if the current potential step should be executed.
```
add_filter( 'gravityflow_step_is_condition_met', 'gform_109_7_1_conditional_logic_match_14_9'), 10, 5);

function gform_109_7_conditional_logic_match_14_9( $do_action, $logic, $form, $entry, $step ) {
		if ( false == $step ) {
			return false;
		}

		$step_id = $step->get_id();
		if ( false == in_array( $step_id, array( '109', '111' ) ) ) {
			return false;
		}
		if( !empty( $entry['7'] ) ) {
			$search_criteria['field_filters'][] = array( 'key' => '1', 'value' => $entry['7'] );
			$paging      = array( 'offset' => 0, 'page_size' => 1 );
			$total_count = 0;
			$apps        = GFAPI::get_entries( 14, $search_criteria, array(), $paging, $total_count );
			if( ! empty( $apps ) ) {
				foreach( $apps as $app ) {
					if( isset( $app['19'] ) && $app['19'] == 'Y' ) {
						$is_match = true;
					} else {
						$is_match = false;
					}
				}
			}
		}
		return $is_match;
	}
```
