### PR TITLE
Fix Step Condition having Form Submission Step fetching wrong entry meta

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -5,3 +5,4 @@
 - Fixed an issue with the print button on workflow details page.
 - Fixed an issue with the print button on front-end pages.
 - Fix JS errors with multiple status shortcodes on the same page.
+- Fixed an issue with Step Condition on Form Submission Step. The entry meta of child form was fetched to process the condition, instead of parent form.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8710,9 +8710,8 @@ AND m.meta_value='queued'";
 				return true;
 			}
 
-			$form_id         = $form['id'];
-			$step_id         = $this->get_current_feed_id();			
-			$entry_meta      = array_merge( $this->get_feed_condition_entry_meta( $form_id, $step_id ), $this->get_feed_condition_entry_properties() );
+			$form_id         = $form['id'];			
+			$entry_meta      = array_merge( $this->get_feed_condition_entry_meta( $form_id ), $this->get_feed_condition_entry_properties() );
 			$entry_meta_keys = array_keys( $entry_meta );
 			$match_count     = 0;
 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8552,6 +8552,13 @@ AND m.meta_value='queued'";
 		public function get_feed_condition_entry_meta() {
 			$step_id    = absint( rgget( 'fid' ) );
 			$form_id    = absint( rgget( 'id' ) );
+			
+			if ( isset( $_POST['workflow_parent_entry_id'] ) ) {
+				$parent_entry_id = absint( rgpost( 'workflow_parent_entry_id' ) );
+				$parent_entry    = GFAPI::get_entry( $parent_entry_id );
+				$form_id = $parent_entry['form_id'];
+			}
+			
 			$entry_meta = GFFormsModel::get_entry_meta( $form_id );
 
 			unset( $entry_meta['workflow_final_status'], $entry_meta['workflow_step'], $entry_meta[ 'workflow_step_status_' . $step_id ] );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8547,7 +8547,8 @@ AND m.meta_value='queued'";
 		/**
 		 * Get the entry meta for use with the feed_condition setting.
 		 *
-		 * @since 2.6
+		 * @since 1.7.1-dev
+		 * @since 2.6.1     Added parameters for form_id and step_id.
 		 *
 		 * @param int $form_id The form ID.
 		 * @param int $step_id The step ID.		 

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8555,7 +8555,7 @@ AND m.meta_value='queued'";
 		 *
 		 * @return array
 		 */
-		public function get_feed_condition_entry_meta( $form_id, $step_id ) {
+		public function get_feed_condition_entry_meta( $form_id = 0, $step_id = 0 ) {
 			$entry_meta = GFFormsModel::get_entry_meta( $form_id );
 
 			unset( $entry_meta['workflow_final_status'], $entry_meta['workflow_step'], $entry_meta[ 'workflow_step_status_' . $step_id ] );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -8521,7 +8521,9 @@ AND m.meta_value='queued'";
 		 * @return string
 		 */
 		public function settings_feed_condition( $field, $echo = true ) {
-			$entry_meta  = array_merge( $this->get_feed_condition_entry_meta(), $this->get_feed_condition_entry_properties() );
+			$form_id     = absint( rgget( 'id' ) );
+			$step_id     = $this->get_current_feed_id();
+			$entry_meta  = array_merge( $this->get_feed_condition_entry_meta( $form_id, $step_id ), $this->get_feed_condition_entry_properties() );
 			$find        = 'var feedCondition';
 			$replacement = sprintf( 'var entry_meta = %s; %s', json_encode( $entry_meta ), $find );
 
@@ -8545,20 +8547,14 @@ AND m.meta_value='queued'";
 		/**
 		 * Get the entry meta for use with the feed_condition setting.
 		 *
-		 * @since 1.7.1-dev
+		 * @since 2.6
+		 *
+		 * @param int $form_id The form ID.
+		 * @param int $step_id The step ID.		 
 		 *
 		 * @return array
 		 */
-		public function get_feed_condition_entry_meta() {
-			$step_id    = absint( rgget( 'fid' ) );
-			$form_id    = absint( rgget( 'id' ) );
-			
-			if ( isset( $_POST['workflow_parent_entry_id'] ) ) {
-				$parent_entry_id = absint( rgpost( 'workflow_parent_entry_id' ) );
-				$parent_entry    = GFAPI::get_entry( $parent_entry_id );
-				$form_id = $parent_entry['form_id'];
-			}
-			
+		public function get_feed_condition_entry_meta( $form_id, $step_id ) {
 			$entry_meta = GFFormsModel::get_entry_meta( $form_id );
 
 			unset( $entry_meta['workflow_final_status'], $entry_meta['workflow_step'], $entry_meta[ 'workflow_step_status_' . $step_id ] );
@@ -8713,7 +8709,9 @@ AND m.meta_value='queued'";
 				return true;
 			}
 
-			$entry_meta      = array_merge( $this->get_feed_condition_entry_meta(), $this->get_feed_condition_entry_properties() );
+			$form_id         = $form['id'];
+			$step_id         = $this->get_current_feed_id();			
+			$entry_meta      = array_merge( $this->get_feed_condition_entry_meta( $form_id, $step_id ), $this->get_feed_condition_entry_properties() );
 			$entry_meta_keys = array_keys( $entry_meta );
 			$match_count     = 0;
 


### PR DESCRIPTION
## Description
Re: [HS# 15322](https://secure.helpscout.net/conversation/1325992575/15322?folderId=1113492#thread-3825730334)
When processing the step condition having a Form Submission step, the conditional logic wasn't evaluating properly, thus failing the entire workflow. The issue was the `$form_id` on `get_feed_condition_entry_meta()` was taken as the child `$form_id`. To fix this, we check if it's a `$parent_entry` and get the parent `$form_id`.

## Testing instructions
1. Use the testing form provided on the ticket.
2. Replicate the issue with `master`.
3. Switch to this branch and see the issue is resolved.
4. Test for other parent-child scenarios with the Form Connector plugin, like New Entry, etc.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->