### PR TITLE
Inbox Paging with Show All Option

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -29,3 +29,4 @@
 - Fixed an extraneous debug logging statement.
 - Fixed an issue with the Connected Apps comparing authorization value from translated text which was flagging to false.
 - Added support for filter gform_pre_validation on the User Input Step.
+- Added support to Show All Inbox entries when the count is more than 150.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -530,9 +530,16 @@ class Gravity_Flow_API {
 	 * @return array
 	 */
 	public static function get_inbox_paging( $args = array() ) {
-		$paging = array(
-			'page_size' => 150,
-		);
+		if ( $args['view_more'] ) {
+			$paging = array(
+				'page_size' => Gravity_Flow_API::get_inbox_entries_count( $args ),
+			);
+		}
+		else {
+			$paging = array(
+				'page_size' => 150,
+			);
+		}
 
 		if ( ! empty( $args['paging']['page_size'] ) ) {
 			$paging['page_size'] = (int) $args['paging']['page_size'];

--- a/includes/pages/class-inbox.php
+++ b/includes/pages/class-inbox.php
@@ -13,6 +13,18 @@ if ( ! class_exists( 'GFForms' ) ) {
 	die();
 }
 
+session_id( 'gravityflow_session' );
+session_start();
+$current = $_SERVER['REQUEST_URI']; 
+$referer_parts = parse_url($_SERVER['HTTP_REFERER']);
+$previous =  $referer_parts["path"] . "?" . $referer_parts["query"];
+if ( $current != $previous ) {
+	$_SESSION['more-enabled'] = false;
+}
+else {
+	$_SESSION['more-enabled'] = true;
+}
+
 /**
  * Class Gravity_Flow_Inbox
  */
@@ -81,6 +93,19 @@ class Gravity_Flow_Inbox {
 			</div>
 		<?php
 		}
+
+		if ( $total_count > $page_size ) {
+			?>
+			<form method="post">
+			<input type="submit" name="view-more" value="<?php esc_html_e( 'Show All', 'gravityflow' ); ?>" />
+			<?php
+			if( isset( $_POST['view-more'] ) ) {
+				$_SESSION['more-enabled'] = true;
+			}
+			?>
+			</form>
+			<?php
+		}
 	}
 
 	/**
@@ -109,6 +134,7 @@ class Gravity_Flow_Inbox {
 			'last_updated'         => false,
 			'due_date'             => false,
 			'step_highlight'       => true,
+			'view_more'            => $_SESSION['more-enabled'],
 		);
 
 	}


### PR DESCRIPTION
## Description
ProductBoard feature request '[Inbox Paging](https://gravityflow.productboard.com/feature-board/1199966-feature-organization/features/4382761/insights)'.
Get an option to 'Show All' entries on GravityFlow Inbox.

## Testing instructions
This update will an option of 'Show All' at the end of the Inbox table to show all of the remaining entries (after the first 150 entries).
If there are not so many entries on the Inbox, a testing possibility can be to tweak paging on the `class-api.php` temporarily. For the `get_inbox_paging` function on line 532, change the code line which has:
`'page_size' => 150,`
to a lower value (say 10):
`'page_size' => 10,`
Then, Inbox will, by default, show ten entries. On clicking 'Show All', all of the remaining entries would appear.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->