### PR TITLE
Download CSV option on the front-end status page

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Fixed an issue where GP Limit Dates does not function on the User Input step when the min and max range is based on non-editable Date fields.
+- Added download CSV option to the front-end status page.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -7745,7 +7745,7 @@ AND m.meta_value='queued'";
 		 * Processes the Ajax status export request.
 		 */
 		public function ajax_export_status() {
-			if ( ! wp_verify_nonce( rgget( 'gravityflow_export_nonce' ), 'gravityflow_export_nonce' ) || ! GFAPI::current_user_can_any( 'gravityflow_status' ) ) {
+			if ( ! wp_verify_nonce( rgget( 'gravityflow_export_nonce' ), 'gravityflow_export_nonce' ) ) {
 				$response['status'] = 'error';
 				$response['message'] = __( 'Not authorized', 'gravityflow' );
 				$response_json = json_encode( $response );
@@ -7770,7 +7770,7 @@ AND m.meta_value='queued'";
 		 */
 		public function ajax_download_export() {
 
-			if ( ! wp_verify_nonce( rgget( 'nonce' ), 'gravityflow_download_export' ) || ! GFAPI::current_user_can_any( 'gravityflow_status' ) ) {
+			if ( ! wp_verify_nonce( rgget( 'nonce' ), 'gravityflow_download_export' ) ) {
 				$response['status'] = 'error';
 				$response['message'] = __( 'Not authorized', 'gravityflow' );
 				$response_json = json_encode( $response );

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -136,19 +136,17 @@ class Gravity_Flow_Status {
 		</form>
 
 		<?php
-		if ( is_admin() ) {
-			$str = $_SERVER['QUERY_STRING'];
-			parse_str( $str, $query_args );
+		$str = $_SERVER['QUERY_STRING'];
+		parse_str( $str, $query_args );
 
-			$remove_args = array( 'paged', '_wpnonce', '_wp_http_referer', 'action', 'action2' );
-			foreach ( $remove_args as $remove_arg_key ) {
-				unset( $query_args[ $remove_arg_key ] );
-			}
-			$query_args['gravityflow_export_nonce'] = wp_create_nonce( 'gravityflow_export_nonce' );
-			$filter_args_str                        = '&' . http_build_query( $query_args );
-			echo sprintf( '<br /><a class="gravityflow-export-status-button button" data-filter_args="%s">%s</a>', $filter_args_str, esc_html__( 'Export', 'gravityflow' ) );
-			echo sprintf( '<img class="gravityflow-spinner" src="%s" style="display:none;margin:5px"/>', GFCommon::get_base_url() . '/images/spinner.gif' );
+		$remove_args = array( 'paged', '_wpnonce', '_wp_http_referer', 'action', 'action2' );
+		foreach ( $remove_args as $remove_arg_key ) {
+			unset( $query_args[ $remove_arg_key ] );
 		}
+		$query_args['gravityflow_export_nonce'] = wp_create_nonce( 'gravityflow_export_nonce' );
+		$filter_args_str                        = '&' . http_build_query( $query_args );
+		echo sprintf( '<br /><a class="gravityflow-export-status-button button" data-filter_args="%s">%s</a>', $filter_args_str, esc_html__( 'Export', 'gravityflow' ) );
+		echo sprintf( '<img class="gravityflow-spinner" src="%s" style="display:none;margin:5px"/>', GFCommon::get_base_url() . '/images/spinner.gif' );
 	}
 
 	/**

--- a/js/status-list.js
+++ b/js/status-list.js
@@ -34,7 +34,7 @@
 
         function processExport(){
             var url;
-            url = ajaxurl + '?action=gravityflow_export_status&order=asc&paged=' + page;
+            url = gravityflow_status_list_strings.ajaxurl + '?action=gravityflow_export_status&order=asc&paged=' + page;
             url += filters;
             $.getJSON(url, function(data){
                 if ( data.status =='complete' ) {


### PR DESCRIPTION
## Description
[ProductBoard feature](https://gravityflow.productboard.com/feature-board/1199966-feature-organization/notes/7263486)
Added the Download CSV on the front-end status page instead of just the admin view. This would allow clients to get hold of the entries data assigned to them if they are given access to the front-end page.

## Testing instructions
Create a Front-End Status page and test the presence of the 'Export' button at the bottom of the page, and it's functionality to download CSV holding the data from the Status table.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->