### PR TITLE
Support for Merge Tags on Workflow Step Conditions

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -23,3 +23,4 @@
 - Fixed an issue where the scripts and styles are not enqueued when using the shortcode or block in a reusable block.
 - Fixed an issue in the step settings page where duplicate Workflow step icons appear for the Gravity Forms HubSpot Add-on and third-party HubSpot Add-on. IMPORTANT: check that your HubSpot workflow steps are correct after updating to this version.
 - Fixed a bug with 'Schedule expiration' on Workflow step. 'Next Step if Expired' option should only appear when 'Status after expiration' is set as 'Expired'.
+- Added support for Merge Tags on Workflow Step Conditions.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8353,6 +8353,8 @@ AND m.meta_value='queued'";
 			if ( is_array( $logic['rules'] ) ) {
 				foreach ( $logic['rules'] as $rule ) {
 
+					$rule['value'] = GFCommon::replace_variables( $rule['value'], $form, $entry, false, false, false, 'text' );
+					
 					if ( in_array( $rule['fieldId'], $entry_meta_keys ) ) {
 						$is_value_match = GFFormsModel::is_value_match( rgar( $entry, $rule['fieldId'] ), $rule['value'], $rule['operator'], null, $rule, $form );
 					} else {


### PR DESCRIPTION
## Description
Added Support for Merge Tags on Workflow Step Conditions
https://secure.helpscout.net/conversation/1147238931/13378?folderId=516731

## Testing instructions
On a workflow step add a 'Step Condition' with a merge tag, say the value on field ID 1 is {form_id}. If the form_id is 17, on processing the form this workflow step should only process when the value entered on field ID 1 is 17. For all other values, this workflow step will not run.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->