### PR TITLE
Sync the WP5.5 auto-updates state and the app background updates setting

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6642,6 +6642,10 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 				foreach ( $pages as $page ) {
 					$this->maybe_update_page_content( $page, $settings, $previous_settings );
 				}
+
+				if ( $settings['background_updates'] != $previous_settings['background_updates'] ) {
+					$this->update_wp_auto_updates( $settings['background_updates'] );
+				}
 			}
 
 			parent::update_app_settings( $settings );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -330,6 +330,7 @@ if ( class_exists( 'GFForms' ) ) {
 				}
 				$settings['background_updates'] = true;
 				$this->update_app_settings( $settings );
+				$this->update_wp_auto_updates( true );
 
 			} else {
 				// Upgrade.
@@ -352,6 +353,11 @@ if ( class_exists( 'GFForms' ) ) {
 				if ( version_compare( $previous_version, '2.5', '<' ) ) {
 					$this->upgrade_250();
 				}
+
+				if ( version_compare( $previous_version, '2.5.12', '<' ) ) {
+					$this->upgrade_2512();
+				}
+
 			}
 
 			wp_cache_flush();
@@ -556,6 +562,18 @@ PRIMARY KEY  (id)
 			$settings['allow_allow_anonymous_attribute'] = true;
 			$settings['allow_field_ids']                 = true;
 			$this->update_app_settings( $settings );
+		}
+
+		/**
+		 * Populates the WordPress auto_update_plugins option, if background updates is enabled.
+		 *
+		 * @since 2.5.12
+		 */
+		public function upgrade_2512() {
+			$settings = $this->get_app_settings();
+			if ( $settings['background_updates'] ) {
+				$this->update_wp_auto_updates( true );
+			}
 		}
 
 		/**

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -9079,5 +9079,26 @@ AND m.meta_value='queued'";
 			return $query_vars;
 		}
 
+		/**
+		 * Updates the WordPress auto_update_plugins option to enable or disable automatic updates so the correct state is displayed on the plugins page.
+		 *
+		 * @since 2.5.12
+		 *
+		 * @param bool $is_enabled Indicates if background updates are enabled for Gravity Flow in the app settings.
+		 */
+		public function update_wp_auto_updates( $is_enabled ) {
+			$option       = 'auto_update_plugins';
+			$auto_updates = (array) get_site_option( $option, array() );
+
+			if ( $is_enabled ) {
+				$auto_updates[] = GRAVITY_FLOW_PLUGIN_BASENAME;
+				$auto_updates   = array_unique( $auto_updates );
+			} else {
+				$auto_updates = array_diff( $auto_updates, array( GRAVITY_FLOW_PLUGIN_BASENAME ) );
+			}
+
+			update_site_option( $option, $auto_updates );
+		}
+
 	}
 }

--- a/gravityflow.php
+++ b/gravityflow.php
@@ -33,6 +33,8 @@ define( 'GRAVITY_FLOW_EDD_STORE_URL', 'https://gravityflow.io' );
 
 define( 'GRAVITY_FLOW_EDD_ITEM_ID', 1473 );
 
+define( 'GRAVITY_FLOW_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
 add_action( 'gform_loaded', array( 'Gravity_Flow_Bootstrap', 'load' ), 1 );
 
 /**

--- a/includes/wizard/steps/class-iw-step-updates.php
+++ b/includes/wizard/steps/class-iw-step-updates.php
@@ -154,9 +154,6 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 		$settings = $gravityflow->get_app_settings();
 		$settings['background_updates'] = $this->background_updates !== 'disabled';
 		gravity_flow()->update_app_settings( $settings );
-
-		if ( $settings['background_updates'] ) {
-			$gravityflow->update_wp_auto_updates( true );
-		}
+		$gravityflow->update_wp_auto_updates( $settings['background_updates'] );
 	}
 }

--- a/includes/wizard/steps/class-iw-step-updates.php
+++ b/includes/wizard/steps/class-iw-step-updates.php
@@ -155,5 +155,8 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 		$settings['background_updates'] = $this->background_updates !== 'disabled';
 		gravity_flow()->update_app_settings( $settings );
 
+		if ( $settings['background_updates'] ) {
+			$gravityflow->update_wp_auto_updates( true );
+		}
 	}
 }


### PR DESCRIPTION
## Description
This fixes an issue where the auto-updates link on the installed plugins page and our background updates setting can get out of sync.

## Testing instructions
- With master toggle the enable/disable auto-updates link on the installed plugins page
- Go to the workflow settings page to find the background updates setting did not change
- Change and save the setting
- Return to the installed plugins page to find the auto-updates link was not updated
- Switch to this branch
- Repeat above tests to confirm using the link on the installed plugins page updates our setting and vice versa
- Install the plugin on a new site
- Find auto-updates are enabled on the installed plugins page
- Go to one of our admin pages to trigger the installation wizard, disable updates during the wizard
- Go to the installed plugins page to find auto-updates are disabled
- Uninstall from the our uninstall page
- Reactivate
- Go through the installation wizard again, this time keeping updates enabled
- Visit the installed plugins page to confirm auto updates are enabled

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->