### PR TITLE
Fix PHP fatal error thrown when processing expired entries with steps that no longer exist

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed incorrect feedback when user input step confirmation message content is left empty and the step is completed.
 - Fixed an issue where PHP fatal error is thrown in the filter_gravityview_common_get_entry_check_entry_display() method.
+- Fixed an issue where PHP fatal error is thrown when processing expired entries with steps that no longer exist.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6925,6 +6925,8 @@ AND m.meta_value='queued'";
 						$current_step = $this->get_step( $entry['workflow_step'], $entry );
 
 						if ( ! $current_step ) {
+							$this->log_debug( __METHOD__ . '(): The step (id: ' . $entry['workflow_step'] . ') no longer exists.' );
+
 							continue;
 						}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6924,6 +6924,10 @@ AND m.meta_value='queued'";
 					foreach ( $entries as $entry ) {
 						$current_step = $this->get_step( $entry['workflow_step'], $entry );
 
+						if ( ! $current_step ) {
+							continue;
+						}
+
 						$this->log_debug( __METHOD__ . '(): processing entry: ' . $entry['id'] );
 
 						if ( $current_step->is_expired() ) {

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6925,7 +6925,7 @@ AND m.meta_value='queued'";
 						$current_step = $this->get_step( $entry['workflow_step'], $entry );
 
 						if ( ! $current_step ) {
-							$this->log_debug( __METHOD__ . '(): The step (id: ' . $entry['workflow_step'] . ') no longer exists.' );
+							$this->log_debug( __METHOD__ . '(): The step (id: ' . $entry['workflow_step'] . ') no longer exists. Skip entry id: ' . $entry['id'] );
 
 							continue;
 						}


### PR DESCRIPTION
re:[HS#11058](https://secure.helpscout.net/conversation/974045212/11058?folderId=1113492)

This PR fixes an issue where PHP fatal error is thrown when processing expired entries with steps that no longer exist.

## Testing instructions
This is a fix that we add based on the PHP fatal error message the ticket provided. We don't seem to find an easy way to reproduce the error at our end.