### PR TITLE
Fix user auto receiving activation email with Manual User Activation on User Registration Feed

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed an issue where GP Limit Dates does not function on the User Input step when the min and max range is based on non-editable Date fields.
 - Fixed an issue where merge tags for Confirmation Message in User Input Step evaluated to values before the workflow step.
+- Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.

--- a/includes/steps/class-step-feed-user-registration.php
+++ b/includes/steps/class-step-feed-user-registration.php
@@ -93,6 +93,12 @@ class Gravity_Flow_Step_Feed_User_Registration extends Gravity_Flow_Step_Feed_Ad
 
 		if ( class_exists( 'GF_User_Registration' ) ) {
 
+			$disable_notification_email = isset( $feed['meta']['userActivationValue'] ) &&  ( $feed['meta']['userActivationValue'] === 'manual' );
+			
+      if ( $disable_notification_email ) {
+        add_filter( 'wpmu_signup_user_notification_email', '__return_empty_string' ); 
+			}
+						
 			parent::process_feed( $feed );
 
 			$activation_enabled = isset( $feed['meta']['userActivationEnable'] ) &&  $feed['meta']['userActivationEnable'];

--- a/includes/steps/class-step-feed-user-registration.php
+++ b/includes/steps/class-step-feed-user-registration.php
@@ -93,15 +93,16 @@ class Gravity_Flow_Step_Feed_User_Registration extends Gravity_Flow_Step_Feed_Ad
 
 		if ( class_exists( 'GF_User_Registration' ) ) {
 
-			$disable_notification_email = isset( $feed['meta']['userActivationValue'] ) &&  ( $feed['meta']['userActivationValue'] === 'manual' );
+			$activation_enabled = isset( $feed['meta']['userActivationEnable'] ) &&  $feed['meta']['userActivationEnable'];
+
+			$disable_notification_email = $activation_enabled && rgar( $feed['meta'], 'userActivationValue' ) === 'manual';
 			
-      if ( $disable_notification_email ) {
-        add_filter( 'wpmu_signup_user_notification_email', '__return_empty_string' ); 
+			if ( $disable_notification_email ) {
+				add_filter( 'wpmu_signup_user_notification', '__return_false', 50 );
+				add_filter( 'wpmu_signup_blog_notification', '__return_false', 50 );
 			}
 						
 			parent::process_feed( $feed );
-
-			$activation_enabled = isset( $feed['meta']['userActivationEnable'] ) &&  $feed['meta']['userActivationEnable'];
 
 			$step_complete = ! $activation_enabled;
 


### PR DESCRIPTION
re: [HS#14111](https://secure.helpscout.net/conversation/1222275682/14111/)

## Description
Adding filter before `process_feed` to disable email when User Activation setting on the User Registration feed is set to 'manual'.
Adding check for the `userActivationValue` on the feed meta when processing the filter to disable email on the 'manual' scenario.

## Testing instructions

- See: HS#14111](https://secure.helpscout.net/conversation/1222275682/14111/#thread-3498041731)
- With this branch, check the user activation email link sent normally when User Activation on User Registration Feed settings is set to 'by email from WordPress'.
- Next, check the user activation email link is not sent when the User Activation setting is set to 'manually'.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->