### PR TITLE
Fix missing status page field filters when form id constraint is an array

### DIFF
--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -602,13 +602,13 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 
 		$forms = GFAPI::get_forms();
 		foreach ( $forms as $form ) {
-		    if ( is_array( $form_id ) && ! in_array( $form['id'], $form_id ) ) {
-		        continue;
-            }
-
-		    if ( ! empty( $form_id ) && $form['id'] != $form_id )  {
-		        continue;
-            }
+			if ( ! empty( $form_id ) ) {
+				if ( is_array( $form_id ) && ! in_array( $form['id'], $form_id ) ) {
+					continue;
+				} elseif ( ! is_array( $form_id ) && $form['id'] != $form_id ) {
+					continue;
+				}
+			}
 
 			$form_filters = GFCommon::get_field_filter_settings( $form );
 


### PR DESCRIPTION
## Description
This was reported to me directly in RG Slack. When ForGravity Advanced Permissions uses the gravityflow_status_filter to return an array of form IDs which the current user can access the field filters drop down does not appear when a form is selected.

## Testing instructions
- Add code snippet updating the form IDs to match a few of those available on your site
```
add_filter( 'gravityflow_status_filter', function ( $args ) {
	$args['form_id'] = array( 3, 4, 5 );
	return $args;
} );
```
- Visit the Status page and in the filters select a form
- Find the field filters drop down does not appear
- Switch to this branch
- Reload page and find the fields drop down does appear when a form is selected
- Modify the code snippet to `$args['form_id'] = 3;` or any other valid form id on your site
- Reload page and find the fields drop down is visible
- Remove code snippet
- Reload page and find the fields drop down does appear when selecting forms

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->