### PR TITLE
Fix assignee email merge tag dropdown with Gravity Forms 2.5

### DIFF
--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -19,6 +19,7 @@
     position: relative;
     right: 15px;
     top: 90px;
+    z-index: 1;
 }
 
 .rtl .mt-_gform_setting_workflow_notification_message,


### PR DESCRIPTION
## Description
[Issue# 45](https://github.com/gravityflow/backlog/issues/45)

## Testing instructions
1. Enable Assignee Email "Send an email to the assignee" on a workflow step.
2. With Gravity Forms 2.4, the merge tag dropdown on the Message body does appear fine. It doesn't on Gravity Forms 2.5.
3. Update to this branch and check with both Gravity Forms 2.4, and Gravity Forms 2.5. Gravity Forms 2.4 should display the same. Gravity Forms 2.5 should now be fixed.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->