### PR TITLE
Fix Duplicate HubSpot Step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -19,4 +19,4 @@
 - Fixed an issue where the report data for assignees by month is incorrect.
 - Fixed an issue where the Discussion Field view more/less effect would not operate on the Form > Entries screen (both view and edit).
 - Fixed an issue where the scripts and styles are not enqueued when using the shortcode or block in a reusable block.
-- Fixed an issue of duplicacy on Workflow steps with Gravity Forms Hub Spot Add-on and third party Hub Spot Add-on.
+- Fixed an issue in the step settings page where duplicate Workflow step icons appear for the Gravity Forms HubSpot Add-on and third-party HubSpot Add-on. IMPORTANT: check that your HubSpot workflow steps are correct after updating to this version.

--- a/change_log.txt
+++ b/change_log.txt
@@ -19,3 +19,4 @@
 - Fixed an issue where the report data for assignees by month is incorrect.
 - Fixed an issue where the Discussion Field view more/less effect would not operate on the Form > Entries screen (both view and edit).
 - Fixed an issue where the scripts and styles are not enqueued when using the shortcode or block in a reusable block.
+- Fixed an issue of duplicacy on Workflow steps with Gravity Forms Hub Spot Add-on and third party Hub Spot Add-on.

--- a/includes/steps/class-step-feed-hubspot.php
+++ b/includes/steps/class-step-feed-hubspot.php
@@ -48,19 +48,6 @@ class Gravity_Flow_Step_Feed_HubSpot extends Gravity_Flow_Step_Feed_Add_On {
 		return 'HubSpot';
 	}
 
-	/**
-	 * Returns the class name for the add-on.
-	 *
-	 * @return string
-	 */
-	public function get_feed_add_on_class_name() {
-		if ( ! class_exists( '\BigSea\GFHubSpot\GF_HubSpot' ) ) {
-			$this->_class_name = 'GF_HubSpot';
-		}
-
-		return $this->_class_name;
-	}
-
 }
 
 Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_HubSpot() );


### PR DESCRIPTION
## Description
This fixes the issue of duplicate HubSpot steps. The issue of having steps displayed for both Gravity Forms Hub Spot Add-on and the third party Hub Spot Add-on is resolved.

## Testing instructions
- Install the Offical Gravity Forms Hub Spot Add-on.
- Install the third-party Gravity Forms Hub Spot Add-on: https://wordpress.org/plugins/gravityforms-hubspot/
- Activate only the Official Gravity Forms Hub Spot Add-on and check workflow step only consists of this one and not the other.
- Activate only the third-party Gravity Forms Hub Spot Add-on and check workflow step only consists of this one and not the other.
- Activate both Add-ons and check workflow step contains both.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->