### PR TITLE
Update background updates strings

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -4737,8 +4737,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 						),
 						array(
 							'name'          => 'background_updates',
-							'label'         => esc_html__( 'Background Updates', 'gravityflow' ),
-							'tooltip' => __( 'Set this to ON to allow Gravity Flow to download and install bug fixes and security updates automatically in the background. Requires a valid license key.' , 'gravityflow' ),
+							'label'         => esc_html__( 'Automatic Updates', 'gravityflow' ),
+							'tooltip' => __( 'Set this to ON to allow WordPress to download and install Gravity Flow bug fixes and security updates automatically in the background. Requires a valid license key.' , 'gravityflow' ),
 							'type'          => 'radio',
 							'horizontal' => true,
 							'default_value' => false,

--- a/includes/wizard/steps/class-iw-step-pages.php
+++ b/includes/wizard/steps/class-iw-step-pages.php
@@ -35,7 +35,7 @@ class Gravity_Flow_Installation_Wizard_Step_Pages extends Gravity_Flow_Installat
 			// First run.
 			$this->workflow_pages = 'admin';
 		};
-		echo '<p>' . esc_html__( "Users can access workflowws via the front-end of your site and/or from the built-in WordPress admin pages (Workflow menu). If you would like your users to access via the front-end of your site then you'll need to add some pages.", 'gravityflow' ) . '</p>';
+		echo '<p>' . esc_html__( "Users can access workflows via the front-end of your site and/or from the built-in WordPress admin pages (Workflow menu). If you would like your users to access via the front-end of your site then you'll need to add some pages.", 'gravityflow' ) . '</p>';
 
 		/* translators: 1. The opening link tag 2. the closing link tag */
 		echo '<p>' . sprintf( esc_html__( 'Would you like to create custom inbox, status, and submit pages now? The pages will contain the %s[gravityflow]%s shortcode.', 'gravityflow' ), '<a href="http://docs.gravityflow.io/article/36-the-shortcode" target="_blank">', '</a>' ) . '</p>';

--- a/includes/wizard/steps/class-iw-step-updates.php
+++ b/includes/wizard/steps/class-iw-step-updates.php
@@ -32,13 +32,13 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 		?>
 		<p>
 			<?php
-			esc_html_e( 'Gravity Flow will download important bug fixes, security enhancements and plugin updates automatically. Updates are extremely important to the security of your WordPress site.', 'gravityflow' );
+			esc_html_e( 'WordPress will automatically install important Gravity Flow bug fixes, security enhancements and plugin updates. Updates are extremely important to the security of your site.', 'gravityflow' );
 			?>
 		</p>
 		<p>
 
 			<?php
-			esc_html_e( 'This feature is activated by default unless you opt to disable it below. We only recommend disabling background updates if you intend on managing updates manually. A valid license is required for background updates.', 'gravityflow' );
+			esc_html_e( 'This feature is activated by default unless you opt to disable it below. We only recommend disabling automatic updates if you intend on managing updates manually. A valid license is required for automatic updates.', 'gravityflow' );
 			?>
 
 		</p>
@@ -58,13 +58,13 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 		<div>
 			<label>
 				<input type="radio" id="background_updates_enabled" value="enabled" <?php checked( 'enabled', $this->background_updates ); ?> name="background_updates"/>
-				<?php esc_html_e( 'Keep background updates enabled', 'gravityflow' ); ?>
+				<?php esc_html_e( 'Keep automatic updates enabled', 'gravityflow' ); ?>
 			</label>
 		</div>
 		<div>
 			<label>
 				<input type="radio" id="background_updates_disabled" value="disabled" <?php checked( 'disabled', $this->background_updates ); ?> name="background_updates"/>
-				<?php esc_html_e( 'Turn off background updates', 'gravityflow' ); ?>
+				<?php esc_html_e( 'Turn off automatic updates', 'gravityflow' ); ?>
 			</label>
 		</div>
 		<div id="accept_terms_container" style="display:none;">
@@ -73,7 +73,7 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 				<h3><i class="fa fa-exclamation-triangle gf_invalid"></i> <?php _e( 'Are you sure?', 'gravityflow' ); ?>
 				</h3>
 				<p>
-					<strong><?php esc_html_e( 'By disabling background updates your site may not get critical bug fixes and security enhancements. We only recommend doing this if you are experienced at managing a WordPress site and accept the risks involved in manually keeping your WordPress site updated.', 'gravityflow' ); ?></strong>
+					<strong><?php esc_html_e( 'By disabling automatic updates your site may not get critical bug fixes and security enhancements. We only recommend doing this if you are experienced at managing a WordPress site and accept the risks involved in manually keeping your WordPress site updated.', 'gravityflow' ); ?></strong>
 				</p>
 			</div>
 			<label>
@@ -108,7 +108,7 @@ class Gravity_Flow_Installation_Wizard_Step_Updates extends Gravity_Flow_Install
 	 * @return string
 	 */
 	function get_title() {
-		return esc_html__( 'Background Updates', 'gravityflow' );
+		return esc_html__( 'Automatic Updates', 'gravityflow' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This updates the strings related to background updates on the installation wizard and workflow settings pages to use "automatic updates" to match the nomenclature used by WordPress 5.5.
 
## Screenshots
![Screen Shot 2020-08-30 at 10 24 57](https://user-images.githubusercontent.com/1872371/91655762-1fad9c00-eaab-11ea-9474-7de1780f9d3b.png)

![Screen Shot 2020-08-30 at 10 32 21](https://user-images.githubusercontent.com/1872371/91655885-1ec93a00-eaac-11ea-9797-cba55d7111e7.png)

![Screen Shot 2020-08-30 at 10 35 10](https://user-images.githubusercontent.com/1872371/91655942-84b5c180-eaac-11ea-9d60-56be7db61076.png)

![Screen Shot 2020-08-30 at 10 36 13](https://user-images.githubusercontent.com/1872371/91655963-a7e07100-eaac-11ea-8ddc-cf64a3b8a893.png)

![Screen Shot 2020-08-30 at 10 37 02](https://user-images.githubusercontent.com/1872371/91655985-dcecc380-eaac-11ea-98e1-fcbb4713e0ec.png)


## Documentation Changes?
The following article will need updating with the above screenshots: https://docs.gravityflow.io/article/159-how-to-install-gravity-flow

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->