### PR TITLE
Approval Step - Require Confirmation apply to revert prompt

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed an issue with second layer confirmation for Approval Step. When the Revert to User Input step option is enabled, the Revert button was not displaying the confirm box.
+- Fixed support for latest versions of Gravity View Advanced Filters. (Thanks Vlad/MrCasual)

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with second layer confirmation for Approval Step. When the Revert to User Input step option is enabled, the Revert button was not displaying the confirm box.

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -777,19 +777,19 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 				'rejectMessage'  => __( 'Are you sure you want to reject this entry?', 'gravityflow' ),
 				'revertMessage'  => __( 'Are you sure you want to revert this entry?', 'gravityflow' ),
 			);
-			
+
 			/**
 			* Allows the user to modify the messages for approval/rejection confirmation.
 			*
 			* @since 2.5.10
 			*
-			* @param array  $messages The array containing approval/rejection messages.
-			* @param int    $form_id  The current form id.
-			* @param array  $entry    The current entry array.
-			* @param int    $step     The current step.
+			* @param array             $messages The array containing approval/rejection messages.
+			* @param int               $form_id  The current form id.
+			* @param array             $entry    The current entry array.
+			* @param Gravity_Flow_Step $step     The current step.
 			*/
 			$confirmation_approval = apply_filters( 'gravityflow_approval_confirm_prompt_messages', $messages, $form['id'], $this->get_entry(), $this ); 
-			
+
 			$messages['approveMessage'] = wp_kses_post( $messages['approveMessage'] );
 			$messages['rejectMessage'] = wp_kses_post( $messages['rejectMessage'] );
 			$messages['revertMessage'] = wp_kses_post( $messages['revertMessage'] );		

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -775,7 +775,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 			$messages = array(
 				'approveMessage' => __( 'Are you sure you want to approve this entry?', 'gravityflow'),
 				'rejectMessage'  => __( 'Are you sure you want to reject this entry?', 'gravityflow' ),
-				'revertMessage'  => __( 'Are you sure you want to revert to the User Input step?', 'gravityflow' ),
+				'revertMessage'  => __( 'Are you sure you want to revert this entry?', 'gravityflow' ),
 			);
 			
 			/**

--- a/includes/steps/class-step-approval.php
+++ b/includes/steps/class-step-approval.php
@@ -775,6 +775,7 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 			$messages = array(
 				'approveMessage' => __( 'Are you sure you want to approve this entry?', 'gravityflow'),
 				'rejectMessage'  => __( 'Are you sure you want to reject this entry?', 'gravityflow' ),
+				'revertMessage'  => __( 'Are you sure you want to revert to the User Input step?', 'gravityflow' ),
 			);
 			
 			/**
@@ -790,11 +791,13 @@ class Gravity_Flow_Step_Approval extends Gravity_Flow_Step {
 			$confirmation_approval = apply_filters( 'gravityflow_approval_confirm_prompt_messages', $messages, $form['id'], $this->get_entry(), $this ); 
 			
 			$messages['approveMessage'] = wp_kses_post( $messages['approveMessage'] );
-			$messages['rejectMessage'] = wp_kses_post( $messages['rejectMessage'] );		
+			$messages['rejectMessage'] = wp_kses_post( $messages['rejectMessage'] );
+			$messages['revertMessage'] = wp_kses_post( $messages['revertMessage'] );		
 
 			wp_localize_script( 'gravityflow_approval', 'gravityflow_approval_confirmation_prompts', array(
 					'approveMessage' => $messages['approveMessage'],
 					'rejectMessage'  => $messages['rejectMessage'],
+					'revertMessage'  => $messages['revertMessage'],
 				)
 			);
 		}

--- a/js/step-approval.js
+++ b/js/step-approval.js
@@ -14,4 +14,13 @@
           e.preventDefault();
         }
       });
+
+      if (buttons.length == 3) {
+        buttons[2].addEventListener('click', function(e) {
+          var revertConfirm = confirm( gravityflow_approval_confirmation_prompts.revertMessage );
+          if ( !revertConfirm ) {
+            e.preventDefault();
+          }
+        });        
+      }
 })();


### PR DESCRIPTION
## Description
When 'Require Confirmation' step setting for Approval step is active, the approve/reject options get an added browser default JS confirmation prompt before accepting the chosen selection. This should also apply when a revert (to user input step) option exists.

[Trello reference link](https://trello.com/c/0pxmd7WQ/519-approval-step-require-confirmation-apply-to-revert-prompt)

## Testing instructions
Create a workflow with User Input and Approval Steps. On the Approval step, enable the following setting:
![approval revert](https://user-images.githubusercontent.com/26293394/84183500-a1dc8480-aaa9-11ea-9bfd-bb82f257aee4.png)

On clicking 'Revert' on the Approval step, the confirmation box pop up should appear.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->