### PR TITLE
Adding confirm box for Approval/Reject button

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -25,3 +25,4 @@
 - Fixed a bug with 'Schedule expiration' on Workflow step. 'Next Step if Expired' option should only appear when 'Status after expiration' is set as 'Expired'.
 - Fixed the field filter not appearing on the status page when the form_id constraint is set to an array using the gravityflow_status_filter hook.
 - Added support for Merge Tags on Workflow Step Conditions.
+- Added second layer confirmation for Approval Step with a conform box.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -756,6 +756,16 @@ PRIMARY KEY  (id)
 						'nonce'   => $nonce,
 					),
 				),
+				array(
+					'handle' => 'gravityflow_approval',
+					'src' => $this->get_base_url() . "/js/approval-box{$min}.js",
+					'version' => $this->_version,
+					'enqueue' => array(
+						array(
+							'query' => 'page=gravityflow-inbox',
+						),
+					),
+				),
 			);
 
 			$magic = true;
@@ -782,6 +792,7 @@ PRIMARY KEY  (id)
 					wp_enqueue_script( 'gravityflow_entry_detail', $this->get_base_url() . "/js/entry-detail{$min}.js", array( 'jquery', 'sack' ), $this->_version );
 					wp_enqueue_script( 'gravityflow_status_list', $this->get_base_url() . "/js/status-list{$min}.js",  array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'gform_datepicker_init' ), $this->_version );
 					wp_enqueue_script( 'gform_field_filter', GFCommon::get_base_url() . "/js/gf_field_filter{$min}.js",  array( 'jquery', 'gform_datepicker_init' ), $this->_version );
+					wp_enqueue_script( 'gravityflow_approval', $this->get_base_url() . "/js/approval-box{$min}.js",  array(), $this->_version );
 					wp_enqueue_script( 'gravityflow_frontend', $this->get_base_url() . "/js/frontend{$min}.js",  array(), $this->_version );
 					wp_enqueue_script( 'gravityflow_inbox', $this->get_base_url() . "/js/inbox{$min}.js",  array(), $this->_version );
 

--- a/js/approval-box.js
+++ b/js/approval-box.js
@@ -1,0 +1,22 @@
+(function(){
+  setTimeout(function() {
+    try {
+      const buttons = document.getElementsByClassName('gravityflow-action-buttons')[0].getElementsByTagName('button');
+  
+      buttons[0].addEventListener('click', function(e) {
+        const approveConfirm = confirm( "Are you sure you want to approve?" );
+        if ( !approveConfirm ) {
+          e.preventDefault();
+        }
+      });
+  
+      buttons[1].addEventListener('click', function(e) {
+        const rejectConfirm = confirm( "Are you sure you want to reject?" );
+        if ( !rejectConfirm ) {
+          e.preventDefault();
+        }
+      });        
+    } catch (error) {
+    }
+  }, 2000);
+})();


### PR DESCRIPTION
## Description
A Vanilla JS confirm box for the Approval Step double-checking the user entered Approval/Reject choices.
PB link: https://gravityflow.productboard.com/feature-board/1199966-feature-organization/notes/7527366

## Testing instructions
To be tested Approval Step for both Approve/Reject choices.
To be tested on both WP Dashboard and Front-End interface.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->