### PR TITLE
Adding gravityflow_timeline_notes filter 

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Added the filter gravityflow_timeline_note_add to support customizing the potential note to add to timeline.
+- Added the filter gravityflow_timeline_notes to support customizing the display of timeline notes.

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -294,7 +294,7 @@ class Gravity_Flow_Common {
 		/**
 		 * Allows the timeline notes to be modified.
 		 *
-		 * @since 2.5.7
+		 * @since 2.5.8
 		 *
 		 * @param array $notes The notes for timeline of current entry.
 		 * @param array $entry The current entry.

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -291,6 +291,18 @@ class Gravity_Flow_Common {
 
 		$notes = array_reverse( $notes );
 
+		/**
+		 * Allows the timeline notes to be modified.
+		 *
+		 * @since 2.5.7
+		 *
+		 * @param array $notes The notes for timeline of current entry.
+		 * @param array $entry The current entry.
+		 *
+		 * @return array
+		 */
+		$notes = apply_filters( 'gravityflow_timeline_notes', $notes, $entry );
+
 		return $notes;
 	}
 


### PR DESCRIPTION
re: [HS#10855](https://secure.helpscout.net/conversation/955303810/10855?folderId=1776095)

Adds a filter gravityflow_timeline_notes filter to allow developers to customize the order, amount and content for timeline notes.

**Testing Instructions**

- Switch to this PR branch
- Add a snippet similar to the following
```
add_filter( 'gravityflow_timeline_notes', 'jo_timeline_reverse', 10, 2 );
function jo_timeline_reverse( $notes, $entry ) {
	$notes = array_reverse( $notes );
	return $notes;
}
```
- Notice how the notes are in chronological order.
- Test that other changes to contents of $notes via code are applied as expected.