### PR TITLE
Fix : Connected App Translation Text

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -26,3 +26,4 @@
 - Fixed the field filter not appearing on the status page when the form_id constraint is set to an array using the gravityflow_status_filter hook.
 - Added support for Merge Tags on Workflow Step Conditions.
 - Fixed an issue for the completed URL of Partial Entry Submission step, which was directing to a new form entry. Updated to return a message stating that the entry was already completed.
+- Fixed an issue with the Connected Apps comparing authorization value from translated text which was flagging to false.

--- a/includes/class-connected-apps.php
+++ b/includes/class-connected-apps.php
@@ -702,7 +702,7 @@ class Gravity_Flow_Connected_Apps {
 								       value="Authorize App"/>
 								<input type="submit" id="gflow_authorize_app_button" name="gflow_authorize_app"
 								       class="button primary"
-								       value="<?php esc_html_e( 'Authorize App', 'gravityflow' ); ?>"/>
+								       value="Authorize App"/>
 
 							</td>
 						</tr>

--- a/includes/class-connected-apps.php
+++ b/includes/class-connected-apps.php
@@ -700,9 +700,11 @@ class Gravity_Flow_Connected_Apps {
 							<td>
 								<input type="hidden" id="gflow_authorize_app_hidden_action" name="gflow_authorize_app"
 								       value="Authorize App"/>
-								<input type="submit" id="gflow_authorize_app_button" name="gflow_authorize_app"
+								<button type="submit" id="gflow_authorize_app_button" name="gflow_authorize_app"
 								       class="button primary"
-								       value="Authorize App"/>
+								       value="Authorize App">
+											 <?php esc_html_e( 'Authorize App', 'gravityflow' ); ?>
+								</button>
 
 							</td>
 						</tr>


### PR DESCRIPTION
## Description
Bugfix for [HS# 13500](https://secure.helpscout.net/conversation/1159586921/13500?folderId=3509658): 
Issue on the class `Gravity_Flow_Connected_Apps` (located in includes/class-connected-apps.php).
[L119](https://github.com/gravityflow/gravityflow/blob/master/includes/class-connected-apps.php#L119) compares to 'Authorize App' but a translated text maybe sent via the button text located on [L703-705](https://github.com/gravityflow/gravityflow/blob/master/includes/class-connected-apps.php#L703,L705).

## Testing instructions
To test 'Authorize App' for different translations on the 'Connected Apps' settings for Gravity Flow.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->