### PR TITLE
fix-11171-view-more-safari

### DIFF
--- a/js/entry-detail.js
+++ b/js/entry-detail.js
@@ -5,7 +5,7 @@
 
     GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
 
-            $toggle = $(':focus').parent();
+            $toggle = $('.field_description_below');
             $toggle.find( '.gravityflow-dicussion-item-hidden' ).slideToggle( 'fast' );
 
             var $viewMore = $toggle.children( '.gravityflow-dicussion-item-toggle-display' );


### PR DESCRIPTION
## Description
Refer to [HS #11171](https://secure.helpscout.net/conversation/982861014/11171?folderId=1113492)
Issue pertains to inability to properly click through the Discussion Field view more/less when using Safari browser on Mac or iPhone.

## Testing instructions
- Create a form with discussion field
- Create user inputs steps that have the discussion field as editable. Either use [gravityflow_discussion_items_display_limit](https://docs.gravityflow.io/article/188-gravityflowdiscussionitemsdisplaylimit) to reduce # of steps required (default of 10), use admin actions to return workflow to a single user input step, or have 10+ steps in workflow.
- Using Safari note that when the display limit has been passed the view more/less JS clickable link does not show/hide entries as expected
- Change to this PR branch and re-test.
- Confirm that it works as expected.

## Automated Test Enhancements
None


## Documentation Changes?
None.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->