### PR TITLE
Fix missing scripts and styles when using reusable block

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -844,16 +844,11 @@ PRIMARY KEY  (id)
 			$blocks = parse_blocks( $post_content );
 
 			foreach ( $blocks as $block ) {
-				if ( rgar( $block, 'blockName' ) !== 'core/block' ) {
+				if ( rgar( $block, 'blockName' ) !== 'core/block' || empty( $block['attrs']['ref'] ) ) {
 					continue;
 				}
 
-				$ref = rgars( $block, 'attrs/ref' );
-				if ( empty( $ref ) ) {
-					continue;
-				}
-
-				$reusable_block = get_post( $ref );
+				$reusable_block = get_post( $block['attrs']['ref'] );
 				if ( empty( $reusable_block ) || $reusable_block->post_type !== 'wp_block' ) {
 					continue;
 				}

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -837,7 +837,7 @@ PRIMARY KEY  (id)
 				return true;
 			}
 
-			if ( ! function_exists( 'has_block' ) || ! has_block( 'core/block' ) ) {
+			if ( ! function_exists( 'has_block' ) || ! has_block( 'block', $post_content ) ) {
 				return false;
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -803,21 +803,20 @@ PRIMARY KEY  (id)
 		}
 
 		/**
-		 * Determines if the gravityflow shortcode is used in the post content.
+		 * Determines if at least one of the posts for the current WP query contains the shortcode or block.
 		 *
 		 * @return bool
 		 */
 		public function look_for_shortcode() {
 			global $wp_query;
 
-			$shortcode_found = false;
 			foreach ( $wp_query->posts as $post ) {
-				if ( stripos( $post->post_content, '[gravityflow' ) !== false || stripos( $post->post_content, '<!-- wp:gravityflow/' ) !== false ) {
-					$shortcode_found = true;
-					break;
+				if ( $post instanceof WP_Post && $this->has_shortcode_or_block( $post->post_content ) ) {
+					return true;
 				}
 			}
-			return $shortcode_found;
+
+			return false;
 		}
 
 		/**

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -837,7 +837,7 @@ PRIMARY KEY  (id)
 				return true;
 			}
 
-			if ( ! has_block( 'core/block' ) ) {
+			if ( ! function_exists( 'has_block' ) || ! has_block( 'core/block' ) ) {
 				return false;
 			}
 

--- a/tests/unit-tests/gravity-flow/test-has-shortcode-or-block.php
+++ b/tests/unit-tests/gravity-flow/test-has-shortcode-or-block.php
@@ -25,9 +25,11 @@ class Tests_Gravity_Flow_Has_Shortcode_Or_Block extends GF_UnitTestCase {
 	public function test_reusable_block() {
 		$id = wp_insert_post( array(
 			'post_type'    => 'wp_block',
-			'post_content' => '<!-- wp:gravityflow/inbox /-->',
+			'post_content' => '<!-- WP:GRAVITYFLOW/INBOX /-->',
 		) );
 		$this->assertTrue( gravity_flow()->has_shortcode_or_block( sprintf( '<!-- wp:block {"ref":%d} /-->', $id ) ) );
+		$this->assertFalse( gravity_flow()->has_shortcode_or_block( '<!-- wp:block /-->' ) );
+		$this->assertFalse( gravity_flow()->has_shortcode_or_block( '<!-- wp:block {"ref":-1} /-->' ) );
 	}
 
 }

--- a/tests/unit-tests/gravity-flow/test-has-shortcode-or-block.php
+++ b/tests/unit-tests/gravity-flow/test-has-shortcode-or-block.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Testing Gravity_Flow::has_shortcode_or_block()
+ *
+ * @group testsuite
+ */
+class Tests_Gravity_Flow_Has_Shortcode_Or_Block extends GF_UnitTestCase {
+
+	public function test_empty() {
+		$this->assertFalse( gravity_flow()->has_shortcode_or_block( '' ) );
+	}
+
+	public function test_shortcode() {
+		$this->assertFalse( gravity_flow()->has_shortcode_or_block( 'before [gravityforms id=1] after' ) );
+		$this->assertTrue( gravity_flow()->has_shortcode_or_block( 'before [gravityflow page=inbox] after' ) );
+		$this->assertTrue( gravity_flow()->has_shortcode_or_block( '[GRAVITYFLOW page=inbox]' ) );
+	}
+
+	public function test_block() {
+		$this->assertFalse( gravity_flow()->has_shortcode_or_block( 'before <!-- wp:gravityforms/form {"formId":"1"} /--> after' ) );
+		$this->assertTrue( gravity_flow()->has_shortcode_or_block( 'before <!-- wp:gravityflow/inbox {"actionsColumn":true} /--> after' ) );
+	}
+
+	public function test_reusable_block() {
+		$id = wp_insert_post( array(
+			'post_type'    => 'wp_block',
+			'post_content' => '<!-- wp:gravityflow/inbox /-->',
+		) );
+		$this->assertTrue( gravity_flow()->has_shortcode_or_block( sprintf( '<!-- wp:block {"ref":%d} /-->', $id ) ) );
+	}
+
+}


### PR DESCRIPTION
## Description
This was prompted by a Gravity Forms ticket reporting that a form using conditional logic does not function when located in a reusable block. It was discovered that the methods used to determine if the posts for the current WP query contain the shortocode or block were not checking the contents of reusable blocks which are stored as separate posts. This issue prevented the required scripts and styles being enqueued correctly. 

This adds `Gravity_Flow::has_shortcode_or_block()` and updates `Gravity_Flow::look_for_shortcode()` so that the post content for reusable blocks is also checked when determining if the scripts and styles need to be enqueued.

## Testing instructions
- Create a page with the Workflow Inbox block
- Click the block options icon and select the "Add to Reusable Blocks" choice
- Enter a name and save
- Save and view the page
- Inspect the page source code and find the scripts and styles are missing
- Switch to this branch
- Reload page and find the scripts and styles are now present

## Automated Test Enhancements
Added unit tests for `Gravity_Flow::has_shortcode_or_block()`
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->