### PR TITLE
Fix token submission UI step

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5666,7 +5666,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					if ( ( $next_step && $next_step->is_assignee( $current_user_assignee_key ) ) || $args['check_permissions'] == false || $this->current_user_can_any( 'gravityflow_status_view_all' ) ) {
 						$step = $next_step;
 					} else {
-						$step = false;
+						$args['disable_workflow_update'] = true;
 						$args['display_instructions'] = false;
 					}
 					$args['check_permissions'] = false;

--- a/includes/pages/class-entry-detail.php
+++ b/includes/pages/class-entry-detail.php
@@ -43,6 +43,7 @@ class Gravity_Flow_Entry_Detail {
 		$show_timeline                = (bool) $args['timeline'];
 		$display_instructions         = (bool) $args['display_instructions'];
 		$sidebar                      = (bool) $args['sidebar'];
+		$disable_workflow_update      = (bool) $args['disable_workflow_update'];
 
 		self::include_scripts();
 
@@ -97,7 +98,7 @@ class Gravity_Flow_Entry_Detail {
 
 								if ( $current_step ) {
 									$can_update = self::can_update( $current_step );
-									if ( $can_update ) {
+									if ( $can_update && ! $disable_workflow_update ) {
 										$editable_fields = $can_update ? $current_step->get_editable_fields() : array();
 										$instructions_step = $current_step;
 									} else {
@@ -116,7 +117,7 @@ class Gravity_Flow_Entry_Detail {
 
 								do_action( 'gravityflow_entry_detail', $form, $entry, $current_step );
 
-								if ( ! $sidebar ) {
+								if ( ! $sidebar && ! $disable_workflow_update ) {
 									gravity_flow()->workflow_entry_detail_status_box( $form, $entry, $current_step, $args );
 									self::print_button( $entry, $show_timeline, $check_view_entry_permissions );
 								}
@@ -126,7 +127,7 @@ class Gravity_Flow_Entry_Detail {
 							<div id="postbox-container-1" class="postbox-container">
 
 							<?php
-							if ( $sidebar ) {
+							if ( $sidebar && ! $disable_workflow_update ) {
 								gravity_flow()->workflow_entry_detail_status_box( $form, $entry, $current_step, $args );
 								self::print_button( $entry, $show_timeline, $check_view_entry_permissions );
 							}


### PR DESCRIPTION
## Description
Re: [HS# 15628](https://secure.helpscout.net/conversation/1356724153/15628?folderId=3509661)
Following [PR#359](https://github.com/gravityflow/gravityflow/pull/359), a scenario was presented which caused issues with that update. We look at adding an argument to process the entry detail, instead of disabling the $step.

## Testing instructions
1. Create a form with 2 fields (say Field A and Field B). Also add an email field.
2. Create a User Input workflow step, with Field A as the editable field and the only display field. Assign this step to the Email field. Pass `{workflow_entry_link}` merge tag on the assignee email.
3. Process an entry for the form. Enter values for both fields A and B. Also, enter your email id in the email field.
4. Open the tokenized workflow entry link received in your email. Click Submit.
5. After submission, the workflow will display 'Entry updated and marked complete'. However, it will display both fields A and B. In Step 2, we had set Field A as the only display field.
6. Now switch to this branch, and repeat steps 1 to 5. Notice, the workflow only displays field A after submission.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->