### PR TITLE
Support step specific complex conditional logic

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Fixed an issue when Sliced Invoices status was manually updated to paid, entries weren't released from Sliced Invoices steps.
 - Fixed an issue with the Status shortcode where users with the gravityflow_status_view_all capability don't see all entries when the shortcode security settings are set to disallow the display_all attribute.
 - Fixed validation issue in Assignee, User and Multi-User fields
+- Added the filter gravityflow_step_conditional_logic_match to enable complex conditional logic for step execution.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8075,14 +8075,16 @@ AND m.meta_value='queued'";
 		 * Fork of GFCommon::evaluate_conditional_logic which supports evaluating logic based on entry properties.
 		 *
 		 * @since 1.7.1-dev
+		 * @since 2.5.6-dev Added the optional $step and gravityflow_step_conditional_logic_match filter
 		 *
-		 * @param array $logic The conditional logic to be evaluated.
-		 * @param array $form  The current form.
-		 * @param array $entry The current entry.
+		 * @param array $logic                  The conditional logic to be evaluated.
+		 * @param array $form                   The current form.
+		 * @param array $entry                  The current entry.
+		 * @param bool|Gravity_Flow_Step $step  The current (potential) step
 		 *
 		 * @return bool
 		 */
-		public function evaluate_conditional_logic( $logic, $form, $entry ) {
+		public function evaluate_conditional_logic( $logic, $form, $entry, $step = false ) {
 			if ( ! $logic || ! is_array( rgar( $logic, 'rules' ) ) ) {
 				return true;
 			}
@@ -8109,6 +8111,20 @@ AND m.meta_value='queued'";
 			}
 
 			$do_action = ( $logic['logicType'] == 'all' && $match_count == sizeof( $logic['rules'] ) ) || ( $logic['logicType'] == 'any' && $match_count > 0 );
+
+			if( $step != false ) {
+				/**
+				* Allows the conditional logic for the step to be customized.
+				*
+				* @since 2.5.7
+				* @param bool              $do_action Should the conditional logic pass
+				* @param array             $logic The conditional logic to be evaluated.
+				* @param array             $form  The current form.
+				* @param array             $entry The current entry.
+				* @param Gravity_Flow_Step $step  The current (potential) step
+				*/
+				$do_action = apply_filters( 'gravityflow_step_conditional_logic_match', $do_action, $logic, $form, $entry, $step );
+			}
 
 			return $do_action;
 		}

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1386,7 +1386,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		}
 		$entry = $this->get_entry();
 
-		return gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry );
+		return gravity_flow()->evaluate_conditional_logic( $logic, $form, $entry, $this );
 	}
 
 	/**


### PR DESCRIPTION
See [HS#10486](https://secure.helpscout.net/conversation/932770262/10509/)

This PR adds the filter gravityflow_step_conditional_logic_match and customizes the parameters for evaluate_conditional_logic to enable step specific conditional logic. Prior to this PR:

- You were limited to a single ANY (or) / ALL (and) set of conditions for enabling condition
- The use of [gform_is_value_match](https://docs.gravityforms.com/gform_is_value_match/) has limited parameters to retrieve multiple field values or cinoare any (potential) step settings.

**Test Instructions**
-Switch to the PR branch in your local environment
-Create a form with workflow step involving at least one conditional rule
-Add the a variation of the following snippet to your functions.php file. This one assumes some step, form and field IDs but will value check a different entry field to determine if the current potential step should be executed.
```
add_filter( 'gravityflow_step_conditional_logic_match', 'gform_109_7_1_conditional_logic_match_14_9'), 10, 5);

function gform_109_7_conditional_logic_match_14_9( $do_action, $logic, $form, $entry, $step ) {
		if ( $step == false ) {
			return $do_action;
		}

		if ( $step->get_id() != '109' ) {
			return $do_action;
		}

		if( !empty( $entry['7'] ) ) {
			$search_criteria['field_filters'][] = array( 'key' => '1', 'value' => $entry['7'] );
			$paging      = array( 'offset' => 0, 'page_size' => 1 );
			$total_count = 0;
			$apps        = GFAPI::get_entries( 14, $search_criteria, array(), $paging, $total_count );
			if( ! empty( $apps ) ) {
				foreach( $apps as $app ) {
					if( isset( $app['19'] ) && $app['19'] == 'Y' ) {
						$is_match = true;
					} else {
						$is_match = false;
					}
				}
			}
		}
		return $is_match;
	}
```
