### PR TITLE
Update revert notification timing to capture correct workflow note

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
+- Updated the Members integration to include the missing Status page Admin Actions capability.
 - Fixed incorrect feedback when user input step confirmation message content is left empty and the step is completed.
 - Fixed an issue when attempting to modify step settings for a step type that is not active (plugin deactivated, incorrect permissions).
 - Fixed an issue where PHP fatal error is thrown in the filter_gravityview_common_get_entry_check_entry_display() method.
@@ -5,4 +6,4 @@
 - Fixed an issue where a multi-select on User Input step settings pages would shrink to a very small width on smaller window resolutions.
 - Fixed a PHP notice which can occur when conditional logic is evaluated and the rule is not based on a form field.
 - Fixed an issue where workflow merge tags would not be available in the merge tag dropdown for notification content fields in certain steps.
-- Updated the Members integration to include the missing Status page Admin Actions capability.
+- Fixed an issue where revert notifications would not include the latest workflow note.

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -603,10 +603,10 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 			if ( $step ) {
 				$this->end();
 
-				$this->send_revert_notification();
-
 				$note = $this->get_name() . ': ' . esc_html__( 'Reverted to step', 'gravityflow' ) . ' - ' . $step->get_label();
 				$this->add_note( $note . $this->maybe_add_user_note(), true );
+
+				$this->send_revert_notification();
 
 				//Determine whether the revert notification is set and whether the user input notification should be sent or not as a result
 				if ( $this->{'revert_notification_enabled'} ) {


### PR DESCRIPTION
[See HS#11186](https://secure.helpscout.net/conversation/984454562/11186?folderId=1776095)

## Description
Resolving an issue where an approval step being selected to revert where the workflow note is required will not have the expected note included via {workflow_note} in the revert notification.

## Testing instructions
- Start from master branch
- Create form with an user input step
- Add an approval step with revert set + workflow note required.
- Ensure the revert notification is setup and includes {workflow_note} merge tag.
- Process the workflow. Select the revert option and provide a workflow note.
- The notification will not include that note, but may have any previous step notes.
- Switch to fix-11186-revert-notes branch
- Re-test and note that the correct note is included.

## Automated Test Enhancements
None required

## Documentation Changes?
None required

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards.
- [x] My code follows the inline documentation standards.