### PR TITLE
Inbox Count Shortcode

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -29,3 +29,4 @@
 - Fixed an extraneous debug logging statement.
 - Fixed an issue with the Connected Apps comparing authorization value from translated text which was flagging to false.
 - Added support for filter gform_pre_validation on the User Input Step.
+- Added a shortcode that displays the entry count for the current user.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6094,6 +6094,17 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 			$a = $this->get_shortcode_atts( $atts );
 
+			if ( $a['count'] ) {
+				$count = Gravity_Flow_API::get_inbox_entries_count();
+
+				if ( $count ) {
+					return sprintf( '<h5>You have %d entries in your inbox.</h5>', $count );
+				}
+				else {
+					return sprintf( '<h5>No pending inbox entries.</h5>' );
+				}
+			}
+
 			if ( $a['display_all'] || $a['allow_anonymous'] || $a['fields'] ) {
 
 				$app_settings = $this->get_app_settings();
@@ -6249,6 +6260,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				'category'         => '',
 				'step_id'          => null,
 				'assignee'         => '',
+				'count'            => false,
 			);
 
 			return $defaults;


### PR DESCRIPTION
## Description
Added a shortcode that displays the entry count for the current user, for ProductBoard [feature request](https://gravityflow.productboard.com/feature-board/1199966-feature-organization/features/3716821/detail).

It can be used as follows:
`[gravityflow count=true]`
or
`[gravityflow page="inbox" count=true]`

## Testing instructions
Create a Front-End page using the shortcode and test the output.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
Update the shortcode documentation [here](https://docs.gravityflow.io/article/36-the-shortcode).

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->