### PR TITLE
Add the gravityflow_admin_actions cap to Members

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -95,6 +95,7 @@ if ( class_exists( 'GFForms' ) ) {
 			'gravityflow_reports',
 			'gravityflow_activity',
 			'gravityflow_workflow_detail_admin_actions',
+            'gravityflow_admin_actions',
 		);
 
 		/**
@@ -8641,6 +8642,7 @@ AND m.meta_value='queued'";
 				'gravityflow_submit'                        => $this->translate_navigation_label( 'submit' ),
 				'gravityflow_status'                        => $status_label,
 				'gravityflow_status_view_all'               => $status_label . ' - ' . __( 'View All', 'gravityflow' ),
+				'gravityflow_admin_actions'                 => $status_label . ' - ' . __( 'Admin Actions', 'gravityflow' ),
 				'gravityflow_reports'                       => $this->translate_navigation_label( 'reports' ),
 				'gravityflow_activity'                      => $this->translate_navigation_label( 'activity' ),
 				'gravityflow_settings'                      => __( 'Manage Settings', 'gravityflow' ),

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -95,7 +95,7 @@ if ( class_exists( 'GFForms' ) ) {
 			'gravityflow_reports',
 			'gravityflow_activity',
 			'gravityflow_workflow_detail_admin_actions',
-            'gravityflow_admin_actions',
+			'gravityflow_admin_actions',
 		);
 
 		/**


### PR DESCRIPTION
re: [HS#11490](https://secure.helpscout.net/conversation/1001284230/11490?folderId=1113492)

Fixes an issue where the "Restart Workflow" choice is missing from the Status page bulk actions drop down when the Members plugin is used to enable the Gravity Forms and Gravity Flow capabilities for a role.

##  Testing Instructions
- With the Members plugin deactivated find that the "Restart Workflow" choice is included in the Status page bulk actions drop down
- Enable Members and enable the Gravity Forms and Gravity Flow capabilities for your role
- Visit the Status page and find the choice is missing
- Switch to this branch 
- Enable the "Status - Admin Actions" capability in Members for your role
- Return to the Status page and find the "Restart Workflow" choice is now available