### PR TITLE
Extend settings + UI to always show CC field

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Add support for CC: field to all Gravity Flow notification types.

--- a/includes/steps/class-common-step-settings.php
+++ b/includes/steps/class-common-step-settings.php
@@ -195,6 +195,7 @@ class Gravity_Flow_Common_Step_Settings {
 				'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
 				'label' => __( 'CC', 'gravityflow' ),
 				'type'  => 'text',
+				'tooltip'  => '<h6>' . __( 'Name', 'gravityflow' ) . '</h6>' . __( 'Be aware of any privacy policies your website is subject to that would apply to using the CC field. For example, GDPR indicates names and emails are private that should not be exposed.', 'gravityflow' ),
 			),
 			array(
 				'name'  => $prefix . '_notification_bcc',

--- a/includes/steps/class-common-step-settings.php
+++ b/includes/steps/class-common-step-settings.php
@@ -191,6 +191,12 @@ class Gravity_Flow_Common_Step_Settings {
 				'type'  => 'text',
 			),
 			array(
+				'name'  => $prefix . '_notification_cc',
+				'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
+				'label' => __( 'CC', 'gravityflow' ),
+				'type'  => 'text',
+			),
+			array(
 				'name'  => $prefix . '_notification_bcc',
 				'class' => 'fieldwidth-2 merge-tag-support mt-hide_all_fields mt-position-right ui-autocomplete-input',
 				'label' => __( 'BCC', 'gravityflow' ),

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1832,7 +1832,9 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 		$this->log_debug( __METHOD__ . '() - sending notification: ' . print_r( $notification, true ) );
 
+		add_filter( 'gform_notification_enable_cc', '__return_true' );
 		GFCommon::send_notification( $notification, $form, $entry );
+		remove_filter( 'gform_notification_enable_cc', '__return_true' );
 	}
 
 	/**

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -999,6 +999,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		$notification['fromName']          = empty( $this->{$from_name} ) ? gravity_flow()->get_app_setting( 'from_name', get_bloginfo( 'name' ) ) : $this->{$from_name};
 		$notification['from']              = empty( $this->{$from_email} ) ? gravity_flow()->get_app_setting( 'from_email', get_bloginfo( 'admin_email' ) ) : $this->{$from_email};
 		$notification['replyTo']           = $this->{$type . 'reply_to'};
+		$notification['cc']                = $this->{$type . 'cc'};
 		$notification['bcc']               = $this->{$type . 'bcc'};
 		$notification['message']           = $this->{$type . 'message'};
 		$notification['disableAutoformat'] = $this->{$type . 'disable_autoformat'};

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -382,7 +382,7 @@
 	}
 
 	function toggleNotificationTabFields(showType, notificationType) {
-		var fields = ['users', 'routing', 'from_name', 'from_email', 'reply_to', 'bcc', 'subject', 'message', 'autoformat', 'resend', 'gpdf'],
+		var fields = ['users', 'routing', 'from_name', 'from_email', 'reply_to', 'cc', 'bcc', 'subject', 'message', 'autoformat', 'resend', 'gpdf'],
 			prefix = '#gaddon-setting-tab-field-' + notificationType + '_notification_';
 
 		$.each(fields, function (i, field) {
@@ -404,8 +404,8 @@
 
 	function toggleWorkflowNotificationType(showType) {
 		var fields = {
-			select: ['workflow_notification_users\\[\\]', 'workflow_notification_from_name', 'workflow_notification_from_email', 'workflow_notification_reply_to', 'workflow_notification_bcc', 'workflow_notification_subject', 'workflow_notification_message', 'workflow_notification_autoformat', 'workflow_notification_gpdf'],
-			routing: ['workflow_notification_routing', 'workflow_notification_from_name', 'workflow_notification_from_email', 'workflow_notification_reply_to', 'workflow_notification_bcc', 'workflow_notification_subject', 'workflow_notification_message', 'workflow_notification_autoformat', 'workflow_notification_gpdf']
+			select: ['workflow_notification_users\\[\\]', 'workflow_notification_from_name', 'workflow_notification_from_email', 'workflow_notification_reply_to', 'workflow_notification_cc', 'workflow_notification_bcc', 'workflow_notification_subject', 'workflow_notification_message', 'workflow_notification_autoformat', 'workflow_notification_gpdf'],
+			routing: ['workflow_notification_routing', 'workflow_notification_from_name', 'workflow_notification_from_email', 'workflow_notification_reply_to', 'workflow_notification_cc', 'workflow_notification_bcc', 'workflow_notification_subject', 'workflow_notification_message', 'workflow_notification_autoformat', 'workflow_notification_gpdf']
 		};
 		toggleFields(fields, showType, false);
 	}
@@ -454,6 +454,7 @@
 			'assignee_notification_from_name',
 			'assignee_notification_from_email',
 			'assignee_notification_reply_to',
+			'assignee_notification_cc',
 			'assignee_notification_bcc',
 			'assignee_notification_subject',
 			'assignee_notification_message',
@@ -480,6 +481,7 @@
 			'workflow_notification_from_name',
 			'workflow_notification_from_email',
 			'workflow_notification_reply_to',
+			'workflow_notification_cc',
 			'workflow_notification_bcc',
 			'workflow_notification_subject',
 			'workflow_notification_message',


### PR DESCRIPTION
See [HS #10520](https://secure.helpscout.net/conversation/933782946/10520?folderId=1113497)

This PR adds the option for CC: to be included for all notification types of Gravity Flow (assignee, approval, rejection, complete). It does not currently evaluate whether [gform_notification_enable_cc](https://docs.gravityforms.com/gform_notification_enable_cc/) filter has been set or not. Perhaps worth discussion whether it should, or a Gravity Flow filter that includes step-specific parameters.

**Testing Instructions**

- Enable the dev-notification-cc branch
- Test that all notification types include an option for CC: distribution
- Confirm that notifications deliver with CC: users/emails specified
