### PR TITLE
Display checkbox values when not selected

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,3 +3,4 @@
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
 - Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).
 - Added the red bubble inbox count display on the WP Dashboard Workflow menu item.
+- Changed Workflow entry detail to display all of the checkbox values with a strike on the unselected ones.

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -942,30 +942,29 @@ class Gravity_Flow_Entry_Detail {
 
 						$display_value = empty( $display_value ) && $display_value !== '0' ? '&nbsp;' : $display_value;
 
-						if ( $field->get_input_type() == 'checkbox' && $display_value == '&nbsp;') {
+						if ( $field->get_input_type() == 'checkbox' && $display_value == '&nbsp;' ) {
 							$content = '
-																	<tr>
-																			<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
-																	</tr>';
-						}
-						else {
+										<tr>
+											<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
+										</tr>';
+						} else {
 							$content = '
-																	<tr>
-																			<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
-																	</tr>
-																	<tr>
-																			<td colspan="2" class="entry-view-field-value' . $last_row . '">' . $display_value . '</td>
-																	</tr>';
+										<tr>
+											<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
+										</tr>
+										<tr>
+											<td colspan="2" class="entry-view-field-value' . $last_row . '">' . $display_value . '</td>
+										</tr>';
 						}
 						if ( $field->get_input_type() == 'checkbox' ) {
-							$all_html_values = $field->get_checkbox_choices( $value, '' );
-							$dom = new DOMDocument();
+							$all_html_values 	= $field->get_checkbox_choices( $value, '' );
+							$dom 				= new DOMDocument();
 
 							$dom->loadHTML( $all_html_values );
 							$input_tags = $dom->getElementsByTagName( 'input' );
 							$all_values = array();
 							foreach ( $input_tags as $input_tag ) {
-								if( is_object( $input_tag ) ) {
+								if ( is_object( $input_tag ) ) {
 									$value = '';
 									$name_object = $input_tag->attributes->getNamedItem( 'name' );
 									if( is_object( $name_object ) ) {
@@ -980,8 +979,8 @@ class Gravity_Flow_Entry_Detail {
 							}
 
 							$dom->loadHTML( $display_value );
-							$all_li = $dom->getElementsByTagName( 'li' );
-							$selected_values = array();
+							$all_li 			= $dom->getElementsByTagName( 'li' );
+							$selected_values 	= array();
 							foreach ( $all_li as $li ) {
 								$selected_values[] = trim( $li->nodeValue );
 							}

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -962,10 +962,21 @@ class Gravity_Flow_Entry_Detail {
 							$dom = new DOMDocument();
 
 							$dom->loadHTML( $all_html_values );
-							$all_li = $dom->getElementsByTagName( 'li' );
+							$input_tags = $dom->getElementsByTagName( 'input' );
 							$all_values = array();
-							foreach ( $all_li as $li ) {
-								$all_values[] = trim( $li->nodeValue );
+							foreach ( $input_tags as $input_tag ) {
+								if( is_object( $input_tag ) ) {
+									$value = '';
+									$name_object = $input_tag->attributes->getNamedItem( 'name' );
+									if( is_object( $name_object ) ) {
+										$value_object = $input_tag->attributes->getNamedItem( 'value' );
+										if( is_object( $value_object ) ) {
+											$value = $value_object->value;
+										}
+							
+										$all_values[] = $value;
+									}
+								}
 							}
 
 							$dom->loadHTML( $display_value );

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -942,7 +942,7 @@ class Gravity_Flow_Entry_Detail {
 
 						$display_value = empty( $display_value ) && $display_value !== '0' ? '&nbsp;' : $display_value;
 
-						if ( $field['type'] == 'checkbox' && $display_value == '&nbsp;') {
+						if ( $field->get_input_type() == 'checkbox' && $display_value == '&nbsp;') {
 							$content = '
 																	<tr>
 																			<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
@@ -957,8 +957,8 @@ class Gravity_Flow_Entry_Detail {
 																			<td colspan="2" class="entry-view-field-value' . $last_row . '">' . $display_value . '</td>
 																	</tr>';
 						}
-						if ( $field['type'] == 'checkbox' ) {
-							$all_html_values = $field->get_checkbox_choices();
+						if ( $field->get_input_type() == 'checkbox' ) {
+							$all_html_values = $field->get_checkbox_choices( $value, '' );
 							$dom = new DOMDocument();
 
 							$dom->loadHTML( $all_html_values );
@@ -981,7 +981,7 @@ class Gravity_Flow_Entry_Detail {
 								<tr>
 										<td colspan="2" class="entry-view-field-value' . $last_row . '">';
 								foreach ( $unselected_values as $unselected_value ) {
-									$content .= '<li><strike>' . $unselected_value . '</strike></li>';
+									$content .= '<li><span style="text-decoration: line-through;">' . $unselected_value . '</span></li>';
 								}
 								$content .= '</td>
 								</tr>';

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -942,13 +942,51 @@ class Gravity_Flow_Entry_Detail {
 
 						$display_value = empty( $display_value ) && $display_value !== '0' ? '&nbsp;' : $display_value;
 
-						$content = '
-                                <tr>
-                                    <td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
-                                </tr>
-                                <tr>
-                                    <td colspan="2" class="entry-view-field-value' . $last_row . '">' . $display_value . '</td>
-                                </tr>';
+						if ( $field['type'] == 'checkbox' && $display_value == '&nbsp;') {
+							$content = '
+																	<tr>
+																			<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
+																	</tr>';
+						}
+						else {
+							$content = '
+																	<tr>
+																			<td colspan="2" class="entry-view-field-name">' . esc_html( self::get_label( $field ) ) . '</td>
+																	</tr>
+																	<tr>
+																			<td colspan="2" class="entry-view-field-value' . $last_row . '">' . $display_value . '</td>
+																	</tr>';
+						}
+						if ( $field['type'] == 'checkbox' ) {
+							$all_html_values = $field->get_checkbox_choices();
+							$dom = new DOMDocument();
+
+							$dom->loadHTML( $all_html_values );
+							$all_li = $dom->getElementsByTagName( 'li' );
+							$all_values = array();
+							foreach ( $all_li as $li ) {
+								$all_values[] = trim( $li->nodeValue );
+							}
+
+							$dom->loadHTML( $display_value );
+							$all_li = $dom->getElementsByTagName( 'li' );
+							$selected_values = array();
+							foreach ( $all_li as $li ) {
+								$selected_values[] = trim( $li->nodeValue );
+							}
+							
+							$unselected_values = array_diff( $all_values, $selected_values );
+							if ( count($unselected_values) != 0 ) {
+								$content .= '
+								<tr>
+										<td colspan="2" class="entry-view-field-value' . $last_row . '">';
+								foreach ( $unselected_values as $unselected_value ) {
+									$content .= '<li><strike>' . $unselected_value . '</strike></li>';
+								}
+								$content .= '</td>
+								</tr>';
+							}
+						}
 
 						$content = apply_filters( 'gform_field_content', $content, $field, $value, $entry['id'], $form['id'] );
 						echo $content;


### PR DESCRIPTION
## Description
Resonating with [this](https://gravityflow.productboard.com/feature-board/1199966-feature-organization/features/3835948/insights) ProductBoard feature request, this update displays all of the checkbox values on the entry detail page. Any of the checkbox values that are not selected by the user are displayed with a strike over them.

## Testing instructions

- Create a form with different checkbox fields.
- Add a Workflow Approval Step.
- After submitting a form entry, check the updated behaviour on the Workflow

## Automated Test Enhancements
N/A

## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->