### PR TITLE
Fix Gravity Flow icon on Gravity Forms 2.5

### DIFF
--- a/css/feed-list.css
+++ b/css/feed-list.css
@@ -72,3 +72,9 @@ th.column-step_highlight, td.column-step_highlight {
 .gravityflow-routing {
     text-align: left;
 }
+
+span.icon > img {
+    height: 20px;
+    width: 20px;
+    transform: translateY(5%);
+}


### PR DESCRIPTION
## Description
[Issue# 48](https://github.com/gravityflow/backlog/issues/48)

## Testing instructions
1. Switch to Gravity Forms `develop` branch. 
2. Explore the icon display as described on the issue page.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->