### PR TITLE
Support the delayed payment enhancements in GF 2.4.13

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5784,8 +5784,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Determines if workflow processing should be delayed for the current submission.
 		 *
-		 * @since 2.5.8 Updated to support the delayed payment enhancements in GF 2.4.13.
 		 * @since unknown
+		 * @since 2.5.8 Updated to support the delayed payment enhancements in GF 2.4.13.
 		 *
 		 * @param array $entry The entry created from the current form submission.
 		 * @param array $form  The form object used to process the current submission.
@@ -5827,8 +5827,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Starts the workflow if it was delayed pending PayPal payment.
 		 *
-		 * @since 2.5.8 Updated to use action_trigger_payment_delayed_feeds().
 		 * @since unknown
+		 * @since 2.5.8 Updated to use action_trigger_payment_delayed_feeds().
 		 *
 		 * @param array  $entry          The entry for which the PayPal payment has been completed.
 		 * @param array  $paypal_config  The PayPal feed used to process the entry.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5862,7 +5862,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				$this->process_workflow( $form, $entry_id );
 			} else {
 				$this->log_debug( __METHOD__ . '(): Entry ' . $entry['id'] . ' is already fulfilled or workflow is not delayed. No action necessary.' );
-            }
+			}
 		}
 
 		/**

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5782,7 +5782,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		}
 
 		/**
-		 * Determines if the current submission requires a PayPal payment and if the workflow should be delayed.
+		 * Determines if workflow processing should be delayed for the current submission.
+		 *
+		 * @since 2.5.8 Updated to support the delayed payment enhancements in GF 2.4.13.
+		 * @since unknown
 		 *
 		 * @param array $entry The entry created from the current form submission.
 		 * @param array $form  The form object used to process the current submission.
@@ -5792,15 +5795,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				return;
 			}
 
-			$is_delayed = false;
-
-			if ( class_exists( 'GFPayPal' ) ) {
-				$feed = gf_paypal()->get_single_submission_feed( $entry, $form );
-
-				if ( ! empty( $feed ) && $this->is_delayed( $feed ) && $this->has_paypal_payment( $feed, $form, $entry ) ) {
-					$is_delayed = true;
-				}
-			}
+			// From GF 2.4.13 GFPaymentAddOn uses the gform_is_delayed_pre_process_feed filter located in maybe_delay_feed() to delay processing.
+			// With older GF versions maybe_delay_feed() contains the logic for PayPal Standard.
+			$is_delayed = $this->maybe_delay_feed( $entry, $form );
 
 			/**
 			 * Allow processing of the workflow to be delayed.
@@ -5830,6 +5827,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		/**
 		 * Starts the workflow if it was delayed pending PayPal payment.
 		 *
+		 * @since 2.5.8 Updated to use action_trigger_payment_delayed_feeds().
+		 * @since unknown
+		 *
 		 * @param array  $entry          The entry for which the PayPal payment has been completed.
 		 * @param array  $paypal_config  The PayPal feed used to process the entry.
 		 * @param string $transaction_id The PayPal transaction ID.
@@ -5838,11 +5838,31 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 * @return void
 		 */
 		public function paypal_fulfillment( $entry, $paypal_config, $transaction_id, $amount ) {
-			if ( empty( $entry['workflow_step'] ) && $this->is_delayed( $paypal_config ) && ! $this->is_entry_view() ) {
-				$form     = GFAPI::get_form( $entry['form_id'] );
+			$this->action_trigger_payment_delayed_feeds( $transaction_id, $paypal_config, $entry );
+		}
+
+		/**
+		 * Starts the workflow if it was delayed pending payment by a GFPaymentAddOn.
+		 *
+		 * @since 2.5.8
+		 *
+		 * @param string     $transaction_id The transaction or subscription ID.
+		 * @param array      $payment_feed   The payment feed which originated the transaction.
+		 * @param array      $entry          The entry currently being processed.
+		 * @param null|array $form           The form currently being processed or null for the legacy PayPal integration.
+		 */
+		public function action_trigger_payment_delayed_feeds( $transaction_id, $payment_feed, $entry, $form = null ) {
+			$this->log_debug( __METHOD__ . '(): Checking fulfillment for transaction ' . $transaction_id . ' for ' . $payment_feed['addon_slug'] );
+
+			if ( empty( $entry['workflow_step'] ) && $this->is_delayed( $payment_feed ) && ! $this->is_entry_view() ) {
+				if ( is_null( $form ) ) {
+					$form = GFFormsModel::get_form_meta( $entry['form_id'] );
+				}
 				$entry_id = absint( $entry['id'] );
 				$this->process_workflow( $form, $entry_id );
-			}
+			} else {
+				$this->log_debug( __METHOD__ . '(): Entry ' . $entry['id'] . ' is already fulfilled or workflow is not delayed. No action necessary.' );
+            }
 		}
 
 		/**


### PR DESCRIPTION
Updates `Gravity_Flow::maybe_delay_workflow()` to support delaying workflow processing for PayPal Standard, Stripe 3.1, and future `GFPaymentAddOn` based add-ons which add delayed payment support.

Also overrides the new `action_trigger_payment_delayed_feeds` method so it will trigger the workflow and updates the existing `paypal_fulfillment` method to use it.

## Testing

- [x] Workflow isn't delayed when form does not have PayPal and Stripe feeds
- [x] Workflow isn't delayed when form has a PayPal feed with delay setting disabled
- [x] Workflow isn't delayed when form has a Stripe feed with delay setting disabled
- [x] Workflow is delayed when form has a PayPal feed with delay setting enabled
- [x] Workflow starts when PayPal payment is successful
- [x] Workflow is delayed when form has a Stripe feed with delay setting enabled
- [x] Workflow starts when Stripe payment is successful