### PR TITLE
Add filter for customization of sort order incl. default page load

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,11 +1,12 @@
 - Added filter 'gravityflow_inbox_count_display' for customization of the Gravity Flow Inbox. The Inbox count value can be disabled using it.
 - Added filter gravityflow_sort_columns_status_table to allow custom columns defined in gravityflow_field_value_status_table to be sorted
+- Added filter gravityflow_sort_criteria_status to allow initial sort order on status page load to be defined.
 - Updated Inbox count to be disabled by default, can be enabled with the filter 'gravityflow_inbox_count_display'.
 - Fixed an issue where the front-end workflow was showing stuck on same step for email based assignee.
 - Fixed an issue with Step Assignees on User Input Step causing a Fatal Error.
 - Fixed an issue with the print button on workflow details page.
 - Fixed an issue with the print button on front-end pages.
-- Fix JS errors with multiple status shortcodes on the same page.
+- Fixed JS errors with multiple status shortcodes on the same page.
 - Fixed an issue where workflow steps are processed for entry revisions created by GravityView Entry Revisions.
 - Fixed an issue with the print button on workflow details page and on front-end pages.
 - Fixed an issue with Step Condition on Form Submission Step. The entry meta of child form was fetched to process the condition, instead of parent form.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1738,6 +1738,17 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		$sorting = array( 'key' => $orderby, 'direction' => $order );
 
 		/**
+		 * Allows sorting to be adjusted to define which order entries are displayed in status table.
+		 *
+		 * Return an array of field IDs or meta keys with direction to define sort order for GFAPI::get_entries.
+		 *
+		 * @since 2.6.1
+		 *
+		 * @param array   $sorting The sorting criteria
+		 */
+		$sorting = apply_filters( 'gravityflow_sort_criteria_status', $sorting );
+
+		/**
 		 * Allows form id(s) to be adjusted to define which forms' entries are displayed in status table.
 		 * 
 		 * Return an array of form ids for use with GFAPI.


### PR DESCRIPTION
## Description
[HS #15481](https://secure.helpscout.net/conversation/1343088308/15481?folderId=1776099)
The recently added gravityflow_sort_columns_status_table filter lets custom meta be defined as sortable columns for status views, but the default sort order cannot be customized. Plugin does not currently call [gform_get_entries_args_entry_list](https://docs.gravityforms.com/gform_get_entries_args_entry_list/#filter-entry-list-by-entry-meta) which would be the closest equivalent to allow that customization via Gravity Forms code. This PR creates gravityflow_sort_criteria_status to allow customization of the sort order for either initial page load or any constant alterations.

## Testing instructions
- Add the code from gist https://gist.github.com/Idealien/62c6cc2eece99e924bb6d4afd48c7452 to your environment
- Customize the 2 switch blocks that map a specific field into the custom entry meta
- Customize (or remove) the is_page block within sort_criteria_status function to match your environment
- Create multiple entries with values Urgente / Media / Baja in the associated form / field
- Test a status view without this branch and note that you CAN click the column title to sort, but you cannot set the default sort order.
- Switch to this branch
- Re-test and find that the Prioridad column will be default sorted
 
## Documentation Changes?
- New filter documentation will be required that should link to entry meta docs of Gravity Forms.
- The snippet specific to the new filter to include would be
```
add_filter( 'gravityflow_sort_criteria_status', 'sort_criteria_status' );
function sort_criteria_status( $sort_criteria ) {
	//Adjust to only have the default filter execute on your desired page(s)
	if ( ! is_page( '94' ) ) {
		return $sort_criteria;
	}

	//Ensure that if the user has clicked on a sort column header this filter won't override that
	if ( ! rgget( 'orderby' ) && ! rgget( 'order' ) ) {
		$sort_criteria['key'] = 'prioridadNUM';
		$sort_criteria['direction'] = 'DESC';
		$sort_criteria['is_numeric'] = true;
	}
	return $sort_criteria;
}
```

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->