### PR TITLE
12355 : Fix Expiration Status

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -20,3 +20,4 @@
 - Fixed an issue where the Discussion Field view more/less effect would not operate on the Form > Entries screen (both view and edit).
 - Fixed an issue where the scripts and styles are not enqueued when using the shortcode or block in a reusable block.
 - Fixed an issue in the step settings page where duplicate Workflow step icons appear for the Gravity Forms HubSpot Add-on and third-party HubSpot Add-on. IMPORTANT: check that your HubSpot workflow steps are correct after updating to this version.
+- Fixed a bug with 'Schedule expiration' on Workflow step. 'Next Step if Expired' option should only appear when 'Status after expiration' is set as 'Expired'.

--- a/js/form-settings.js
+++ b/js/form-settings.js
@@ -73,7 +73,7 @@
 		$('#expiration_sub_setting_destination_expired').toggle(expiredSelected);
 		$statusExpiration.change(function () {
 			var show = $(this).val() == 'expired';
-			$('#expiration_sub_setting_destination_expired').fadeToggle(show);
+			show ? $('#expiration_sub_setting_destination_expired').show() : $('#expiration_sub_setting_destination_expired').hide();
 		});
 
 		setSubSettings();


### PR DESCRIPTION
## Description
This is a bug fix for the 'Schedule expiration' selection on a Workflow Step, as described on HS# [12355](https://secure.helpscout.net/conversation/1050698455/12355?folderId=3509658#thread-2970402028).

'Next Step if Expired' should appear only when 'Status after expiration' is selected as 'Expired'.

## Testing instructions
- Create a Workflow Step and enable 'Schedule expiration'.
- Select 'Status after expiration' as 'Expired', the option 'Next Step if Expired' should appear.
- Select 'Status after expiration' as 'Approved', the option 'Next Step if Expired' should not appear.
- Select 'Status after expiration' as 'Rejected', the option 'Next Step if Expired' should not appear.

## Automated Test Enhancements
N/A
 
## Screenshots
Recording before the update: https://share.getcloudapp.com/wbukYdmp
Recording after the update: https://share.getcloudapp.com/6quLpGen

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->