### PR TITLE
Remove page query var for inbox/detail pages

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,5 +2,6 @@
 - Fixed an issue where merge tags for Confirmation Message in User Input Step evaluated to values before the workflow step.
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
 - Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).
-- Added the red bubble inbox count display on the WP Dashboard Workflow menu item.
+- Fixed an issue on front-end pages with WordPress 5.5 removing the page parameter.
 - Fixed the css classname 'wrap' by making it specific as 'gravityflow_wrap'. This avoids conflict with the css rules of themes.
+- Added the red bubble inbox count display on the WP Dashboard Workflow menu item.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -292,6 +292,7 @@ if ( class_exists( 'GFForms' ) ) {
 				add_filter( 'gform_admin_pre_render', array( $this, 'delete_signature_script' ) );
 				$this->maybe_save_signature();
 			}
+			add_filter( 'query_vars', array( $this, 'filter_query_vars' ), 99 );
 		}
 
 		/**
@@ -9058,5 +9059,25 @@ AND m.meta_value='queued'";
 				GFCommon::display_dismissible_message( $notices );
 			}
 		}
+
+		/**
+		 * Removes "page" from the query vars array when accessing the inbox/detail pages to fix an issue introduced in WP 5.5 where it results in a 404.
+		 *
+		 * @since 2.5.12
+		 *
+		 * @param array $query_vars The array of allowed query variable names.
+		 *
+		 * @return array
+		 */
+		public function filter_query_vars( $query_vars ) {
+			global $wp_version;
+
+			if ( rgget( 'page' ) === 'gravityflow-inbox' && version_compare( $wp_version, '5.5', '>=' ) ) {
+				$query_vars = array_diff( $query_vars, array( 'page' ) );
+			}
+
+			return $query_vars;
+		}
+
 	}
 }


### PR DESCRIPTION
## Description
re: [slack thread](https://gravityflow.slack.com/archives/G7C6W4PD1/p1597758590004500)

This uses the `query_vars` filter to remove `page` from the array of query variables when accessing the front-end inbox and detail pages with WordPress 5.5+. This prevents the page var triggering a 404 error.

## Testing instructions
- Use the inbox shortcode in a page and set that page as the front page in the wp general settings
- View the page and click on an entry
- Find a 404 not found occurs
- Switch to this branch
- View the page and click on an entry
- Find the detail page is displayed
- Test accessing the entry from the status page
- Test the block
- Enable the back link on the shortcode and/or block
- Test the inbox is displayed when using the back link on the detail page

## Automated Test Enhancements
N/A

## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->