### PR TITLE
Fix gravityview entry revision user input

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -5,3 +5,4 @@
 - Fixed an issue with the print button on workflow details page.
 - Fixed an issue with the print button on front-end pages.
 - Fix JS errors with multiple status shortcodes on the same page.
+- Fix an issue with Gravity View Entry Revisions causing Gravity Flow to run steps out of sync.

--- a/change_log.txt
+++ b/change_log.txt
@@ -5,4 +5,4 @@
 - Fixed an issue with the print button on workflow details page.
 - Fixed an issue with the print button on front-end pages.
 - Fix JS errors with multiple status shortcodes on the same page.
-- Fix an issue with Gravity View Entry Revisions causing Gravity Flow to run steps out of sync.
+- Fixed an issue where workflow steps are processed for entry revisions created by GravityView Entry Revisions.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8377,7 +8377,7 @@ AND m.meta_value='queued'";
 		 * @param array $form  The form for this entry.
 		 */
 		public function action_gform_post_add_entry( $entry, $form ) {
-			if ( is_wp_error( $entry ) || ! empty( $entry['partial_entry_id'] ) ) {
+			if ( is_wp_error( $entry ) || ! empty( $entry['partial_entry_id'] ) || $entry['id'] !== rgget( 'lid' ) ) {
 				return;
 			}
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8377,7 +8377,7 @@ AND m.meta_value='queued'";
 		 * @param array $form  The form for this entry.
 		 */
 		public function action_gform_post_add_entry( $entry, $form ) {
-			if ( is_wp_error( $entry ) || ! empty( $entry['partial_entry_id'] ) || $entry['id'] !== rgget( 'lid' ) ) {
+			if ( is_wp_error( $entry ) || ! empty( $entry['partial_entry_id'] ) || rgar( $entry, 'status' ) !== 'active' ) {
 				return;
 			}
 

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1131,6 +1131,8 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	public function save_entry( $form, &$entry, $editable_fields ) {
 	    global $wpdb;
 
+		remove_action( 'gform_after_update_entry', array( GV_Entry_Revisions::get_instance(), 'gform_after_update_entry' ), -100 );
+		
 		$this->log_debug( __METHOD__ . '(): Saving entry.' );
 
 		$is_new_lead = $entry == null;

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1130,8 +1130,6 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	 */
 	public function save_entry( $form, &$entry, $editable_fields ) {
 	    global $wpdb;
-
-		remove_action( 'gform_after_update_entry', array( GV_Entry_Revisions::get_instance(), 'gform_after_update_entry' ), -100 );
 		
 		$this->log_debug( __METHOD__ . '(): Saving entry.' );
 

--- a/includes/steps/class-step-user-input.php
+++ b/includes/steps/class-step-user-input.php
@@ -1130,7 +1130,7 @@ class Gravity_Flow_Step_User_Input extends Gravity_Flow_Step {
 	 */
 	public function save_entry( $form, &$entry, $editable_fields ) {
 	    global $wpdb;
-		
+	
 		$this->log_debug( __METHOD__ . '(): Saving entry.' );
 
 		$is_new_lead = $entry == null;


### PR DESCRIPTION
## Description
Re: [HS#14607](https://secure.helpscout.net/conversation/1270186867/14607?folderId=1113492#thread-3788450740)
With Gravity View Entry Revisions, a successfully completed User Input Step on the workflow processes it's expiration step (when it should not).

## Testing instructions
1. Replicate the form and workflow settings as on the sandbox provided. Ensure Gravity View and Entry Revisions are enabled.
2. After the first step "Need Admin Response", the expiration step email is erroneously triggered.
3. Switch to this branch and repeat 2. This time, the erroneous email trigger doesn't happen,

With this update, entry revisions for User Input step will not be stored. Maybe this limitation or exception with Gravity View Entry Revisions can be updated [here](https://docs.gravityflow.io/article/30-integration-with-gravity-forms-add-ons) for the time being.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->