### PR TITLE
Suppress discussion field merge tag view more link for the APC add-on

### DIFF
--- a/includes/steps/class-step-feed-post-creation.php
+++ b/includes/steps/class-step-feed-post-creation.php
@@ -78,7 +78,9 @@ class Gravity_Flow_Step_Feed_Post_Creation extends Gravity_Flow_Step_Feed_Add_On
 		if ( ! empty( $post_id ) ) {
 			$this->log_debug( sprintf( '%s() - post #%d already exists for this feed.', __METHOD__, $post_id ) );
 		} else {
+			add_filter( 'gravityflow_discussion_items_display_toggle', '__return_false', 99 );
 			parent::process_feed( $feed );
+			remove_filter( 'gravityflow_discussion_items_display_toggle', '__return_false', 99 );
 		}
 
 		return true;


### PR DESCRIPTION
re: [HS#9865](https://secure.helpscout.net/conversation/888930716/9865/)

Updates the APC step to prevent the view more link being output for the discussion field when the feed is being processed.

## Testing Instructions
- Add code snippet:
```
add_filter( 'gravityflow_discussion_items_display_limit', function () {
	return 1;
} );
```
- Create a form with a discussion field
- Add an APC feed with the discussion field merge tag in the post content setting
- Add a User Input step with the discussion field as editable
- Add a APC step
- Submit form with value in discussion field
- On the UI step add another value to the discussion field
- View the post and find the view more link included in the discussion field output
- Switch to this branch
- Repeat test and find the view more link in no longer included in the output