### PR TITLE
Updating css classname wrap to gravityflow_wrap

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,3 +3,4 @@
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
 - Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).
 - Added the red bubble inbox count display on the WP Dashboard Workflow menu item.
+- Fixed the css classname 'wrap' by making it specific as 'gravityflow_wrap'. This avoids conflict with the css rules of themes.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5196,7 +5196,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		public function submit_page( $admin_ui, $form_ids = null ) {
 
 			?>
-			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_submit">
+			<div class="gravityflow_wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_submit">
 				<?php if ( $admin_ui ) :	?>
 					<h2 class="gf_admin_page_title">
 						<img width="45" height="22" src="<?php echo esc_url( gravity_flow()->get_base_url() ); ?>/images/gravity-flow-icon-cropped.svg" style="margin-right:5px;"/>
@@ -5470,7 +5470,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			} else {
 
 				?>
-				<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_detail">
+				<div class="gravityflow_wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_detail">
 					<?php if ( $args['show_header'] ) :	?>
 						<h2 class="gf_admin_page_title">
 							<img width="45" height="22" src="<?php echo $this->get_base_url(); ?>/images/gravity-flow-icon-cropped.svg" style="margin-right:5px;"/>
@@ -5516,7 +5516,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			);
 			$args = array_merge( $defaults, $args );
 			?>
-			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_status">
+			<div class="gravityflow_wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_status">
 
 				<?php if ( $args['display_header'] ) : ?>
 					<h2 class="gf_admin_page_title">
@@ -5560,7 +5560,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			);
 			$args = array_merge( $defaults, $args );
 			?>
-			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_activity">
+			<div class="gravityflow_wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_activity">
 
 				<?php if ( $args['display_header'] ) : ?>
 					<h2 class="gf_admin_page_title">
@@ -5606,7 +5606,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			);
 			$args = array_merge( $defaults, $args );
 			?>
-			<div class="wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_reports">
+			<div class="gravityflow_wrap gf_entry_wrap gravityflow_workflow_wrap gravityflow_workflow_reports">
 
 				<?php if ( $args['display_header'] ) : ?>
 					<h2 class="gf_admin_page_title">
@@ -8893,7 +8893,7 @@ AND m.meta_value='queued'";
 
 			?>
 
-			<div class="wrap <?php echo GFCommon::get_browser_class() ?>">
+			<div class="gravityflow_wrap <?php echo GFCommon::get_browser_class() ?>">
 
 				<?php if ( $message ) { ?>
 					<div id="message" class="updated"><p><?php echo $message; ?></p></div>

--- a/css/status.css
+++ b/css/status.css
@@ -1,4 +1,4 @@
-.wrap {
+.gravityflow_wrap {
     position: static !important;
 }
 


### PR DESCRIPTION
## Description
re: [HS#14335](https://secure.helpscout.net/conversation/1243830658/14335?folderId=1113492)

Avoid theme conflicts with the 'wrap' classname updated to 'gravityflow_wrap', adjusting the div and css rules on the codebase.

## Testing instructions
1. Check Front End Inbox page with the current master branch and default theme, everything ok.
2. Now switch to Business Pro Theme, note the issue on the Front End Inbox page with the header title

![Screenshot2](https://user-images.githubusercontent.com/26293394/90808633-f61fa280-e33d-11ea-80e2-aff81ab55c5e.png)

3. Now switch to this branch, and see the Front End Inbox page with Business Pro Theme. It should appear fine:
![Screenshot1](https://user-images.githubusercontent.com/26293394/90808725-1a7b7f00-e33e-11ea-89a0-2243299fecc3.png)


4. Update back to the default theme and check everything looks alright.


## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->