### PR TITLE
Fix the unit tests for WP 5.5 and PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,17 @@ before_script:
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
     case "$TRAVIS_PHP_VERSION" in
-      7.3|7.4)
-        echo "Using PHPUnit 7.0"
-        composer global require "phpunit/phpunit=7.0.*"
+      7.3|7.4|7.0|5.6|5.5|5.4|nightly)
+        # Use composer to install a compatible version of phpunit
+        composer global require "phpunit/phpunit:>4.0 <6 || ^7.0"
         ;;
       7.2)
         echo "Using PHPUnit 6.0"
         composer global require "phpunit/phpunit=6.0.*"
         ;;
-      7.1|7.0|hhvm|nightly)
+      7.1)
         echo "Using PHPUnit 5.7"
         composer global require "phpunit/phpunit=5.7.*"
-        ;;
-      5.6|5.5|5.4)
-        echo "Using PHPUnit 4.8"
-        composer global require "phpunit/phpunit=4.8.*"
         ;;
       *)
         echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"


### PR DESCRIPTION
## Description
This updates the Travis CI config to use the correct version of PHPUnit for the PHP version the tests are running on. [Gravity Forms made similar changes recently](https://github.com/gravityforms/gravityforms/pull/1180/commits/b8d94367ebc801110be8dea6734f9973cbf24a78).

## Testing instructions
Here is the failing test on master: https://travis-ci.com/github/gravityflow/gravityflow/builds/180872802
The tests are now passing on this branch: https://travis-ci.com/github/gravityflow/gravityflow/builds/180991459

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->