### PR TITLE
Added gravityflow_sort_columns_status_table filter

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
+- Added filter gravityflow_sort_columns_status_table to allow custom columns defined in gravityflow_field_value_status_table to be sorted
 - Updated Inbox count to be disabled by default, can be enabled with the filter 'gravityflow_inbox_count_display'.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1210,6 +1210,16 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			}
 		}
 
+		/**
+		 * Allows the sortability of columns to be filtered for the status table.
+		 *
+		 * @since 2.6.1
+		 *
+		 * @param array         $columns The columns to be sorted
+		 * @param WP_List_Table $this    The current WP_List_Table object.
+		 */
+		$sortable_columns = apply_filters( 'gravityflow_sort_columns_status_table', $sortable_columns, $this );
+
 		return $sortable_columns;
 	}
 
@@ -1242,9 +1252,9 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$columns['workflow_final_status'] = esc_html__( 'Status', 'gravityflow' );
 		}
 
-        if ( ! empty( $args['form-id'] ) && ! is_array( $args['form-id'] ) ) {
-	        $columns = Gravity_Flow_Common::get_field_columns( $columns, rgar( $args, 'form-id' ), $this->field_ids );
-        }
+		if ( ! empty( $args['form-id'] ) && ! is_array( $args['form-id'] ) ) {
+			$columns = Gravity_Flow_Common::get_field_columns( $columns, rgar( $args, 'form-id' ), $this->field_ids );
+		}
 
 		if ( $step_id = $this->get_filter_step_id() ) {
 			unset( $columns['workflow_step'] );


### PR DESCRIPTION
## Description
Re: [#14868](https://secure.helpscout.net/conversation/1291017933/14868?folderId=1776095)
Custom columns defined through gravityflow_columns_status_table filter cannot be set to be sortable in current version of Gravity Flow. The introduction of gravityflow_sort_columns_status_table allows them to be provided they refer to an [entry_meta ](https://docs.gravityforms.com/gform_entry_meta/) or a field ID.

In order for truly custom values to be sorted, an update to **Gravity Forms** query parse function would be required and perhaps support for more than GF_Query::TYPE_DECIMAL - both of which are beyond the scope of this PR.

## Testing instructions
1. Switch to the feature-sort-status-columns branch of code
1. Place the [example_filters.txt](https://github.com/gravityflow/gravityflow/files/5352194/example_filters.txt) into your theme functions.php file - modifying the form ID default (51) to be a form on your site with at least 3 fields. The only net new filter example is:
```
add_filter( 'gravityflow_field_value_status_table', 'custom_column_field_values', 10, 4 );
function custom_column_field_values( $value, $form_id, $column_name, $entry ) {
	if ( $column_name == 'project_score' && isset( $entry['project_score'] ) && intval( $entry['project_score'] ) > 0 ) {
		return $entry['project_score'];
	}
	return $value;
}
```
1. Create (or edit via Gravity Forms edit) several entries so the project_score random value will be updated on each.
1. Access Workflow > Status or a custom status page and see that column is sortable and entries sort in expected order.


## Documentation Changes?
New filter doc to be created upon merge.

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->