### PR TITLE
Change logging statements to remove some noise

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6981,7 +6981,7 @@ AND m.meta_value='queued'";
 
 			$form_ids = $this->get_workflow_form_ids();
 
-			$this->log_debug( __METHOD__ . '(): workflow form IDs: ' . print_r( $form_ids, true ) );
+			$this->log_debug( __METHOD__ . '(): workflow form IDs: ' . json_encode( $form_ids ) );
 
 			foreach ( $form_ids as $form_id ) {
 				$form = GFAPI::get_form( $form_id );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -515,7 +515,7 @@ class Gravity_Flow_API {
 		 */
 		$form_ids = apply_filters( 'gravityflow_form_ids_inbox', $form_ids, $search_criteria );
 
-		gravity_flow()->log_debug( __METHOD__ . '(): ' . print_r( $form_ids, 1 ) );
+		gravity_flow()->log_debug( __METHOD__ . '(): ' . json_encode( $form_ids ) );
 
 		return $form_ids;
 	}

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -688,8 +688,12 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 		$args = apply_filters( 'gravityflow_webhook_args_' . $this->get_form_id(), $args, $entry, $this );
 
 		$response = wp_remote_request( $url, $args );
-		$this->log_debug( __METHOD__ . '() - request: ' . print_r( $args, true ) );
-		$this->log_debug( __METHOD__ . '() - response: ' . print_r( $response, true ) );
+		$args_adjusted = $args;
+		unset( $args_adjusted['body'] );
+		$response_adjusted = $response;
+		unset( $response_adjusted['headers'], $response_adjusted['cookies'], $response_adjusted['http_response'] );
+		$this->log_debug( __METHOD__ . '() - request: ' . print_r( $args_adjusted, true ) );
+		$this->log_debug( __METHOD__ . '() - response: ' . print_r( $response_adjusted, true ) );
 
 		if ( is_wp_error( $response ) ) {
 			$step_status = 'error';

--- a/includes/steps/class-step-webhook.php
+++ b/includes/steps/class-step-webhook.php
@@ -691,7 +691,11 @@ class Gravity_Flow_Step_Webhook extends Gravity_Flow_Step {
 		$args_adjusted = $args;
 		unset( $args_adjusted['body'] );
 		$response_adjusted = $response;
-		unset( $response_adjusted['headers'], $response_adjusted['cookies'], $response_adjusted['http_response'] );
+		
+		if ( ! is_wp_error( $response ) ) {
+			unset( $response_adjusted['headers'], $response_adjusted['cookies'], $response_adjusted['http_response'] );
+		}
+		
 		$this->log_debug( __METHOD__ . '() - request: ' . print_r( $args_adjusted, true ) );
 		$this->log_debug( __METHOD__ . '() - response: ' . print_r( $response_adjusted, true ) );
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1519,7 +1519,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 		if ( ! empty( $this->type ) ) {
 			$this->maybe_add_select_assignees();
 			$this->maybe_add_routing_assignees();
-			$this->log_debug( __METHOD__ . '(): assignees: ' . print_r( $this->get_assignee_keys(), true ) );
+			$this->log_debug( __METHOD__ . '(): assignees: ' . json_encode( $this->get_assignee_keys() ) );
 
 			/**
 			 * Allows the assignees to be modified for the step.


### PR DESCRIPTION
## Description
This enhances some of the logging statements. Following updates are on this branch:
- `get_inbox_form_ids()` on _/includes/class-api.php_ presented in a compact way.
- `get_assignees()` on _/includes/steps/class-step.php_ presented in a compact way.
-  `maybe_process_expiration_and_reminders()` on _/class-gravity-flow.php_ presented in a compact way.
- `send_webhook()` on _/includes/steps/class-step-webhook.php_ enhanced with lesser noise option on request-response.
- `send_webhook()` on _/includes/steps/class-step-webhook.php_ enhanced with lesser noise option on Updated Entry.
- `maybe_display_assignee_status_list()` _/includes/steps/class-step-user-input.php_ enhanced with lesser noise option on assignee details.

To test the lighter logging snippets, define the constant `GF_LIGHT_LOGGING` on _wp-config.php_

`define( 'GF_LIGHT_LOGGING', true );`

## Testing instructions
Review log files for the steps as described.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->