### PR TITLE
Fix Fatal Error with Assignees on User Input Step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fix an issue with Step Assignees on User Input Step causing a Fatal Error.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1616,13 +1616,15 @@ abstract class Gravity_Flow_Step extends stdClass {
 		$has_editable_fields = ! empty( $this->editable_fields );
 
 		foreach ( $this->assignees as $assignee_key ) {
-			$args = $this->get_assignee_args( $assignee_key );
+			if ( ! empty( $assignee_key) ) {
+				$args = $this->get_assignee_args( $assignee_key );
 
-			if ( $has_editable_fields ) {
-				$args['editable_fields'] = $this->editable_fields;
+				if ( $has_editable_fields ) {
+					$args['editable_fields'] = $this->editable_fields;
+				}
+
+				$this->maybe_add_assignee( $args );
 			}
-
-			$this->maybe_add_assignee( $args );
 		}
 	}
 
@@ -1672,11 +1674,8 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 */
 	public function maybe_add_assignee( $args ) {
 		$assignee = $this->get_assignee( $args );
-
-		if ( $assignee ) {
-			$id       = $assignee->get_id();
-			$key      = $assignee->get_key();
-		}
+		$id       = $assignee->get_id();
+		$key      = $assignee->get_key();
 
 		if ( ! empty( $id ) && ! in_array( $key, $this->get_assignee_keys() ) ) {
 			$type = $assignee->get_type();

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -1672,8 +1672,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 	 */
 	public function maybe_add_assignee( $args ) {
 		$assignee = $this->get_assignee( $args );
-		$id       = $assignee->get_id();
-		$key      = $assignee->get_key();
+
+		if ( $assignee ) {
+			$id       = $assignee->get_id();
+			$key      = $assignee->get_key();
+		}
 
 		if ( ! empty( $id ) && ! in_array( $key, $this->get_assignee_keys() ) ) {
 			$type = $assignee->get_type();


### PR DESCRIPTION
## Description
Re: [Issue#41](https://github.com/gravityflow/backlog/issues/41)

## Testing instructions
1. Create a form with a User Input step and select Step Assignees, and try to save step settings.
(Alternatively can use the form export attached on the Issue page).
2. Saving the step settings will result in a fatal error.
3. Switch to this branch, and then repeat step 1.
4. Step settings success.
5. Test the workflow to confirm everything works as expected.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->