### PR TITLE
Setting to allow the reports shortcode

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -5,6 +5,7 @@
 - Added support for Gravity Forms conditional shortcode within Outgoing webhook raw body requests.
 - Added filter gravityflow_send_to_step_condition_met_required to allow customization of the API send_to_step when the proposed steps conditions are not met. Default is false that API will always send to the proposed step.
 - Added filter gravityflow_send_to_step_condition_not_met to allow customization of the API when the proposed next step has not met its step conditions. Defaults to next step after the proposed step.
+- Added setting to allow the reports shortcode.
 - Updated Outgoing Webhook settings to allow GET requests to include request body.
 - Updated gravityflow_print_styles filter to include 2nd parameter of entry IDs.
 - Fixed an issue with the User Input Step where editable Total, Coupon, Subtotal, Tax, or Discount fields required all other pricing fields to be editable to function correctly.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4956,24 +4956,19 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 								'tooltip' => esc_html__( 'This setting allows the display_all attribute to be used in the shortcode.', 'gravityflow' ),
 							),
 							array(
-								'label'   => esc_html__( 'Allow the Reports shortcode to display the report chart to all registered users.', 'gravityflow' ),
-								'name'    => 'allow_reports_display_all_attribute',
-								'tooltip' => esc_html__( 'This setting allows the display_all attribute to be used in the Reports shortcode.', 'gravityflow' ),
-							),
-							array(
 								'label'   => esc_html__( 'Allow the Status shortcode to display all entries to all anonymous users.', 'gravityflow' ),
 								'name'    => 'allow_allow_anonymous_attribute',
 								'tooltip' => esc_html__( 'This setting allows the allow_anonymous attribute to be used in the shortcode.', 'gravityflow' ),
 							),
 							array(
-								'label'   => esc_html__( 'Allow the Reports shortcode to display the report chart to all anonymous users.', 'gravityflow' ),
-								'name'    => 'allow_reports_allow_anonymous_attribute',
-								'tooltip' => esc_html__( 'This setting allows the allow_anonymous attribute to be used in the Reports shortcode.', 'gravityflow' ),
-							),
-							array(
 								'label'   => esc_html__( 'Allow the Inbox and Status shortcodes to display field values.', 'gravityflow' ),
 								'name'    => 'allow_field_ids',
 								'tooltip' => esc_html__( 'This setting allows the fields attribute to be used in the shortcode.', 'gravityflow' ),
+							),
+							array(
+								'label'   => esc_html__( 'Allow the Reports shortcode to display workflow reports.', 'gravityflow' ),
+								'name'    => 'allow_display_reports',
+								'tooltip' => esc_html__( 'This setting allows the Reports shortcode to display workflow reports.', 'gravityflow' ),
 							),
 						),
 					),
@@ -6401,10 +6396,6 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			wp_enqueue_script( 'google_charts', 'https://www.google.com/jsapi',  array(), $this->_version );
 			wp_enqueue_script( 'gravityflow_reports', $this->get_base_url() . "/js/reports{$min}.js",  array( 'jquery', 'google_charts' ), $this->_version );
 
