### PR TITLE
Update the EDD SL updater to v1.7.1

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,7 +1,8 @@
+- Added the red bubble inbox count display on the WP Dashboard Workflow menu item.
+- Added support for the WordPress 5.5 enable/disable auto-updates feature on the installed plugins page.
 - Fixed an issue where GP Limit Dates does not function on the User Input step when the min and max range is based on non-editable Date fields.
 - Fixed an issue where merge tags for Confirmation Message in User Input Step evaluated to values before the workflow step.
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
 - Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).
 - Fixed an issue on front-end pages with WordPress 5.5 removing the page parameter.
 - Fixed the css classname 'wrap' by making it specific as 'gravityflow_wrap'. This avoids conflict with the css rules of themes.
-- Added the red bubble inbox count display on the WP Dashboard Workflow menu item.

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Allows plugins to use their own update API.
  *
  * @author Easy Digital Downloads
- * @version 1.6.17
+ * @version 1.7.1
  */
 class Gravity_Flow_EDD_SL_Plugin_Updater {
 
@@ -117,15 +117,33 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
 
+			$no_update = false;
 			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
 
 				$_transient_data->response[ $this->name ] = $version_info;
 
+				// Make sure the plugin property is set to the plugin's name/location. See issue 1463 on Software Licensing's GitHub repo.
+				$_transient_data->response[ $this->name ]->plugin = $this->name;
+
+			} else {
+				$no_update              = new stdClass();
+				$no_update->id          = '';
+				$no_update->slug        = $this->slug;
+				$no_update->plugin      = $this->name;
+				$no_update->new_version = $version_info->new_version;
+				$no_update->url         = $version_info->homepage;
+				$no_update->package     = $version_info->package;
+				$no_update->icons       = $version_info->icons;
+				$no_update->banners     = $version_info->banners;
+				$no_update->banners_rtl = array();
 			}
 
 			$_transient_data->last_checked           = time();
 			$_transient_data->checked[ $this->name ] = $this->version;
 
+			if ( $no_update ) {
+				$_transient_data->no_update[ $this->name ] = $no_update;
+			}
 		}
 
 		return $_transient_data;
@@ -182,6 +200,10 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 					$version_info->icons = $this->convert_object_to_array( $version_info->icons );
 				}
 
+				if ( isset( $version_info->contributors ) && ! is_array( $version_info->contributors ) ) {
+					$version_info->contributors = $this->convert_object_to_array( $version_info->contributors );
+				}
+
 				$this->set_version_info_cache( $version_info );
 			}
 
@@ -189,14 +211,29 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				return;
 			}
 
+			$no_update = false;
 			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
 
 				$update_cache->response[ $this->name ] = $version_info;
 
+			} else {
+				$no_update              = new stdClass();
+				$no_update->id          = '';
+				$no_update->slug        = $this->slug;
+				$no_update->plugin      = $this->name;
+				$no_update->new_version = $version_info->new_version;
+				$no_update->url         = $version_info->homepage;
+				$no_update->package     = $version_info->package;
+				$no_update->icons       = $version_info->icons;
+				$no_update->banners     = $version_info->banners;
+				$no_update->banners_rtl = array();
 			}
 
-			$update_cache->last_checked = time();
+			$update_cache->last_checked           = time();
 			$update_cache->checked[ $this->name ] = $this->version;
+			if ( $no_update ) {
+				$update_cache->no_update[ $this->name ] = $no_update;
+			}
 
 			set_site_transient( 'update_plugins', $update_cache );
 
@@ -280,10 +317,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			)
 		);
 
-		$cache_key = 'edd_api_request_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) );
-
 		// Get the transient where we store the api request for this plugin for 24 hours
-		$edd_api_request_transient = $this->get_cached_version_info( $cache_key );
+		$edd_api_request_transient = $this->get_cached_version_info();
 
 		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
 		if ( empty( $edd_api_request_transient ) ) {
@@ -291,7 +326,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			$api_response = $this->api_request( 'plugin_information', $to_send );
 
 			// Expires in 3 hours
-			$this->set_version_info_cache( $api_response, $cache_key );
+			$this->set_version_info_cache( $api_response );
 
 			if ( false !== $api_response ) {
 				$_data = $api_response;
@@ -316,6 +351,15 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			$_data->icons = $this->convert_object_to_array( $_data->icons );
 		}
 
+		// Convert contributors into an associative array, since we're getting an object, but Core expects an array.
+		if ( isset( $_data->contributors ) && ! is_array( $_data->contributors ) ) {
+			$_data->contributors = $this->convert_object_to_array( $_data->contributors );
+		}
+
+		if( ! isset( $_data->plugin ) ) {
+			$_data->plugin = $this->name;
+		}
+
 		return $_data;
 	}
 
