### PR TITLE
Change hook used when ending signature step

### DIFF
--- a/includes/steps/class-step-feed-wp-e-signature.php
+++ b/includes/steps/class-step-feed-wp-e-signature.php
@@ -333,7 +333,7 @@ function gravity_flow_step_esign_signature_saved( $args ) {
 				if ( $step ) {
 					$feed  = gravity_flow()->get_feed( $feed_id );
 					$label = $step->get_feed_label( $feed );
-					$step->add_note( sprintf( esc_html__( 'Document signed: %s', 'gravityflow' ), $label ) );
+					$step->add_note( sprintf( esc_html__( 'All signatures collected for document: %s', 'gravityflow' ), $label ) );
 					$step->log_debug( __METHOD__ . '() - Feed processing complete: ' . $label );
 
 					$add_on_feeds = $step->get_processed_add_on_feeds( $entry_id );
@@ -349,4 +349,4 @@ function gravity_flow_step_esign_signature_saved( $args ) {
 	}
 }
 
-add_action( 'esig_signature_saved', 'gravity_flow_step_esign_signature_saved' );
+add_action( 'esig_all_signature_request_signed', 'gravity_flow_step_esign_signature_saved' );


### PR DESCRIPTION
## Description
RE: [HS #10868 ](https://secure.helpscout.net/conversation/957146571/10868?folderId=3106366)

Currently if users are using the WP E Signature add-on to handle assignment order for signatures (basically when the user who first signs the document saves the document, it generates a second document for an approval signer to sign) the signature step in Gravity Flow will end when any signature is saved, so in this case when the initial signer completes signing, the workflow continues despite another signature being required before the document is "closed" and the workflow should continue to the next step.

This PR just changes what we're hooking our code when wrapping up the signature step, currently we use a hook that will run whenever any signature is saved, when more than one signature is required this means that the workflow continues to the next step when it should not. This change will hook the logic into a hook that runs only when all signatures are collected for a particular document. I spent a bonkers amount of time running thing down and as far as I could tell this was the only reliable method of ensuring that all signatures has been collected for a document before running our code in the step.

From my understanding it doesn't seem like this should impact any other functionality with the signature step as it just looks like we're looking to see if the document has been completed.

## Testing instructions
(Setup for testing this is a bit of a nightmare, so if you run into issues please let me know or have any questions about a step or the flow)
- Make sure WP E Signature is installed and you've installed the add-ons, you can get these from Subrato's note in the ticket. Make sure that the assign order and the stand alone document add-on are enabled for the plugin. You will also need to install the third-party gravity forms specific plugin they have on the WordPress plugin repo.
- Create a new document in the e signature plugin, this should be a standalone document, if everything is installed as it should you should have an option to assign an approval signer if you toggle the "advanced options" towards the bottom of the document setup, check that. Set your email as the approver in the popup and save the document.
- Create a form with fields to collect a name and an email. In the WP E Signature add-on page under the form settings, set up the form to send the user to the document you created above.
- For the workflow, create three steps, an approval step, a signature step, and another approval step.
- Preview and submit the form, approve the entry in your workflow inbox to move onto the signature step.
- You should (hopefully) now be emailed a link to sign the document. Open, sign, and save. 
- Look at the entry again in your workflow inbox, notice that the entry is on the third approval step and the signature step completed despite the documented not being complete with all signatures.
- Monitor the email you set up for the approver signer, you'll get a link to sign again, open that, sign, and save. (More informational for testing this branch to see the flow).
- Switch to this branch, submit the form again, approve the first step. Open, sign, and save the form again.
- Take a look at the entry in the workflow inbox again, notice that the signature step is still in progress.
- Open the link sent to your email set as the approval signer, sign it and save the document.
- View the entry again in the inbox, notice that that workflow has continued now that all signatures have been collected.
- Go back to your document in WP E Signature, disable the approval signing setting.
- Complete the test again, notice that the step continues as it should when just one signature is collected as no approval signature is required.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->