### PR TITLE
Add filter gravityflow_approval_revert_step_id

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,5 @@
 - Added filter gravityflow_entry_url_inbox_table to allow customization of the link from inbox.
+- Added filter gravityflow_approval_revert_step_id to allow customization of the revert step. 
 - Fixed the Post Creation step creating duplicate posts when the workflow or step is restarted.
 - Fixed back link display on entry detail page to use css with class gravityflow-back-link-container instead of line breaks for spacing.
 - Fixed PHP 7.3 compatability warning related to entry detail screen display.

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -583,7 +583,22 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 		$feedback = false;
 
 		if ( $this->revertEnable ) {
-			$step = gravity_flow()->get_step( $this->revertValue, $this->get_entry() );
+
+			$this->get_entry();
+
+			/**
+			* Allows the revert step to be modified before routing.
+			*
+			* @since 2.5.6
+			*
+			* @param string                $revert_step_id    The revert step ID from current step settings.
+			* @param array                 $entry             The current entry array.
+			* @param array                 $form              The current form array.
+			* @param Gravity_Flow_Step     $step              The current step
+			*/
+			$revert_step_id = apply_filters( 'gravityflow_approval_revert_step_id', $this->revertValue, $this->get_entry(), $this->get_form(), $this );
+
+			$step = gravity_flow()->get_step( $revert_step_id, $this->get_entry() );
 
 			if ( $step ) {
 				$this->end();


### PR DESCRIPTION
See [HS#10674](https://secure.helpscout.net/conversation/936611609/10674?folderId=1776095)

This PR adds the filter gravityflow_approval_revert_step_id to enable customization of what step the revert option sends a workflow to during an approval step.

**Testing Instructions**
- Change to the PR branch
- Create a form + workflow with at least an approval step, user input step and one other step.
- Setup the approval step to have revert option active and pointing to the user input step.
- Use a filter similar to the one below customized to your step IDs
- Submit form and verify that when clicking 'revert' on approval step it goes to the expected step.

```
add_filter( 'gravityflow_approval_revert_step_id', 'sh_gravityflow_step_revert_control', 10, 4 );
function sh_gravityflow_step_revert_control( $revert_id, $entry, $form, $step ) {
	if ( $step->get_id() == '138' ) {
		$revert_id = '139';
	}
	return $revert_id;
}
```
