### PR TITLE
Fix shrinking multi-select in user input step routing at smaller resolutions

### DIFF
--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -124,6 +124,7 @@ table.gform-routings tr.gform-routing-row td .repeater-buttons{
 
 .gform-routing-input-field{
     width:100%;
+	min-width: 200px;
 }
 
 #gaddon-setting-row-step_type td label{


### PR DESCRIPTION
RE: [HS 11234](https://secure.helpscout.net/conversation/988660276/11234?folderId=3106366)

This PR addresses an issue where at smaller browser resolutions the multi-select field in a user input step using the "Conditional Routing" option the multi-select used under the "Editable Fields" heading would shrink to a very small size. Changes in this branch add a minimum width to the field to prevent shrinking as other input fields in the same location do not fluidly change based on width.

## Testing Instructions
- Create a form and add a user input step or open a user input step on a pre-existing form.
- Toggle the "Conditional Routing" option for the "Assign To:" section of the step.
- Shrink your browser to a smaller size and notice that the multi-select field under "Editable Fields" will shrink to a very small size.
- Switch to this branch and perform the same test, find the field does not shrink at all.