### PR TITLE
Fix PHP fatal error thrown in the filter_gravityview_common_get_entry_check_entry_display() method

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed incorrect feedback when user input step confirmation message content is left empty and the step is completed.
+- Fixed an issue where PHP fatal error is thrown in the filter_gravityview_common_get_entry_check_entry_display() method.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8567,16 +8567,17 @@ AND m.meta_value='queued'";
 				return $check_entry_display;
 			}
 
+			$form_id = $entry['form_id'];
 			// Hack to ensure that the meta values for assignees are returned when rule matching in GVCommon::check_entry_display().
 			foreach ( $keys as $key ) {
-				$_fields[ $entry['form_id'] . '_' . $key ] = array( 'id' => $key );
+				$_fields[ $form_id . '_' . $key ] = array( 'id' => $key );
 			}
 
 			$entry = GVCommon::check_entry_display( $entry );
 
 			// Clean up the hack.
 			foreach ( $keys as $key ) {
-				unset( $_fields[ $entry['form_id'] . '_' . $key ] );
+				unset( $_fields[ $form_id . '_' . $key ] );
 			}
 
 			// GVCommon::check_entry_display() returns the entry if permission is granted otherwise false or maybe a WP_Error instance.


### PR DESCRIPTION
re:[HS#10021](https://secure.helpscout.net/conversation/904617410/10021?folderId=2308452)

This PR fixes an issue when `GVCommon::check_entry_display()` returns a `WP_Error` object, a PHP fatal error would be thrown in the `filter_gravityview_common_get_entry_check_entry_display()` method.

## Testing instructions
The customer provides some possible scenarios to reproduce it but we couldn't get the expected results. However, since `GVCommon::check_entry_display()` indeed returns `WP_Error` if the entry is not valid according to the view search filters, it makes sense to update our code as the PR proposed.