### PR TITLE
Fix Blank Form for a Partial Entry already completed

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -24,3 +24,4 @@
 - Fixed an issue in the step settings page where duplicate Workflow step icons appear for the Gravity Forms HubSpot Add-on and third-party HubSpot Add-on. IMPORTANT: check that your HubSpot workflow steps are correct after updating to this version.
 - Fixed a bug with 'Schedule expiration' on Workflow step. 'Next Step if Expired' option should only appear when 'Status after expiration' is set as 'Expired'.
 - Added support for Merge Tags on Workflow Step Conditions.
+- Fixed an issue for the completed URL of Partial Entry Submission step, which was directing to a new form entry. Updated to return a message stating that the entry was already completed.

--- a/includes/integrations/class-partial-entries.php
+++ b/includes/integrations/class-partial-entries.php
@@ -311,7 +311,7 @@ class Gravity_Flow_Partial_Entries {
 	/**
 	 * Returns a message to indicate that the Partial Entry was completed.
 	 *
-	 * @since 2.5
+	 * @since 2.5.10
 	 */
 	public function partial_entry_complete() {
 		return '<p>' . esc_html__( 'This entry has already been completed.', 'gravityflow' ) . '</p>';

--- a/includes/integrations/class-partial-entries.php
+++ b/includes/integrations/class-partial-entries.php
@@ -278,9 +278,7 @@ class Gravity_Flow_Partial_Entries {
 
 		// Abort if the partial entry was not found.
 		if ( empty( $entries ) ) {
-			add_filter( 'gform_form_not_found_message', function ( $message, $id ) {
-				return '<p>' . esc_html__( 'This entry has completed.', 'gravityforms' ) . '</p>';
-			}, 10, 2 );
+			add_filter( 'gform_form_not_found_message', array( $this, 'partial_entry_complete' ), 50 );
 
 			return false;
 		}
@@ -308,6 +306,15 @@ class Gravity_Flow_Partial_Entries {
 		$_POST['partial_entry_id'] = $partial_entry_id;
 
 		return $form;
+	}
+
+	/**
+	 * Returns a message to indicate that the Partial Entry was completed.
+	 *
+	 * @since 2.5
+	 */
+	public function partial_entry_complete() {
+		return '<p>' . esc_html__( 'This entry has completed.', 'gravityforms' ) . '</p>';
 	}
 
 }

--- a/includes/integrations/class-partial-entries.php
+++ b/includes/integrations/class-partial-entries.php
@@ -278,7 +278,16 @@ class Gravity_Flow_Partial_Entries {
 
 		// Abort if the partial entry was not found.
 		if ( empty( $entries ) ) {
-			return $form;
+			$empty_form = array (
+				'title'        => $form['title'],
+				'description'  => 'This partial entry was already completed!',
+				'is_active'    => '0',
+				'button'  		 => array (
+					'type' => 'text',
+					'text' => 'No data to process here.',
+				)
+			);
+			return $empty_form;
 		}
 
 		$entry        = $entries[0];

--- a/includes/integrations/class-partial-entries.php
+++ b/includes/integrations/class-partial-entries.php
@@ -314,7 +314,7 @@ class Gravity_Flow_Partial_Entries {
 	 * @since 2.5
 	 */
 	public function partial_entry_complete() {
-		return '<p>' . esc_html__( 'This entry has completed.', 'gravityforms' ) . '</p>';
+		return '<p>' . esc_html__( 'This entry has already been completed.', 'gravityflow' ) . '</p>';
 	}
 
 }

--- a/includes/integrations/class-partial-entries.php
+++ b/includes/integrations/class-partial-entries.php
@@ -278,16 +278,11 @@ class Gravity_Flow_Partial_Entries {
 
 		// Abort if the partial entry was not found.
 		if ( empty( $entries ) ) {
-			$empty_form = array (
-				'title'        => $form['title'],
-				'description'  => 'This partial entry was already completed!',
-				'is_active'    => '0',
-				'button'  		 => array (
-					'type' => 'text',
-					'text' => 'No data to process here.',
-				)
-			);
-			return $empty_form;
+			add_filter( 'gform_form_not_found_message', function ( $message, $id ) {
+				return '<p>' . esc_html__( 'This entry has completed.', 'gravityforms' ) . '</p>';
+			}, 10, 2 );
+
+			return false;
 		}
 
 		$entry        = $entries[0];


### PR DESCRIPTION
## Description
This fixes the case when a blank form appears for the partial entry step when the partial entry was already submitted.
Reference HelpScout ticket: https://secure.helpscout.net/conversation/1150735023/13425?folderId=1113492

## Testing instructions
To replicate the issue use the partial entry link to complete the entry.
Then, use the same link again and a blank form will show up.
After this update, it will show a message "This partial entry was already completed!" instead of the blank form.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->