### PR TITLE
Fixed missing Submit button on FE for role-based assignee

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -3,5 +3,6 @@
 - Fixed an issue on the User Registration Step, where manual User Activation feed setting was sending email with activation link to User.
 - Fixed an issue on the User and Multi-User field 'Users Role Filter' setting display (but not filter save).
 - Fixed an issue on front-end pages with WordPress 5.5 removing the page parameter.
+- Fixed an issue where combination of inbox shortcode arguments would prevent role based assignees from accessing submit button.
 - Fixed the css classname 'wrap' by making it specific as 'gravityflow_wrap'. This avoids conflict with the css rules of themes.
 - Added the red bubble inbox count display on the WP Dashboard Workflow menu item.

--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -448,7 +448,7 @@ class Gravity_Flow_Assignee {
 
 		$status = $this->get_status();
 
-		if ( !rgempty( $status ) && $status != 'pending' ) {
+		if ( !rgblank( $status ) && $status != 'pending' ) {
 			return false;
 		}
 

--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -448,7 +448,7 @@ class Gravity_Flow_Assignee {
 
 		$status = $this->get_status();
 
-		if ( !rgblank( $status ) && $status != 'pending' ) {
+		if ( ! rgblank( $status ) && $status != 'pending' ) {
 			return false;
 		}
 

--- a/includes/assignees/class-assignee.php
+++ b/includes/assignees/class-assignee.php
@@ -448,7 +448,7 @@ class Gravity_Flow_Assignee {
 
 		$status = $this->get_status();
 
-		if ( $status != 'pending' ) {
+		if ( !rgempty( $status ) && $status != 'pending' ) {
 			return false;
 		}
 


### PR DESCRIPTION
RE: [HS#14496](https://secure.helpscout.net/conversation/1260478325/14496?folderId=3509658#thread-3618865023)

## Description
Submit button missing on FE workflow step for role-based user assignment, with the following shortcode:

`[gravityflow page="inbox" sidebar="false" workflow_info="false" step_status="false"]`

## Testing instructions
1. Create a workflow and select assignee by role.
2. Create a front-end page with the above shortcode.
3. Open the inbox entry from the front-end page, submit button would be missing.
4. Switch to this branch and see if the submit button is available now.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A
## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->