### PR TITLE
Add workflow merge tags to merge tag dropdown for certain step notifications

### DIFF
--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -518,6 +518,8 @@
 			'_gaddon_setting_approval_notification_message',
 			'_gaddon_setting_rejection_notification_message',
 			'_gaddon_setting_revert_notification_message',
+			'_gaddon_setting_complete_notification_message',
+			'_gaddon_setting_in_progress_notification_message',
 		];
 
 		if (supportedElementIds.indexOf(elementId) < 0) {


### PR DESCRIPTION
RE: [HS #11292](https://secure.helpscout.net/conversation/990291660/11292?folderId=3106366)

Currently workflow merge tags are missing from the merge tag dropdown when editing certain notification types in a step, specifically the "In Progress" and "Complete" types. This PR adds support for making the merge tags available in the merge tag dropdown for these types.

## Testing Instructions
- Create and form, add a new user input step, activate the save progress functionality.
- Tab into the In Progress notification, select the merge tag dropdown and find there are no workflow merge tags available. Do the same for the complete notification and find this is also the case.
- Switch to this branch, perform the same test, find that the merge tags are available in the merge tag dropdown for both of the above listed notification types.