### PR TITLE
Refine discussion view more/less JS to execute in multiple page contexts

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -16,3 +16,4 @@
 - Fixed notices with PHP 7.4.
 - Fixed an issue where the Dropbox step does not complete with Dropbox Add-On 2.4.1+.
 - Fixed an issue where the report data for assignees by month is incorrect.
+- Fixed an issue where the Discussion Field view more/less effect would not operate on the Form > Entries screen (both view and edit).

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -709,9 +709,8 @@ PRIMARY KEY  (id)
 					'version' => $this->_version,
 					'deps'    => array( 'jquery', 'sack' ),
 					'enqueue' => array(
-						array(
-							'query' => 'page=gravityflow-inbox',
-						),
+						array( 'query' => 'page=gravityflow-inbox', ),
+						array( 'query' => 'page=gf_entries', ),
 					),
 				),
 				array(
@@ -758,6 +757,8 @@ PRIMARY KEY  (id)
 					),
 				),
 			);
+
+			$magic = true;
 
 			return array_merge( parent::scripts(), $scripts );
 		}

--- a/js/entry-detail.js
+++ b/js/entry-detail.js
@@ -4,11 +4,10 @@
     };
 
     GravityFlowEntryDetail.displayDiscussionItemToggle = function (formId, fieldId, displayLimit) {
+            $toggle = $('.gravityflow-dicussion-item-hidden');
+            $toggle.slideToggle( 'fast' );
 
-            $toggle = $('.field_description_below');
-            $toggle.find( '.gravityflow-dicussion-item-hidden' ).slideToggle( 'fast' );
-
-            var $viewMore = $toggle.children( '.gravityflow-dicussion-item-toggle-display' );
+            var $viewMore = $toggle.siblings( '.gravityflow-dicussion-item-toggle-display' );
             var oldText = $viewMore.attr( 'title' );
             var newText = $viewMore.data( 'title' );
 


### PR DESCRIPTION
## Description
See [HS 11171](https://secure.helpscout.net/conversation/982861014/11171?folderId=1113497). The Discussion Field View More/Less feature displays visually on the Form > Entries screen of core GForms, but the click events are not executing due to the different markup structure of where/how the field is being rendered.

## Testing instructions
- Create a form with discussion field.
- Add a workflow with a user input step that includes the save in progress setting.
- Submit discussion field values 10 times, or alternatively you can use [gravityflow_discussion_items_display_limit](https://docs.gravityflow.io/article/180-gravityflowdiscussionitemsdisplaylimit) and a lower number to trigger the view more/less effect.
- Confirm that on Form > Entries screen when viewing or editing the entry the effect does not work.
- Switch to fix-11171-discussion-more branch
- Repeat tests to confirm that view more/less effect does operate on GForms pages along with existing GFlow scenarios (status, inbox, editable field, display field, etc).
 
## Documentation Changes?
Not directly related to PR, but the originating HS ticket identified the use case related to the Advanced Post Creation add-on and same view more/less feature not being ported to the created post. Recommend either an addition to [The Discussion Field](https://docs.gravityflow.io/article/116-the-discussion-field) or a [walkthrough ](https://docs.gravityflow.io/category/34-walkthroughs) covering snippet JS that replicates the effect on a single post template. See HS ticket for example.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->