### PR TITLE
Adding gravityflow_timeline_note_add filter

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Added the filter gravityflow_timeline_note_add to support customizing the potential note to add to timeline.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6613,7 +6613,25 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				}
 			}
 
-			GFFormsModel::add_note( $entry_id, $user_id, $user_name, $note, 'gravityflow' );
+			/**
+			* Allows the timeline note to be customized.
+			*
+			* @since 2.5.7
+			*
+			* @param string                 $note           The message to be added to the timeline.
+			* @param int                    $entry_id       The entry of the current step.
+			* @param bool|int               $user_id        The ID of user performing the action.
+			* @param string                 $user_name      The username of user performing the action.
+			* @param bool|Gravity_Flow_Step $step           If it is a step based action the current step.
+			*
+			* @return bool|string
+			*/
+
+			$note = apply_filters( 'gravityflow_timeline_note_add', $note, $entry_id, $user_id, $user_name, false );
+
+			if ( $note ) {
+				GFFormsModel::add_note( $entry_id, $user_id, $user_name, $note, 'gravityflow' );
+			}
 		}
 
 		/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1964,7 +1964,27 @@ abstract class Gravity_Flow_Step extends stdClass {
 			}
 		}
 
-		GFFormsModel::add_note( $this->get_entry_id(), $user_id, $user_name, $note, 'gravityflow' );
+		$entry_id = $this->get_entry_id();
+
+		/**
+		 * Allows the timeline note to be customized.
+		 *
+		 * @since 2.5.7
+		 *
+		 * @param string                 $note       The message to be added to the timeline.
+		 * @param int                    $entry_id   The entry of the current step.
+		 * @param bool|int               $user_id    The ID of user performing the current step action.
+		 * @param string                 $user_name  The username of user performing the current step action.
+		 * @param bool|Gravity_Flow_Step $step       If it is a step based action the current step.
+		 *
+		 * @return bool|string
+		 */
+
+		$note = apply_filters( 'gravityflow_timeline_note_add', $note, $entry_id, $user_id, $user_name, $this );
+
+		if ( $note ) {
+			GFFormsModel::add_note( $entry_id, $user_id, $user_name, $note, 'gravityflow' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
re: [HS#10854](https://secure.helpscout.net/conversation/955270281/10854?folderId=1776095)

Adds a filter gravityflow_timeline_note_add to both step and gravityflow() scenarios allowing developers to customize if, and what the message would be, for timeline notes.

**Testing Instructions**

- Switch to this PR branch
- Add a snippet similar to the following
```
add_filter( 'gravityflow_timeline_note_add', 'timeline_note_step_only', 10, 5 );
function timeline_note_step_only( $note, $entry_id, $user_id, $user_name, $step ) {

	if ( ! $step ) {
		return false;
	}

	return $note;
}
```
- Notice how only step actions (not restart workflow for example) are not included in the timeline.
- Test that changing the $note content also updates with revised text.