### PR TITLE
Fixed an issue with the 'Users Role Filter' not saving on the Multi-U…

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,4 @@
 - Fixed an issue where GP Limit Dates does not function on the User Input step when the min and max range is based on non-editable Date fields.
 - Fixed an issue where merge tags for Confirmation Message in User Input Step evaluated to values before the workflow step.
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
-- Fixed an issue with the 'Users Role Filter' not saving on the Multi-User field.
+- Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
 - Fixed an issue where GP Limit Dates does not function on the User Input step when the min and max range is based on non-editable Date fields.
 - Fixed an issue where merge tags for Confirmation Message in User Input Step evaluated to values before the workflow step.
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
+- Fixed an issue with the 'Users Role Filter' not saving on the Multi-User field.

--- a/js/form-editor.js
+++ b/js/form-editor.js
@@ -56,8 +56,9 @@ jQuery(document).bind('gform_load_field_settings', function (event, field, form)
 	var isWorkflowUserField = field.type == 'workflow_user';
 	var isWorkflowRoleField = field.type == 'workflow_role';
 	var isWorkflowDiscussionField = field.type == 'workflow_discussion';
+	var isWorkflowMultiUserField = field.type == 'workflow_multi_user';
 
-	if ( isAssigneeField || isWorkflowUserField || isWorkflowRoleField ) {
+	if ( isAssigneeField || isWorkflowUserField || isWorkflowRoleField || isWorkflowMultiUserField ) {
 		field.choices = '';
 	}
 
@@ -73,7 +74,7 @@ jQuery(document).bind('gform_load_field_settings', function (event, field, form)
 		}
 	}
 
-	if (isAssigneeField || isWorkflowUserField) {
+	if ( isAssigneeField || isWorkflowUserField || isWorkflowMultiUserField ) {
 		jQuery('#gravityflow_users_role_filter').val(field.gravityflowUsersRoleFilter);
 	}
 


### PR DESCRIPTION
re: [HS#14117](https://secure.helpscout.net/conversation/1222790950/14117?folderId=1113492)

## Description
The 'Multi-User' field is not saving the 'Users Role Filter'. Added multi-user workflow field checks with the `gravityflowUsersRoleFilter` on JS, to ensure the user-selected values are updated and displayed.

## Testing instructions

- Create a form with multiple multi-user fields, select different 'Users Role Filter' setting for each of them.
- Save the form and refresh the page. Ensure the settings on 'Users Role Filter' are still appearing correctly.
- Run the form and check the users on the fields are displayed correctly.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->