### PR TITLE
Fix workflows stalling on the Dropbox step

### DIFF
--- a/includes/steps/class-step-feed-dropbox.php
+++ b/includes/steps/class-step-feed-dropbox.php
@@ -78,7 +78,7 @@ class Gravity_Flow_Step_Feed_Dropbox extends Gravity_Flow_Step_Feed_Add_On {
 			return true;
 		}
 
-		$feed['meta']['workflow_step'] = $this->get_id();
+		gform_update_meta( $this->get_entry_id(), sprintf( 'dropbox_%d_workflow_step', $feed['id'] ), $this->get_id(), $this->get_form_id() );
 		parent::process_feed( $feed );
 
 		return false;
@@ -144,10 +144,15 @@ Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_Dropbox() );
  */
 function gravity_flow_step_dropbox_post_upload( $feed, $entry, $form ) {
 	$workflow_is_pending = rgar( $entry, 'workflow_final_status' ) == 'pending';
-	$feed_step_id        = rgar( $feed['meta'], 'workflow_step' );
-	$entry_step_id       = rgar( $entry, 'workflow_step' );
+	$entry_step_id       = (int) rgar( $entry, 'workflow_step' );
 
-	if ( $workflow_is_pending && ! empty( $feed_step_id ) && $feed_step_id == $entry_step_id ) {
+	if ( ! $workflow_is_pending || ! $entry_step_id ) {
+		return;
+	}
+
+	$feed_step_id = (int) gform_get_meta( $entry['id'], sprintf( 'dropbox_%d_workflow_step', $feed['id'] ) );
+
+	if ( ! empty( $feed_step_id ) && $feed_step_id === $entry_step_id ) {
 		$step = Gravity_Flow_Steps::get( 'dropbox' );
 		if ( $step ) {
 			$add_on_feeds = $step->get_processed_add_on_feeds( $entry['id'] );


### PR DESCRIPTION
## Description
re: [HS#12616](https://secure.helpscout.net/conversation/1074719848/12616?folderId=1113492)

This fixes an issue where the Dropbox step does not complete when files are uploaded to  Dropbox. 

The issue was introduced by Dropbox Add-On version 2.4.1 which switched to passing only the feed ID in the processing request instead of the entire feed. As the add-on is now retreiving a clean version of the feed from the database the `workflow_step` property the step added to the feed meta is lost.

The Dropbox step now stashes the step id in custom entry meta which is retreived when the gform_dropbox_post_upload hook is triggered and used to determine if the step should be completed.

## Testing instructions
- Create a form with a file upload or Dropbox upload field
- Create Dropbox feed
- Create Dropbox step
- Create Approval step
- Submit form and find the the file is sent to Dropbox and that the workflow remains on that step
- Switch to this branch
- Submit form again and find the Dropbox step does complete and the Approval step starts

## Automated Test Enhancements
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->