### PR TITLE
Added workflow options to merge tag dropdown for revert notification

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Added the filter gravityflow_timeline_note_add to support customizing the potential note to add to timeline.
 - Added the filter gravityflow_timeline_notes to support customizing the display of timeline notes.
 - Fixed the "view more" link for the Discussion field being output when merge tags are processed for posts created by the Advanced Post Creation Add-On.
+- Fixed the notification tab for Revert Email on Approval step to have the workflow merge tags options.

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -515,6 +515,7 @@
 			'_gaddon_setting_assignee_notification_message',
 			'_gaddon_setting_approval_notification_message',
 			'_gaddon_setting_rejection_notification_message',
+			'_gaddon_setting_revert_notification_message',
 		];
 
 		if (supportedElementIds.indexOf(elementId) < 0) {


### PR DESCRIPTION
See [HS#10838](https://secure.helpscout.net/conversation/953450944/10838?folderId=1776095)

This PR adds the same Workflow merge tag options to the Revert notification tab as the assignee, approval/rejection tabs already provide.
![image](https://user-images.githubusercontent.com/4549984/65821795-77db7e80-e208-11e9-9412-93850a9b0b1d.png)

**Testing Instructions**
- Create a form with approval + user input step.
- Select the 'Revert to User Input step' option to associate user input step.
- Verify that the merge tag dropdown on revert tab for notification message does not include workflow options.
- Switch to the fix-10838-revert-merge-tags branch.
- Review step settings to confirm that merge tag dropdown does include workflow options.