### PR TITLE
Fix Missing Workflow Step Display on Workflow Steps

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3701,7 +3701,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 			if ( empty( $step ) || ! $step->is_supported() ) {
 
-				return '<span class="validation_error"><i class="fa fa-exclamation-triangle gf_invalid"></i> ' . $step_label . '  ' . esc_html__( '(missing)', 'gravityflow' ) . '</span>';
+				return '<span><i class="fa fa-exclamation-triangle gf_invalid"></i> ' . $step_label . '  ' . esc_html__( '(missing)', 'gravityflow' ) . '</span>';
 			}
 
 			$icon_url  = $step->get_icon_url();

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -709,7 +709,7 @@ class Gravity_Flow_Entry_Detail {
 					<?php
 					if ( $allow_display_empty_fields ) {
 						?>
-						<input type="checkbox" id="gentry_display_empty_fields" <?php echo $display_empty_fields ? "checked='checked'" : '' ?> onclick="ToggleShowEmptyFields();" />&nbsp;&nbsp;
+						<input type="checkbox" <?php echo $display_empty_fields ? "checked='checked'" : '' ?> onclick="ToggleShowEmptyFields();" />&nbsp;&nbsp;
 						<label for="gentry_display_empty_fields"><?php _e( 'show empty fields', 'gravityflow' ) ?></label>
 					<?php
 					}


### PR DESCRIPTION
## Description
Re: [Issue#19](https://github.com/gravityflow/backlog/issues/19)

## Testing instructions
1. Check with current stable version of Gravity Forms 2.4 - everything will be normal, as before.
2. Check the latest beta of Gravity Forms 2.5 and see if the missing workflow step on Workflow appears as desired, as pointed by the Issues mentioned above.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->