### PR TITLE
Fix a fatal error during merge tag replacement with Form Connector

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8491,7 +8491,9 @@ AND m.meta_value='queued'";
 				return $text;
 			}
 
+			remove_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_variables' ) );
 			$step = gravity_flow()->get_current_step( $form, $entry );
+			add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_variables' ), 10, 7 );
 
 			$assignee = null;
 


### PR DESCRIPTION
## Description
re: HS[#13809](https://secure.helpscout.net/conversation/1188384647/13809?folderId=1113492)

This updates Gravity Flow in parallel to [Form Connector PR #38](https://github.com/gravityflow/gravityflowformconnector/pull/38) to address a fatal error which occurs when merge tag processing runs during evaluation of conditional logic. 

## Testing instructions
See instructions in [Form Connector PR #38](https://github.com/gravityflow/gravityflowformconnector/pull/38)
