### PR TITLE
Fix incorrect feedback when User Input step confirmation is empty

### DIFF
--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -550,7 +550,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 				return $success;
 			}
 			$note_message = __( 'Entry updated and marked complete.', 'gravityflow' );
-			if ( $this->confirmation_messageEnable ) {
+			if ( $this->confirmation_messageEnable && ! empty( $this->confirmation_messageValue ) ) {
 				$feedback = $this->confirmation_messageValue;
 				$feedback = $assignee->replace_variables( $feedback );
 				$feedback = GFCommon::replace_variables( $feedback, $form, $this->get_entry(), false, true, true, 'html' );


### PR DESCRIPTION
RE: [HS #11095](https://secure.helpscout.net/conversation/976249748/11095?folderId=3106366)

This PR adds a check to see if the confirmation message on a user input step is empty. Currently if the confirmation is enabled via the checkbox and left empty the assignee of the user input step will receive an error "There was a problem while updating the assignee status." when completing the step.

## Testing Instructions 

- Import the form from Subrato's note, make sure the user input step is set to assign the user selected in the dropdown field on the form and the the confirmation in the user input step is empty.
- Preview and submit the form using your user as the selected value in the dropdown.
- View the user input step for the entry and complete it, find that you receive the above mentioned error.
- Edit the user input step and enter a value into the confirmation message input.
- Perform the form test again, find that no error occurs and the confirmation message is output.
- Switch to this branch.
- Perform the form test again with the confirmation message having a non-empty value, when completing the step find the confirmation message is still output and no error is output.
- Edit the UI step again and make the confirmation message input have an empty value.
- Perform the form test again and complete the UI step, find that no error is output and the workflow continues to the next step.