### PR TITLE
Show empty editable fields in {workflow_fields} for the User Input Step

### DIFF
--- a/includes/merge-tags/class-merge-tag-workflow-fields.php
+++ b/includes/merge-tags/class-merge-tag-workflow-fields.php
@@ -63,6 +63,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Fields extends Gravity_Flow_Merge_Tag {
 				$modifiers = rgar( $match, 2 );
 
 				$a = $this->get_attributes( $modifiers, array(
+					'show_empty'	=> false,	// Output empty fields (for User Input step).
 					'empty'    => false, // Output empty fields.
 					'value'    => false, // Output choice values.
 					'admin'    => false, // Output admin labels.
@@ -109,8 +110,20 @@ class Gravity_Flow_Merge_Tag_Workflow_Fields extends Gravity_Flow_Merge_Tag {
 	 */
 	public function merge_tag_filter( $value, $merge_tag, $modifiers, $field ) {
 		$modifiers_array        = $field->get_modifiers();
+		$display_show_empty			= in_array( 'show_empty', $modifiers_array ) && Gravity_Flow_Common::is_editable_field( $field, $this->step );
 		$display_editable_field = in_array( 'editable', $modifiers_array ) && Gravity_Flow_Common::is_editable_field( $field, $this->step );
 		$display_display_field  = in_array( 'display', $modifiers_array ) && Gravity_Flow_Common::is_display_field( $field, $this->step, $this->form, $this->entry );
+
+		if ( in_array( 'show_empty', $modifiers_array ) ) {
+			// Only display editable fields with 'show_empty' for a User Input step.
+			if ( $display_show_empty ) {
+				$value = ' ';
+				return $value;
+			}
+			else {
+				return false;
+			}
+		}
 
 		if ( ! $display_editable_field && ! $display_display_field ) {
 			// Removing non-editable and non-display field from merge tag output.

--- a/includes/merge-tags/class-merge-tag-workflow-fields.php
+++ b/includes/merge-tags/class-merge-tag-workflow-fields.php
@@ -71,7 +71,7 @@ class Gravity_Flow_Merge_Tag_Workflow_Fields extends Gravity_Flow_Merge_Tag {
 					'display'  => true, // Output the steps display fields.
 				) );
 
-				$replacement = GFCommon::get_submitted_fields( $this->form, $entry, $a['empty'], ! $a['value'], $this->format, $a['admin'], $this->name, $this->get_options_string( $a ) );
+				$replacement = GFCommon::get_submitted_fields( $this->form, $entry, $a['empty'], ! $a['value'], $this->format, $a['admin'], $this->name, $modifiers );
 				$text        = str_replace( $full_tag, $replacement, $text );
 			}
 
@@ -110,20 +110,37 @@ class Gravity_Flow_Merge_Tag_Workflow_Fields extends Gravity_Flow_Merge_Tag {
 	 */
 	public function merge_tag_filter( $value, $merge_tag, $modifiers, $field ) {
 		$modifiers_array        = $field->get_modifiers();
-		$display_show_empty			= in_array( 'show_empty', $modifiers_array ) && Gravity_Flow_Common::is_editable_field( $field, $this->step );
+
+		// default case
+		if ( $modifiers_array[0] == '' ) {
+			return $value;
+		}
+
+		$is_empty_field = false;
+		if ( $this->step->get_entry()[ $field->id ] == '' ) {
+			$is_empty_field = true;
+		}
+
+		$display_empty_field    = in_array( 'empty', $modifiers_array ) && $is_empty_field;
 		$display_editable_field = in_array( 'editable', $modifiers_array ) && Gravity_Flow_Common::is_editable_field( $field, $this->step );
 		$display_display_field  = in_array( 'display', $modifiers_array ) && Gravity_Flow_Common::is_display_field( $field, $this->step, $this->form, $this->entry );
 
-		if ( in_array( 'show_empty', $modifiers_array ) ) {
-			// Only display editable fields with 'show_empty' for a User Input step.
-			if ( $display_show_empty ) {
-				$value = ' ';
+		if ( $display_editable_field ) {
+			if ( $is_empty_field ) {
+				return ' ';
+			} else {
 				return $value;
 			}
-			else {
+		}
+
+		if ( $display_empty_field ) {
+			if ( in_array( 'editable', $modifiers_array ) ) {
 				return false;
+			} else {
+				return ' ';
 			}
 		}
+
 
 		if ( ! $display_editable_field && ! $display_display_field ) {
 			// Removing non-editable and non-display field from merge tag output.


### PR DESCRIPTION
## Description
Added a merge tag modifier to allow the empty fields to be displayed in the {workflow_fields} merge tag. e.g. {workflow_fields: show_empty=true}.
This helps when working with the User Input step, for instance. Only the empty and editable fields are displayed.

Reference:
https://trello.com/c/zTPq5WvC/518-show-empty-fields-in-workflowfields
https://gravityflow.productboard.com/insights/all-notes/notes/7480020
https://secure.helpscout.net/conversation/1016383996/11740/

## Testing instructions

1. Create a Form with two fields 'Field-1' and 'Field-2'.
2. Create a Notification step (Workflow step# 1). Make the current user as Assignee, and on the email message body include the merge tag: `{workflow_fields: show_empty=true}`
3. Create a User Input step (Workflow step# 2) with 'Field-2' as editable. Make the current user as Assignee, and on the email message body include the merge tag: `{workflow_fields: show_empty=true}`
4. Run the Form and enter some value for 'Field-1' leaving 'Field-2' empty.
5. Check emails for the user. The email of Workflow step# 1 will not have any data for it.
6. The email of Workflow step# 2 will have the 'Field-2' listed as the empty editable entry.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
Update documentation about the merge tag modifier here: https://docs.gravityflow.io/article/106-merge-tags

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->