### PR TITLE
Fix inbox count to be disabled by default

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Updated Inbox count to be disabled by default, can be enabled with the filter 'gravityflow_inbox_count_display'.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -6204,7 +6204,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			 *
 			 * @param bool show Whether to show inbox count.
 			 */			
-			$show = apply_filters( 'gravityflow_inbox_count_display', true );
+			$show = apply_filters( 'gravityflow_inbox_count_display', false );
 			if ( ! $show ) {
 				return $menu;
 			}


### PR DESCRIPTION
## Description
Re: [HS#14988](https://secure.helpscout.net/conversation/1299881912/14988/)
The issue with the inbox count updates slowing down the website. Updating the configuration so inbox count is disabled by default, and can be enabled with the filter `gravityflow_inbox_count_display`.

## Testing instructions
1. Update to this branch and check the inbox count value is now disabled.
2. Use the filter `add_filter( 'gravityflow_inbox_count_display', '__return_true', 1 );`, and confirm the inbox count value is enabled

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->