### PR TITLE
Added "gravityflow_routing_values_markup" filter to allow filtering t…

### DIFF
--- a/js/routing-setting.js
+++ b/js/routing-setting.js
@@ -242,7 +242,17 @@
                 str = '<input type="text" value="" class="gform-routing-value value_{0}" />'.format(index);
             }
 
-            return str;
+            /**
+             * Filter the markup rendered for the Conditional Routing's value select.
+             *
+             * @param str    str              The markup to be rendered.
+             * @param object filter           An object containing the properties of the current condition.
+             * @param str    selectedOperator The operator that is selected for the current condition.
+             * @param int    index            The index of the current condition.
+             *
+             * @since x.x.x
+             */
+            return gform.applyFilters( 'gravityflow_routing_values_markup', str, filter, selectedOperator, index );
         },
 
         getFilter: function  (key) {


### PR DESCRIPTION
…he markup rendered for the Conditional Routing's value select.

## Testing instructions

Here's how we'll be using this in [Populate Anything](https://gravitywiz.com/documentation/gravity-forms-populate-anything) to allow users to specify custom values for dynamically populated choice-fields.

```js
gform.addFilter( 'gravityflow_routing_values_markup', function( markup, filter, selectedOperator, index ) {

	if ( ! filter || ! jQuery.isNumeric( filter.key ) ) {
		return markup;
	}

	var field = GetFieldById( filter.key );
	if ( ! field ) {
		return markup;
	}

	if ( field['gppa-choices-enabled'] ) {
		markup = '<input type="text" value="" class="gform-routing-value value_{0}" />'.format( index );
	}

	return markup;
} );
```

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->