### PR TITLE
Form Pre Validation on the User Input Step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -26,3 +26,4 @@
 - Fixed the field filter not appearing on the status page when the form_id constraint is set to an array using the gravityflow_status_filter hook.
 - Added support for Merge Tags on Workflow Step Conditions.
 - Fixed an issue for the completed URL of Partial Entry Submission step, which was directing to a new form entry. Updated to return a message stating that the entry was already completed.
+- Added support for filter gform_pre_validation on the User Input Step.

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -394,6 +394,14 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 				return false;
 			}
 
+			/**
+				* Enables pre validation for the User Input step.
+				*
+				* @since 2.5.10
+				*
+				* @param array  $form                The current form.
+				* @param int    $form['id']          The current form ID.
+				*/
 			$form = gf_apply_filters( array( 'gform_pre_validation', $form['id'] ), $form );
 			
 			// Loading files that have been uploaded to temp folder.

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -400,7 +400,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			 * @since 2.5.10
 			 *
 			 * @param array  $form                The current form.
-			 * @param int    $form['id']          The current form ID.
 			 */
 			$form = gf_apply_filters( array( 'gform_pre_validation', $form['id'] ), $form );
 			

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -394,6 +394,8 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 				return false;
 			}
 
+			$form = gf_apply_filters( array( 'gform_pre_validation', $form['id'] ), $form );
+			
 			// Loading files that have been uploaded to temp folder.
 			$files = GFCommon::json_decode( rgpost( 'gform_uploaded_files' ) );
 			if ( ! is_array( $files ) ) {

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -395,13 +395,13 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 			}
 
 			/**
-				* Enables pre validation for the User Input step.
-				*
-				* @since 2.5.10
-				*
-				* @param array  $form                The current form.
-				* @param int    $form['id']          The current form ID.
-				*/
+			 * Enables pre validation for the User Input step.
+			 *
+			 * @since 2.5.10
+			 *
+			 * @param array  $form                The current form.
+			 * @param int    $form['id']          The current form ID.
+			 */
 			$form = gf_apply_filters( array( 'gform_pre_validation', $form['id'] ), $form );
 			
 			// Loading files that have been uploaded to temp folder.


### PR DESCRIPTION
## Description
HelpScout# [13389](https://secure.helpscout.net/conversation/1148375877/13389?folderId=3509658#thread-3266957410)

Added the call to `gform_pre_validation` on User Input Step for Pre Validation on the User Input Workflow Step.

## Testing instructions
To be tested with customer's [form](https://secure.helpscout.net/conversation/1148375877/13389?folderId=3509658#thread-3270096961) and custom GravityPerks e-commerce field [snippet](https://gist.github.com/spivurno/7356056) adding a Calculated Shipping field to the form.
To add a Calculation field to the form and set it as the “field_id” in the snippet config. It will automatically be converted to a shipping field on submission.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->