### PR TITLE
Fix the reports step assignees dropdown missing issue

### DIFF
--- a/js/reports.js
+++ b/js/reports.js
@@ -83,7 +83,7 @@
                 $(this).nextAll('.gravityflow-reports-steps').hide();
             }
         });
-        $(this).nextAll('.gravityflow-reports-steps').change( function(){
+        $('.gravityflow-reports-steps').change( function(){
             if ( this.value ) {
                 var formId = $(this).prevAll('.gravityflow-form-drop-down').val();
                 var assigneeVars = stepVars[formId][this.value].assignees;
@@ -93,8 +93,6 @@
                 $(this).nextAll('.gravityflow-reports-assignees').hide();
             }
         });
-
-
     });
 
     function getStepOptions( formId ){

--- a/tests/acceptance-tests/acceptance/0043ReportsShortcodeCept.php
+++ b/tests/acceptance-tests/acceptance/0043ReportsShortcodeCept.php
@@ -26,6 +26,14 @@ $I->selectOption( 'select[name=category]', 'step' );
 $I->selectOption( 'select[name=step-id]', '1' );
 $I->seeOptionIsSelected( 'select[name=assignee]', 'All Assignees' );
 
+$I->amOnWorkflowPage( 'Reports' );
+
+$I->amGoingTo( 'Test if the Assignees dropdown will show up when the category is step and a step is selected in the Workflow Reports Page' );
+$I->selectOption( 'select[name=form-id]', '1' );
+$I->selectOption( 'select[name=category]', 'step' );
+$I->selectOption( 'select[name=step-id]', '1' );
+$I->seeOptionIsSelected( 'select[name=assignee]', 'All Assignees' );
+
 $page = get_page_by_path( 'reports' );
 wp_update_post( array( 'ID' => $page->ID, 'post_content' => '[gravityflow page="reports" display_filter="false"]' ) );
 

--- a/tests/acceptance-tests/acceptance/0043ReportsShortcodeCept.php
+++ b/tests/acceptance-tests/acceptance/0043ReportsShortcodeCept.php
@@ -20,6 +20,12 @@ $I->amOnPage( '/reports' );
 $I->amGoingTo( 'Test the filter is displayed by default' );
 $I->seeElement( 'input', [ 'type' => 'submit', 'value' => 'Filter' ] );
 
+$I->amGoingTo( 'Test if the Assignees dropdown will show up when the category is step and a step is selected' );
+$I->selectOption( 'select[name=form-id]', '1' );
+$I->selectOption( 'select[name=category]', 'step' );
+$I->selectOption( 'select[name=step-id]', '1' );
+$I->seeOptionIsSelected( 'select[name=assignee]', 'All Assignees' );
+
 $page = get_page_by_path( 'reports' );
 wp_update_post( array( 'ID' => $page->ID, 'post_content' => '[gravityflow page="reports" display_filter="false"]' ) );
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the "Step Assignees" dropdown was missing from the Reports shortcode when "Category" is set to "Step" and a step is chosen. The issue also happened in the Workflow Reports page in WP Dashboard.

## Testing instructions
1. Go to your Workflow Reports in WP Dashboard. Select a form, set the Category to Step, select a Step, and the assignee dropdown won't show up if you're on the `master` branch. Switch to this branch and it'll work.
2. Use the shortcode `[gravityflow page="reports"]` to display the Reports in a Page. Repeat the above steps.

## Automated Test Enhancements
Update test `0043ReportsShortcodeCept.php` to include a validation of the dropdown display.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->