-			$app_settings    = $this->get_app_settings();
-			$display_all     = rgar( $app_settings, 'allow_reports_display_all_attribute' ) && is_user_logged_in();
-			$allow_anonymous = rgar( $app_settings, 'allow_reports_allow_anonymous_attribute' );
-
 			$args = array(
 				'display_header'    => false,
 				'base_url'          => remove_query_arg( array(
@@ -6420,7 +6411,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'category'          => $a['category'],
 				'step_id'           => $a['step_id'],
 				'assignee'          => $a['assignee'],
-				'check_permissions' => ( $display_all || $allow_anonymous ) ? false : true
+				'check_permissions' => false,
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4956,6 +4956,11 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 								'tooltip' => esc_html__( 'This setting allows the display_all attribute to be used in the shortcode.', 'gravityflow' ),
 							),
 							array(
+								'label'   => esc_html__( 'Allow the Reports shortcode to display the report chart to all registered users.', 'gravityflow' ),
+								'name'    => 'allow_reports_display_all_attribute',
+								'tooltip' => esc_html__( 'This setting allows the display_all attribute to be used in the Reports shortcode.', 'gravityflow' ),
+							),
+							array(
 								'label'   => esc_html__( 'Allow the Status shortcode to display all entries to all anonymous users.', 'gravityflow' ),
 								'name'    => 'allow_allow_anonymous_attribute',
 								'tooltip' => esc_html__( 'This setting allows the allow_anonymous attribute to be used in the shortcode.', 'gravityflow' ),
@@ -6058,7 +6063,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 				$app_settings = $this->get_app_settings();
 
-				if ( $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
+				if ( $a['page'] === 'status' && $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
+
+					$a['display_all'] = false;
+				}
+
+				if ( $a['page'] === 'reports' && $a['display_all'] && ! rgar( $app_settings, 'allow_reports_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
 
 					$a['display_all'] = false;
 				}
@@ -6416,7 +6426,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'category'          => $a['category'],
 				'step_id'           => $a['step_id'],
 				'assignee'          => $a['assignee'],
-				'check_permissions' => ( $a['allow_anonymous'] ) ? false : true
+				'check_permissions' => ( $a['allow_anonymous'] || $a['display_all'] ) ? false : true
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4961,6 +4961,11 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 								'tooltip' => esc_html__( 'This setting allows the allow_anonymous attribute to be used in the shortcode.', 'gravityflow' ),
 							),
 							array(
+								'label'   => esc_html__( 'Allow the Reports shortcode to display the report chart to all anonymous users.', 'gravityflow' ),
+								'name'    => 'allow_reports_allow_anonymous_attribute',
+								'tooltip' => esc_html__( 'This setting allows the allow_anonymous attribute to be used in the Reports shortcode.', 'gravityflow' ),
+							),
+							array(
 								'label'   => esc_html__( 'Allow the Inbox and Status shortcodes to display field values.', 'gravityflow' ),
 								'name'    => 'allow_field_ids',
 								'tooltip' => esc_html__( 'This setting allows the fields attribute to be used in the shortcode.', 'gravityflow' ),
@@ -6058,7 +6063,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$a['display_all'] = false;
 				}
 
-				if ( $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_allow_anonymous_attribute' ) ) {
+				if ( $a['page'] === 'status' && $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_allow_anonymous_attribute' ) ) {
+
+					$a['allow_anonymous'] = false;
+				}
+
+				if ( $a['page'] === 'reports' && $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_reports_allow_anonymous_attribute' ) ) {
 
 					$a['allow_anonymous'] = false;
 				}
@@ -6392,8 +6402,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			wp_enqueue_script( 'gravityflow_reports', $this->get_base_url() . "/js/reports{$min}.js",  array( 'jquery', 'google_charts' ), $this->_version );
 
 			$args = array(
-				'display_header' => false,
-				'base_url'       => remove_query_arg( array(
+				'display_header'    => false,
+				'base_url'          => remove_query_arg( array(
 					'page',
 					'range',
 					'form-id',
@@ -6401,11 +6411,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					'step-id',
 					'assignee',
 				) ),
-				'form_id'        => $a['form'],
-				'range'          => $a['range'],
-				'category'       => $a['category'],
-				'step_id'        => $a['step_id'],
-				'assignee'       => $a['assignee'],
+				'form_id'           => $a['form'],
+				'range'             => $a['range'],
+				'category'          => $a['category'],
+				'step_id'           => $a['step_id'],
+				'assignee'          => $a['assignee'],
+				'check_permissions' => ( $a['allow_anonymous'] ) ? false : true
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4966,9 +4966,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 								'tooltip' => esc_html__( 'This setting allows the fields attribute to be used in the shortcode.', 'gravityflow' ),
 							),
 							array(
-								'label'   => esc_html__( 'Allow the Reports shortcode to display workflow reports.', 'gravityflow' ),
+								'label'   => esc_html__( 'Allow the Reports shortcode to display workflow reports to all registered and anonymous users.', 'gravityflow' ),
 								'name'    => 'allow_display_reports',
-								'tooltip' => esc_html__( 'This setting allows the Reports shortcode to display workflow reports.', 'gravityflow' ),
+								'tooltip' => esc_html__( 'This setting allows the Reports shortcode to display workflow reports to all registered and anonymous users.', 'gravityflow' ),
 							),
 						),
 					),

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6414,8 +6414,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'category'              => $a['category'],
 				'step_id'               => $a['step_id'],
 				'assignee'              => $a['assignee'],
-				'check_permissions'     => false,
-				'allow_display_reports' => GFAPI::current_user_can_any( 'gravityflow_reports' ) ? true : $allow_reports,
+				'check_permissions'     => ! $allow_reports,
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6063,22 +6063,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 				$app_settings = $this->get_app_settings();
 
-				if ( $a['page'] === 'status' && $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
+				if ( $a['display_all'] && ! rgar( $app_settings, 'allow_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_status_view_all' ) ) {
 
 					$a['display_all'] = false;
 				}
 
-				if ( $a['page'] === 'reports' && $a['display_all'] && ! rgar( $app_settings, 'allow_reports_display_all_attribute' ) && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
-
-					$a['display_all'] = false;
-				}
-
-				if ( $a['page'] === 'status' && $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_allow_anonymous_attribute' ) ) {
-
-					$a['allow_anonymous'] = false;
-				}
-
-				if ( $a['page'] === 'reports' && $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_reports_allow_anonymous_attribute' ) ) {
+				if ( $a['allow_anonymous'] && ! rgar( $app_settings, 'allow_allow_anonymous_attribute' ) ) {
 
 					$a['allow_anonymous'] = false;
 				}
@@ -6411,6 +6401,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			wp_enqueue_script( 'google_charts', 'https://www.google.com/jsapi',  array(), $this->_version );
 			wp_enqueue_script( 'gravityflow_reports', $this->get_base_url() . "/js/reports{$min}.js",  array( 'jquery', 'google_charts' ), $this->_version );
 
+			$app_settings    = $this->get_app_settings();
+			$display_all     = rgar( $app_settings, 'allow_reports_display_all_attribute' ) && is_user_logged_in();
+			$allow_anonymous = rgar( $app_settings, 'allow_reports_allow_anonymous_attribute' );
+
 			$args = array(
 				'display_header'    => false,
 				'base_url'          => remove_query_arg( array(
@@ -6426,7 +6420,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'category'          => $a['category'],
 				'step_id'           => $a['step_id'],
 				'assignee'          => $a['assignee'],
-				'check_permissions' => ( $a['allow_anonymous'] || $a['display_all'] ) ? false : true
+				'check_permissions' => ( $display_all || $allow_anonymous ) ? false : true
 			);
 
 			ob_start();

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6396,9 +6396,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			wp_enqueue_script( 'google_charts', 'https://www.google.com/jsapi',  array(), $this->_version );
 			wp_enqueue_script( 'gravityflow_reports', $this->get_base_url() . "/js/reports{$min}.js",  array( 'jquery', 'google_charts' ), $this->_version );
 
+			$app_settings  = $this->get_app_settings();
+			$allow_reports = rgar( $app_settings, 'allow_display_reports' );
+
 			$args = array(
-				'display_header'    => false,
-				'base_url'          => remove_query_arg( array(
+				'display_header'        => false,
+				'base_url'              => remove_query_arg( array(
 					'page',
 					'range',
 					'form-id',
@@ -6406,12 +6409,13 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					'step-id',
 					'assignee',
 				) ),
-				'form_id'           => $a['form'],
-				'range'             => $a['range'],
-				'category'          => $a['category'],
-				'step_id'           => $a['step_id'],
-				'assignee'          => $a['assignee'],
-				'check_permissions' => false,
+				'form_id'               => $a['form'],
+				'range'                 => $a['range'],
+				'category'              => $a['category'],
+				'step_id'               => $a['step_id'],
+				'assignee'              => $a['assignee'],
+				'check_permissions'     => false,
+				'allow_display_reports' => GFAPI::current_user_can_any( 'gravityflow_reports' ) ? true : $allow_reports,
 			);
 
 			ob_start();

--- a/includes/pages/class-reports.php
+++ b/includes/pages/class-reports.php
@@ -61,7 +61,14 @@ class Gravity_Flow_Reports {
 			'base_url'          => admin_url( 'admin.php?page=gravityflow-reports' ),
 		);
 
-		$args = array_merge( $defaults, $args );
+		/**
+		 * Allow the reports display arguments to be overridden.
+		 *
+		 * @since 2.5.10
+		 *
+		 * @param array $args The reports display arguments.
+		 */
+		$args = apply_filters( 'gravityflow_reports_args', array_merge( $defaults, $args ) );
 
 		if ( $args['check_permissions'] && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
 			esc_html_e( "You don't have permission to view this page", 'gravityflow' );

--- a/includes/pages/class-reports.php
+++ b/includes/pages/class-reports.php
@@ -76,10 +76,8 @@ class Gravity_Flow_Reports {
 			$is_allowed = false;
 		}
 
-		$app_settings  = gravity_flow()->get_app_settings();
-		$allow_reports = rgar( $app_settings, 'allow_display_reports' );
 		// Shortcode wouldn't check permissions.
-		if ( ! $args['check_permissions'] && ! $allow_reports && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
+		if ( ! $args['check_permissions'] && ! $args['allow_display_reports'] ) {
 			$is_allowed = false;
 		}
 

--- a/includes/pages/class-reports.php
+++ b/includes/pages/class-reports.php
@@ -70,7 +70,20 @@ class Gravity_Flow_Reports {
 		 */
 		$args = apply_filters( 'gravityflow_reports_args', array_merge( $defaults, $args ) );
 
+		$is_allowed = true;
+
 		if ( $args['check_permissions'] && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
+			$is_allowed = false;
+		}
+
+		$app_settings  = gravity_flow()->get_app_settings();
+		$allow_reports = rgar( $app_settings, 'allow_display_reports' );
+		// Shortcode wouldn't check permissions.
+		if ( ! $args['check_permissions'] && ! $allow_reports && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
+			$is_allowed = false;
+		}
+
+		if ( ! $is_allowed ) {
 			esc_html_e( "You don't have permission to view this page", 'gravityflow' );
 			return;
 		}

--- a/includes/pages/class-reports.php
+++ b/includes/pages/class-reports.php
@@ -70,18 +70,7 @@ class Gravity_Flow_Reports {
 		 */
 		$args = apply_filters( 'gravityflow_reports_args', array_merge( $defaults, $args ) );
 
-		$is_allowed = true;
-
 		if ( $args['check_permissions'] && ! GFAPI::current_user_can_any( 'gravityflow_reports' ) ) {
-			$is_allowed = false;
-		}
-
-		// Shortcode wouldn't check permissions.
-		if ( ! $args['check_permissions'] && ! $args['allow_display_reports'] ) {
-			$is_allowed = false;
-		}
-
-		if ( ! $is_allowed ) {
 			esc_html_e( "You don't have permission to view this page", 'gravityflow' );
 			return;
 		}


### PR DESCRIPTION
## Description
This PR adds new Security Options to allow the reports chart can be displayed with the reports shortcode.

## Testing instructions
1. Enable the "Allow the Reports shortcode to display workflow reports." setting. View the page with the reports shortcode as an anonymous user, reports would be displayed; if not checking this option, you'll see "You don't have permission to view this page."
2. Users with the `gravityflow_reports` cap can see the reports chart regardless of the setting.

## Automated Test Enhancements
No.
 
## Screenshots
<img width="750" alt="Screenshot 2020-03-21 21 29 28" src="https://user-images.githubusercontent.com/12166/77229205-73948a80-6bc7-11ea-9cd9-f68da59c43fb.png">

## Documentation Changes?
1. Update the [shortcode](https://docs.gravityflow.io/article/36-the-shortcode) documentation, update the screenshot of the Security Options.
2. Add a new doc for the `gravityflow_reports_args` filter. Code example:
```
/**
 * Force to check permission if it's the report for a certain form.
 *
 * @param array $args The arguments.
 *
 * @return array
 */
function my_gravityflow_reports_args( $args ) {
    if ( $args['form_id'] == 1 ) {
	    $args['check_permissions'] = true;
    }

    return $args;
}
add_filter( 'gravityflow_reports_args', 'my_gravityflow_reports_args' );
```

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->