### PR TITLE
Add workflow note when the Update User step is completed

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -5,6 +5,7 @@
 - Added support for Gravity Forms conditional shortcode within Outgoing webhook raw body requests.
 - Added filter gravityflow_send_to_step_condition_met_required to allow customization of the API send_to_step when the proposed steps conditions are not met. Default is false that API will always send to the proposed step.
 - Added filter gravityflow_send_to_step_condition_not_met to allow customization of the API when the proposed next step has not met its step conditions. Defaults to next step after the proposed step.
+- Added workflow note when the Update User step is completed.
 - Updated Outgoing Webhook settings to allow GET requests to include request body.
 - Updated gravityflow_print_styles filter to include 2nd parameter of entry IDs.
 - Fixed an issue with the User Input Step where editable Total, Coupon, Subtotal, Tax, or Discount fields required all other pricing fields to be editable to function correctly.

--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -308,6 +308,7 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 			$this->add_note( sprintf( esc_html__( '%s: User is not a member of the current site.', 'gravityflow' ), $this->get_name() ) );
 		} else {
 			$this->set_user_properties( $user );
+			$this->add_note( sprintf( esc_html__( '%s: User has been updated.', 'gravityflow' ), $this->get_name() ) );
 		}
 
 		return true;

--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -302,15 +302,15 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 
 		if ( ! $user ) {
 			$this->log_debug( __METHOD__ . '(): user not found. Bailing.' );
-			/* translators: The step name */
+			/* translators: %s: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User not found.', 'gravityflow' ), $this->get_name() ) );
 		} elseif ( is_multisite() && ! is_user_member_of_blog( $user->ID, get_current_blog_id() ) ) {
 			$this->log_debug( __METHOD__ . '(): user is not a member of the current site. Bailing.' );
-			/* translators: The step name */
+			/* translators: %s: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User is not a member of the current site.', 'gravityflow' ), $this->get_name() ) );
 		} else {
 			$this->set_user_properties( $user );
-			/* translators: The step name */
+			/* translators: %s: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User has been updated.', 'gravityflow' ), $this->get_name() ) );
 		}
 

--- a/includes/steps/class-step-update-user.php
+++ b/includes/steps/class-step-update-user.php
@@ -302,12 +302,15 @@ class Gravity_Flow_Step_Update_User extends Gravity_Flow_Step {
 
 		if ( ! $user ) {
 			$this->log_debug( __METHOD__ . '(): user not found. Bailing.' );
+			/* translators: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User not found.', 'gravityflow' ), $this->get_name() ) );
 		} elseif ( is_multisite() && ! is_user_member_of_blog( $user->ID, get_current_blog_id() ) ) {
 			$this->log_debug( __METHOD__ . '(): user is not a member of the current site. Bailing.' );
+			/* translators: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User is not a member of the current site.', 'gravityflow' ), $this->get_name() ) );
 		} else {
 			$this->set_user_properties( $user );
+			/* translators: The step name */
 			$this->add_note( sprintf( esc_html__( '%s: User has been updated.', 'gravityflow' ), $this->get_name() ) );
 		}
 


### PR DESCRIPTION
## Description
re: [HS#12938](https://secure.helpscout.net/conversation/1103134466/12938?folderId=2308452)

This PR adds a workflow note when the Update User step is completed. Previously the notes only added when the step failed.

## Testing instructions
Set up a Update User step in your workflow. With the `master` branch there isn't any note added to the workflow timeline or entry notes if the step is successfully completed. Switch to this branch you'll be able to see the note added.

## Automated Test Enhancements
No.
 
## Screenshots
https://www.dropbox.com/s/m1prht9uyyzz9yu/Screenshot%202020-03-14%2015.41.46.png?dl=0

## Documentation Changes?
No.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->