### PR TITLE
Added filter to remove inbox count

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Added filter 'gravityflow_show_inbox_count' for customization of the Gravity Flow Inbox. The Inbox count value can be disabled using it.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5989,6 +5989,12 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 * @param array $menu The current WP Dashboard Menu.
 		 */		
 		public function show_inbox_count( $menu ) {
+
+			$show = apply_filters( 'gravityflow_show_inbox_count', $show );
+			if ( isset( $show ) && ! $show ) {
+				return $menu;
+			}
+
 			$custom_labels = get_option( 'gravityflow_app_settings_labels', array() );
 			$custom_navigation_labels = rgar( $custom_labels, 'navigation' );
 			$custom_workflow_label = rgar( $custom_navigation_labels, 'workflow' );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5990,8 +5990,8 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 */		
 		public function show_inbox_count( $menu ) {
 
-			$show = apply_filters( 'gravityflow_inbox_count_display', $show );
-			if ( isset( $show ) && ! $show ) {
+			$show = apply_filters( 'gravityflow_inbox_count_display', true );
+			if ( ! $show ) {
 				return $menu;
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5990,6 +5990,11 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 */		
 		public function show_inbox_count( $menu ) {
 
+			/**
+			 * Allows the gravityflow inbox count display to be enabled or disabled
+			 *
+			 * @param bool show Whether to show inbox count.
+			 */			
 			$show = apply_filters( 'gravityflow_inbox_count_display', true );
 			if ( ! $show ) {
 				return $menu;

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5990,7 +5990,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 */		
 		public function show_inbox_count( $menu ) {
 
-			$show = apply_filters( 'gravityflow_show_inbox_count', $show );
+			$show = apply_filters( 'gravityflow_inbox_count_display', $show );
 			if ( isset( $show ) && ! $show ) {
 				return $menu;
 			}


### PR DESCRIPTION
## Description
Re: [HS#14662](https://secure.helpscout.net/conversation/1274562929/14662/) to remove inbox count red bubble.

## Testing instructions
- After switching to this branch, add the filter call on functions.php:
`add_filter( 'gravityflow_inbox_count_display', '__return_false', 1 );`
- Refresh Wordpress Dashboard and confirm the filter count is no longer.
- Remove the filter call from functions.php, and check to see the inbox count value is back.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
Add documentation for the filter `gravityflow_inbox_count_display`

`add_filter( 'gravityflow_inbox_count_display', '__return_false', 1 );`

Alternativey,
```
add_filter( 'gravityflow_inbox_count_display', 'sh_gravityflow_inbox_count_display', 10, 1 );
function sh_gravityflow_inbox_count_display( $show ) {
	return false;
}
```

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->