### PR TITLE
Fix a PHP notice which can occur during conditional logic evaluation

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8270,18 +8270,18 @@ AND m.meta_value='queued'";
 		 *
 		 * @since 2.4.1
 		 *
-		 * @param bool   $is_match     Does the target field’s value match with the rule value?
-		 * @param string $field_value  The field value to use with the comparison.
-		 * @param string $target_value The value from the conditional routing rule to use with the comparison.
-		 * @param string $operation    The conditional routing rule operator.
-		 * @param object $source_field The field object for the source of the field value.
-		 * @param array  $rule         The current rule object.
+		 * @param bool         $is_match     Does the target field’s value match with the rule value?
+		 * @param string|array $field_value  The field value to use with the comparison.
+		 * @param string       $target_value The value from the conditional routing rule to use with the comparison.
+		 * @param string       $operation    The conditional routing rule operator.
+		 * @param object       $source_field The field object for the source of the field value.
+		 * @param array        $rule         The current rule object.
 		 *
 		 * @return bool
 		 */
 		public function filter_gform_is_value_match( $is_match, $field_value, $target_value, $operation, $source_field, $rule ) {
 
-			if ( ! $source_field || ! in_array( $source_field->type, array( 'workflow_multi_user', 'date' ) ) ) {
+			if ( ! ( $source_field instanceof GF_Field ) || ! in_array( $source_field->type, array( 'workflow_multi_user', 'date' ) ) ) {
 				return $is_match;
 			}
 


### PR DESCRIPTION
re: [HS#11327](https://secure.helpscout.net/conversation/992967478/11327/)

This updates our `gform_is_value_match` filter callback so it only checks the type property if `$source_field` is a field object preventing the following PHP notice.

> Notice: Trying to get property 'type' of non-object in /app/public/wp-content/plugins/gravityflow/class-gravity-flow.php on line 8282

## Testing Instructions

- Add the following code snippet
- Create a page and add the [gflow_notice_test] shortcode
- With master view page and find the notice occurs
- With this branch find the notice does not occur

```
add_shortcode( 'gflow_notice_test', function () {
	echo '<h3>notice test</h3>';
	printf( '<p>not a field - match: %s</p>', var_export( GFFormsModel::is_value_match( 'test', 'test', 'is', array( 'not a field' ) ), true ) );
	printf( '<p>not a field - no match: %s</p>', var_export( GFFormsModel::is_value_match( '', 'test', 'is', array( 'not a field' ) ), true ) );

	$workflow_field = new Gravity_Flow_Field_Multi_User();
	printf( '<p>workflow multi user field - match: %s</p>', var_export( GFFormsModel::is_value_match( array( 'test' ), 'test', 'is', $workflow_field ), true ) );
	printf( '<p>workflow multi user field - no match: %s</p>', var_export( GFFormsModel::is_value_match( array(), 'test', 'is', $workflow_field ), true ) );

	$date_field = new GF_Field_Date();
	printf( '<p>date field - match: %s</p>', var_export( GFFormsModel::is_value_match( 'today', 'today', 'is', $date_field ), true ) );
	printf( '<p>date field - no match: %s</p>', var_export( GFFormsModel::is_value_match( 'tomorrow', 'today', 'is', $date_field ), true ) );
} );
```