### PR TITLE
Fix firefox print issue on front-end pages

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,4 @@
 - Added filter gravityflow_sort_columns_status_table to allow custom columns defined in gravityflow_field_value_status_table to be sorted
 - Updated Inbox count to be disabled by default, can be enabled with the filter 'gravityflow_inbox_count_display'.
 - Fixed an issue with the print button on workflow details page.
+- Fixed an issue with the print button on front-end pages.

--- a/js/status-list.js
+++ b/js/status-list.js
@@ -55,7 +55,7 @@
 }(window.GravityFlowStatusList = window.GravityFlowStatusList || {}, jQuery));
 
 function closePrint () {
-    document.body.removeChild(this.__container__);
+    document.body.removeChild(this.contentWindow.__container__);
 }
 
 function setPrint () {


### PR DESCRIPTION
## Description
Re: HS# [15018](https://secure.helpscout.net/conversation/1301980605/15018?folderId=1113492#thread-3763622808)
The popup 'An error occurred while printing' comes up with Firefox when the Print button is clicked on front-end pages.

## Testing instructions

1. Update to this branch and check if the Print error is resolved with Firefox.
2. Confirm nothing breaks with other browsers (Chrome, Safari, IE, Edge).

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->