### PR TITLE
Fix PHP 7.4 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ php:
 env:
   matrix:
     - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=5.1 WP_MULTISITE=0
+    - WP_VERSION=5.2 WP_MULTISITE=0
     - WP_VERSION=5.0 WP_MULTISITE=0
+    - WP_VERSION=4.9 WP_MULTISITE=0
     - WP_VERSION=4.8 WP_MULTISITE=0
-    - WP_VERSION=4.7 WP_MULTISITE=0
-    - WP_VERSION=4.5 WP_MULTISITE=0
+    - WP_VERSION=4.6 WP_MULTISITE=0
   global:
   - WP_TRAVISCI=travis:phpunit
 before_script:
@@ -34,7 +34,11 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.2|7.3)
+      7.3|7.4)
+        echo "Using PHPUnit 7.0"
+        composer global require "phpunit/phpunit=7.0.*"
+        ;;
+      7.2)
         echo "Using PHPUnit 6.0"
         composer global require "phpunit/phpunit=6.0.*"
         ;;
@@ -106,6 +110,7 @@ jobs:
     env: WP_VERSION=5.1 WP_MULTISITE=0
   - php: 7.2
   - php: 7.3
+  - php: 7.4
   - stage: Extensions
     env: WP_TRAVISCI=none
     script: |

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -563,7 +563,7 @@ PRIMARY KEY  (id)
 			$input_fields      = array();
 			$has_start_step    = false;
 			$has_complete_step = false;
-			if ( is_array( $form['fields'] ) ) {
+			if ( is_array( rgar( $form, 'fields' ) ) ) {
 				foreach ( $form['fields'] as $field ) {
 					/* @var GF_Field $field */
 					$input_fields[] = array(

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1683,9 +1683,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 					break;
 
 				case 'assignee_multi_user_field' :
-					$entry      = $this->get_entry();
-					$json_value = $entry[ $id ];
-					$user_ids   = json_decode( $json_value );
+					$user_ids = json_decode( rgar( $this->get_entry(), $id ) );
 					if ( $user_ids && is_array( $user_ids ) ) {
 						$args['type'] = 'user_id';
 						foreach ( $user_ids as $user_id ) {


### PR DESCRIPTION
## Description

- Fixes a notice which occurs on any page where the form `id` query arg is not being used.

```
[01-Feb-2020 13:48:26 UTC] PHP Notice:  Trying to access array offset on value of type bool in /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/class-gravity-flow.php on line 566
[01-Feb-2020 13:48:26 UTC] PHP Stack trace:
[01-Feb-2020 13:48:26 UTC] PHP   1. {main}() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-admin/index.php:0
[01-Feb-2020 13:48:26 UTC] PHP   2. include() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-admin/index.php:111
[01-Feb-2020 13:48:26 UTC] PHP   3. do_action() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-admin/admin-header.php:104
[01-Feb-2020 13:48:26 UTC] PHP   4. WP_Hook->do_action() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/plugin.php:478
[01-Feb-2020 13:48:26 UTC] PHP   5. WP_Hook->apply_filters() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/class-wp-hook.php:312
[01-Feb-2020 13:48:26 UTC] PHP   6. Gravity_Flow->enqueue_scripts() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/class-wp-hook.php:286
[01-Feb-2020 13:48:26 UTC] PHP   7. Gravity_Flow->scripts() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityforms/includes/addon/class-gf-addon.php:810
```

- Fixes notices when accessing the Reports page when there are steps with assignees from the multi user field and the entry is not available.
```
[01-Feb-2020 13:52:36 UTC] PHP Notice:  Trying to access array offset on value of type null in /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/includes/steps/class-step.php on line 1687
[01-Feb-2020 13:52:36 UTC] PHP Stack trace:
[01-Feb-2020 13:52:36 UTC] PHP   1. {main}() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-admin/admin.php:0
[01-Feb-2020 13:52:36 UTC] PHP   2. do_action() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-admin/admin.php:254
[01-Feb-2020 13:52:36 UTC] PHP   3. WP_Hook->do_action() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/plugin.php:478
[01-Feb-2020 13:52:36 UTC] PHP   4. WP_Hook->apply_filters() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/class-wp-hook.php:312
[01-Feb-2020 13:52:36 UTC] PHP   5. Gravity_Flow->reports() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-includes/class-wp-hook.php:288
[01-Feb-2020 13:52:36 UTC] PHP   6. Gravity_Flow->reports_page() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/class-gravity-flow.php:5542
[01-Feb-2020 13:52:36 UTC] PHP   7. Gravity_Flow_Reports::display() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/class-gravity-flow.php:5573
[01-Feb-2020 13:52:36 UTC] PHP   8. Gravity_Flow_Reports::get_filter_config_vars() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/includes/pages/class-reports.php:64
[01-Feb-2020 13:52:36 UTC] PHP   9. Gravity_Flow_Step_Approval->get_assignees() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/includes/pages/class-reports.php:653
[01-Feb-2020 13:52:36 UTC] PHP  10. Gravity_Flow_Step_Approval->maybe_add_select_assignees() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/includes/steps/class-step.php:1520
[01-Feb-2020 13:52:36 UTC] PHP  11. Gravity_Flow_Step_Approval->maybe_add_assignee() /Users/richard/LocalBetaSites/gravity-flow/app/public/wp-content/plugins/gravityflow/includes/steps/class-step.php:1625
```

## Testing instructions
With a test site running on PHP 7.4:
- with master access the dashboard and find the first notice above occurs
- ensure you have a step configured with assignees from a multi user field
- accessing the reports page and find the second notice from above occurs
- with this branch find the notices do not occur

## Automated Test Enhancements
Travis matrix has been updated to include PHP 7.4.

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->