### PR TITLE
Fix workflow showing same step on submission for email based assignee

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
 - Updated Inbox count to be disabled by default, can be enabled with the filter 'gravityflow_inbox_count_display'.
+- Fixed an issue where the front-end workflow was showing stuck on same step for email based assignee.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5666,6 +5666,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					if ( ( $next_step && $next_step->is_assignee( $current_user_assignee_key ) ) || $args['check_permissions'] == false || $this->current_user_can_any( 'gravityflow_status_view_all' ) ) {
 						$step = $next_step;
 					} else {
+						$step = false;
 						$args['display_instructions'] = false;
 					}
 					$args['check_permissions'] = false;


### PR DESCRIPTION
## Description
Re: [HS# 14496](https://secure.helpscout.net/conversation/1277212685/14687?folderId=1113497#thread-3671826413)
An issue with the email assignee not reflecting approval (or move to the next step) on the Workflow Inbox front-end display.

## Testing instructions
1. Create a form with an email field, and any other field (say discussion)
2. Create a user input step with the email field as assignee, passing the workflow entry link merge tag via email.
3. Check the issue is resolved when working through the user input step.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->