@@ -334,7 +378,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 	private function convert_object_to_array( $data ) {
 		$new_data = array();
 		foreach ( $data as $key => $value ) {
-			$new_data[ $key ] = $value;
+			$new_data[ $key ] = is_object( $value ) ? $this->convert_object_to_array( $value ) : $value;
 		}
 
 		return $new_data;
@@ -372,6 +416,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		global $wp_version, $edd_plugin_url_available;
 
+		$verify_ssl = $this->verify_ssl();
+
 		// Do a quick status check on this domain if we haven't already checked it.
 		$store_hash = md5( $this->api_url );
 		if ( ! is_array( $edd_plugin_url_available ) || ! isset( $edd_plugin_url_available[ $store_hash ] ) ) {
@@ -385,7 +431,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				$edd_plugin_url_available[ $store_hash ] = false;
 			} else {
 				$test_url = $scheme . '://' . $host . $port;
-				$response = wp_remote_get( $test_url, array( 'timeout' => $this->health_check_timeout, 'sslverify' => true ) );
+				$response = wp_remote_get( $test_url, array( 'timeout' => $this->health_check_timeout, 'sslverify' => $verify_ssl ) );
 				$edd_plugin_url_available[ $store_hash ] = is_wp_error( $response ) ? false : true;
 			}
 		}
@@ -416,7 +462,6 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			'beta'       => ! empty( $data['beta'] ),
 		);
 
-		$verify_ssl = $this->verify_ssl();
 		$request    = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => $verify_ssl, 'body' => $api_params ) );
 
 		if ( ! is_wp_error( $request ) ) {
@@ -427,14 +472,6 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			$request->sections = maybe_unserialize( $request->sections );
 		} else {
 			$request = false;
-		}
-
-		if ( $request && isset( $request->compatibility ) ) {
-			$request->compatibility = maybe_unserialize( $request->compatibility );
-		}
-
-		if ( $request && ! isset( $request->last_updated ) ) {
-			$request->last_updated = '';
 		}
 
 		if ( $request && isset( $request->banners ) ) {
@@ -454,6 +491,9 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 		return $request;
 	}
 
+	/**
+	 * If available, show the changelog for sites in a multisite install.
+	 */
 	public function show_changelog() {
 
 		global $edd_plugin_data;
@@ -475,9 +515,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 		}
 
 		$data         = $edd_plugin_data[ $_REQUEST['slug'] ];
-		$beta         = ! empty( $data['beta'] ) ? true : false;
-		$cache_key    = md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_' . $beta . '_version_info' );
-		$version_info = $this->get_cached_version_info( $cache_key );
+		$version_info = $this->get_cached_version_info();
 
 		if( false === $version_info ) {
 
@@ -498,7 +536,6 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				$version_info = json_decode( wp_remote_retrieve_body( $request ) );
 			}
 
-
 			if ( ! empty( $version_info ) && isset( $version_info->sections ) ) {
 				$version_info->sections = maybe_unserialize( $version_info->sections );
 			} else {
@@ -511,18 +548,28 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				}
 			}
 
-			$this->set_version_info_cache( $version_info, $cache_key );
+			$this->set_version_info_cache( $version_info );
 
+			// Delete the unneeded option
+			delete_option( md5( 'edd_plugin_' . sanitize_key( $_REQUEST['plugin'] ) . '_' . $this->beta . '_version_info' ) );
 		}
 
-
-		if( ! empty( $version_info ) && isset( $version_info->sections->changelog ) ) {
-			echo '<div style="background:#fff;padding:10px;">' . $version_info->sections->changelog . '</div>';
+		if ( isset( $version_info->sections ) ) {
+			$sections = $this->convert_object_to_array( $version_info->sections );
+			if ( ! empty( $sections['changelog'] ) ) {
+				echo '<div style="background:#fff;padding:10px;">' . wp_kses_post( $sections['changelog'] ) . '</div>';
+			}
 		}
 
 		exit;
 	}
 
+	/**
+	 * Gets the plugin's cached version information from the database.
+	 *
+	 * @param string $cache_key
+	 * @return boolean|string
+	 */
 	public function get_cached_version_info( $cache_key = '' ) {
 
 		if( empty( $cache_key ) ) {
@@ -545,6 +592,12 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 	}
 
+	/**
+	 * Adds the plugin version information to the database.
+	 *
+	 * @param string $value
+	 * @param string $cache_key
+	 */
 	public function set_version_info_cache( $value = '', $cache_key = '' ) {
 
 		if( empty( $cache_key ) ) {
@@ -558,6 +611,8 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		update_option( $cache_key, $data, 'no' );
 
+		// Delete the duplicate option
+		delete_option( 'edd_api_request_' . md5( serialize( $this->slug . $this->api_data['license'] . $this->beta ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
`Gravity_Flow_EDD_SL_Plugin_Updater` has been updated to `EDD_SL_Plugin_Updater` v1.7.1. This adds support for the WP 5.5 automatic updates feature avaialable on the plugins page.

## Testing instructions
- With master visit the plugins page and notice the Gravity Flow row does not include the enable or disable automatic updates link
- Switch to this branch
- Reload the page to find the link is now available
- Change the plugin version number in gravityflow.php to 2.5.11-dev
- Reload the page to find an update is available
- Click the view details link to confirm the changelog modal is displayed and contains the changelog for version 2.5.11

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->