### PR TITLE
Fixed the unnecessary <br> formatting on Display Instructions

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -29,3 +29,4 @@
 - Fixed an extraneous debug logging statement.
 - Fixed an issue with the Connected Apps comparing authorization value from translated text which was flagging to false.
 - Added support for filter gform_pre_validation on the User Input Step.
+- Fixed an issue where the Display Instructions on Workflow step was getting wrongly formatted.

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -415,7 +415,7 @@ class Gravity_Flow_Entry_Detail {
 			return;
 		}
 		
-		$nl2br = apply_filters( 'gravityflow_auto_format_instructions', true );
+		$nl2br = apply_filters( 'gravityflow_auto_format_instructions', false );
 		$nl2br = apply_filters( 'gravityflow_auto_format_instructions_' . $form['id'], $nl2br );
 
 		$instructions = $current_step->instructionsValue;


### PR DESCRIPTION
## Description
HelpScout# [13650](https://secure.helpscout.net/conversation/1173283316/13650?folderId=516726)
Display Instructions on the workflow step was adding additional `<br>` on the front-end. The filter `gravityflow_auto_format_instructions` is assigned to default to `true` on the code [here](https://github.com/gravityflow/gravityflow/blob/master/includes/pages/class-entry-detail.php#L418), which is causing the issue.

## Testing instructions
Creating a miscellaneous text display on the Display Instructions of the workflow step. As an example,

![Screenshot 2020-05-22 at 11 14 17 PM](https://user-images.githubusercontent.com/26293394/82695854-8e48b580-9c83-11ea-8926-901fea6ad136.png)

![Screenshot 2020-05-22 at 11 14 25 PM](https://user-images.githubusercontent.com/26293394/82695774-65282500-9c83-11ea-8b8b-bbb2e85dba46.png)

Without the code update, the front-end display instructions would be:
![Screenshot 2020-05-22 at 11 14 54 PM](https://user-images.githubusercontent.com/26293394/82695925-a4567600-9c83-11ea-87f6-7453119fb5fb.png)

After the code update, the front-end display instructions would be:
![Screenshot 2020-05-22 at 11 14 45 PM](https://user-images.githubusercontent.com/26293394/82695886-999be100-9c83-11ea-8e97-dadf0fd77493.png)

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->