### PR TITLE
Revert JS filter for routing values

### DIFF
--- a/js/routing-setting.js
+++ b/js/routing-setting.js
@@ -241,7 +241,7 @@
             } else {
                 str = '<input type="text" value="" class="gform-routing-value value_{0}" />'.format(index);
             }
-            
+
             return str;
         },
 

--- a/js/routing-setting.js
+++ b/js/routing-setting.js
@@ -241,18 +241,8 @@
             } else {
                 str = '<input type="text" value="" class="gform-routing-value value_{0}" />'.format(index);
             }
-
-            /**
-             * Filter the markup rendered for the Conditional Routing's value select.
-             *
-             * @param str    str              The markup to be rendered.
-             * @param object filter           An object containing the properties of the current condition.
-             * @param str    selectedOperator The operator that is selected for the current condition.
-             * @param int    index            The index of the current condition.
-             *
-             * @since 2.6.1
-             */
-            return gform.applyFilters( 'gravityflow_routing_values_markup', str, filter, selectedOperator, index );
+            
+            return str;
         },
 
         getFilter: function  (key) {


### PR DESCRIPTION
## Description
Reverting the addition of the gravityflow_routing_values_markup JS filter added in #368 for 2 reasons:
1.  It's possible to use the `gform_field_filters` PHP filter to remove the choice values  - forcing the textbox instead of the dropdown.
2. This component is likely to be refactored so it's best to wait until after the refactor before committing to filtering the markup.

## Testing instructions
Check for regressions. 

## Documentation Changes?
None.

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->