### PR TITLE
Add .github folder with default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,24 @@
-See [HS#12345](https://secure.helpscout.net/conversation/953450944/12345?folderId=1776095)
+## Description
+<!-- Describe what you have changed or added. -->
+<!-- Link to the support ticket(s) where appropriate. -->
 
-This PR does what?
+## Testing instructions
+<!-- Add instructions to help the reviewer test your code. -->
+<!-- Include sample forms, add-ons or snippets where appropriate. -->
+<!-- Identify what, if any, features/elements you feel should be focused on testing/code review -->
 
-**Manual Test/Review Instructions**
-- Steps to reproduce the issue from dev/master branch
-- Attach a form export .json if it makes sense
-- Switch to branch (name)
-- What features/elements should be focused on testing in new branch?
+## Automated Test Enhancements
+<!-- Any unit tests or acceptence tests been changed as part of PR? Describe as needed. -->
+ 
+## Screenshots
+<!-- if applicable -->
 
-**Automated Test Enhancements**
-- Any unit tests or acceptence tests been changed as part of PR?
-- Describe the changes made
+## Documentation Changes?
+<!-- Are any documentation updates needed to co-incide with release? -->
+<!-- Are any new documentation pages required to co-incide with the release? -->
 
-**Documentation Changes?**
-- Are any documentation updates needed to co-incide with release?
-- Are any new documentation pages required to co-incide with the release?
+## Checklist:
+- [ ] I've tested the code.
+- [ ] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
+- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
+- [ ] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+See [HS#12345](https://secure.helpscout.net/conversation/953450944/12345?folderId=1776095)
+
+This PR does what?
+
+**Manual Test/Review Instructions**
+- Steps to reproduce the issue from dev/master branch
+- Attach a form export .json if it makes sense
+- Switch to branch (name)
+- What features/elements should be focused on testing in new branch?
+
+**Automated Test Enhancements**
+- Any unit tests or acceptence tests been changed as part of PR?
+- Describe the changes made
+
+**Documentation Changes?**
+- Are any documentation updates needed to co-incide with release?
+- Are any new documentation pages required to co-incide with the release?


### PR DESCRIPTION
See [Github Docs](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template)

Initial draft provides shell sections/questions that appear to be common from most of existing PRs.
If this does add value, the same folder/PR template could be applied to the other add-ons. There currently is not a way to define a template at an org level with Github.