### PR TITLE
Enhance checking step exists before edit step settings / feed add-on

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed incorrect feedback when user input step confirmation message content is left empty and the step is completed.
+- Fixed issue when attempting to modify step settings for a step type that is not active (plugin deactivated, incorrect permissions).

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -1328,6 +1328,9 @@ PRIMARY KEY  (id)
 
 			if ( $current_step_id ) {
 				$step = $this->get_step( $current_step_id );
+				if ( ! $step ) {
+					wp_die(  __( 'Step settings unavailable. The selected step type is not active.', 'gravityflow' ) );
+				}
 				$step_type = $step->get_type();
 			} else {
 				$step_type = $this->get_setting( 'step_type' );


### PR DESCRIPTION
See [HS#11203](https://secure.helpscout.net/conversation/986273684/11203?folderId=1776095)

Viewing the step list does inform users that a step type used within their workflow is currently missing - be it for inactive plugin, plugin permissions issue on server or other reasons.
![image](https://user-images.githubusercontent.com/4549984/67607522-c53d0400-f752-11e9-8bf6-39a6d0fa64f0.png)

However, the user can still attempt to edit step settings (or bookmarked edit link) and encounter the following error, "Fatal error: Call to a member function get_type() on boolean in /var/www/html/myintranet3-jperlman.dawsoncollege.qc.ca/wp-content/plugins/gravityflow/class-gravity-flow.php on line 1331"

This PR addresses by adding additional boolean check and displaying a reasonable error through wp_die.
![image](https://user-images.githubusercontent.com/4549984/67607538-db4ac480-f752-11e9-9162-cbcf4028901b.png)

**Testing Instructions**
- Create form + workflow with steps from add-ons in addition to Gravity Flow
- De-activate add-on plugin that provides the step type
- Attempt to edit step settings and see the error mentioned above.
- Switch to this branch and see a slightly more helpful warning message.
- Approve this PR
- Rejoice.

