### PR TITLE
Add support for Zapier Add-On v4.0

### DIFF
--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -216,22 +216,23 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 				continue;
 			}
 
-			$step_dirty = false;
+			$to_migrate = array();
 			$step_meta  = $step->get_feed_meta();
 
 			foreach ( $migrated_feeds as $feed ) {
 				$legacy_id = rgars( $feed, 'meta/legacy_id' );
 				if ( $legacy_id && isset( $step_meta[ 'feed_' . $legacy_id ] ) ) {
-					$step_dirty = true;
-					$enabled    = $step_meta[ 'feed_' . $legacy_id ] == '1';
+					$to_migrate[ $legacy_id ] = $step_meta[ 'feed_' . $legacy_id ] == '1' ? $feed['id'] : false;
 					unset( $step_meta[ 'feed_' . $legacy_id ] );
-					if ( $enabled ) {
-						$step_meta[ 'feed_' . $feed['id'] ] = '1';
-					}
 				}
 			}
 
-			if ( $step_dirty ) {
+			if ( ! empty( $to_migrate ) ) {
+				foreach ( $to_migrate as $legacy_id => $new_id ) {
+					if ( $new_id !== false ) {
+						$step_meta[ 'feed_' . $new_id ] = '1';
+					}
+				}
 				gravity_flow()->update_feed_meta( $step->get_id(), $step_meta );
 			}
 

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -21,12 +21,17 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 	/**
 	 * The step type.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @var string
 	 */
 	public $_step_type = 'zapier';
 
 	/**
 	 * The name of the class used by the add-on.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 *
 	 * @var string
 	 */
@@ -35,12 +40,16 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 	/**
 	 * The slug used by the add-on.
 	 *
+	 * @since 1.8.0
+	 *
 	 * @var string
 	 */
 	protected $_slug = 'gravityformszapier';
 
 	/**
 	 * Returns the step label.
+	 *
+	 * @since 1.0.0
 	 *
 	 * @return string
 	 */
@@ -51,6 +60,8 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 	/**
 	 * Returns the URL for the step icon.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @return string
 	 */
 	public function get_icon_url() {
@@ -59,6 +70,9 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 	/**
 	 * Returns the feeds for the add-on.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 *
 	 * @return array
 	 */
@@ -72,6 +86,9 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 	/**
 	 * Processes the given feed for the add-on.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 *
 	 * @param array $feed The add-on feed properties.
 	 *
@@ -101,6 +118,9 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 	/**
 	 * Prevent the feeds assigned to the current step from being processed by the associated add-on.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 */
 	public function intercept_submission() {
 		if ( class_exists( 'GFZapier' ) ) {
@@ -112,6 +132,9 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 	/**
 	 * Returns the feed name.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 *
 	 * @param array $feed The feed properties.
 	 *
@@ -127,6 +150,9 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 	/**
 	 * Determines if the supplied feed should be processed.
+	 *
+	 * @since 1.3.2
+	 * @since 2.5.10 Updated to support Zapier v4.0
 	 *
 	 * @param array $feed  The current feed.
 	 * @param array $form  The current form.


### PR DESCRIPTION
## Description
This updates the Zapier step to support processing feeds for the famework version of the add-on. As the feed IDs change during the migration the steps will also be updated at the end of the migration to ensure selected feeds will continue to be processed by the step.

## Testing instructions
- Use this branch and Zapier master branch (v3.2.1)
- Create a form with a Zapier feed
- Configure a workflow with an Approval step and a Zapier step
- Test the form to confirm the zap is only processed after the Approval step
- Update to the Zapier 4.0 branch (v4.0-beta-1.1)
- Check the Zapier step to confirm the feed is selected
- Test the form again to confirm the zap is only processed after the Approval step
- Check a form which does not have a Zapier feed to confirm Zapier is not an available type when creating a new step

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->