### PR TITLE
Remove status page default search box display

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed issue where status page filters would show search box before any form/field selections were specified.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -123,9 +123,10 @@ class Gravity_Flow_Status {
 				printf( '<input type="hidden" name="%s" value="%s"/>', $hidden_field, $hidden_field_value );
 			}
 
-			$table->prepare_items();
 			$table->views();
 			$table->filters();
+			$table->prepare_items();
+
 			?>
 		</form>
 		<form id="gravityflow-status-list" method="POST" action="">


### PR DESCRIPTION
Resolves issue introduced via #269 

**Test Instructions:**
- Switch between master and this branch
- See that the extra/default search box in filter area is not displayed.
![image](https://user-images.githubusercontent.com/4549984/64122502-d16a9d80-cd6f-11e9-98ed-cf2160f2950c.png)
- Verify that [gravityflow_form_ids_status](https://docs.gravityflow.io/article/205-gravityflowformidsstatus) continues to show filtered values for all/pending/complete/cancelled.


