### PR TITLE
Date fields conditions on User Input Step dependent on other Date fields

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue where Gravity Perks Limit Dates conditions dependent on a non-editable Date field for a User Input step did not work.


### PR DESCRIPTION
## Description
HelpScout# [13891](https://secure.helpscout.net/conversation/1194802467/13891?folderId=1113492#thread-3412151553)

Selecting a Date Field on User Input dependent on a non-editable Date Field with conditions from GP-Limit-Dates did not work.

## Testing instructions
Testing form from the ticket, and other possible scenarios where a Date field on User Input step is dependent on a non-editable Date field.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->