### PR TITLE
Fix assignee email merge tag location

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -11,4 +11,4 @@
 - Fixed an issue where workflow steps are processed for entry revisions created by GravityView Entry Revisions.
 - Fixed an issue with Step Condition on Form Submission Step. The entry meta of child form was fetched to process the condition, instead of parent form.
 - Fixed an issue with reassignment when the assignee policy has changed.
-- Fix Assignee Email merge tag to display alongside the container.
+- Fixed Assignee Email merge tag to display alongside the container.

--- a/change_log.txt
+++ b/change_log.txt
@@ -11,3 +11,4 @@
 - Fixed an issue where workflow steps are processed for entry revisions created by GravityView Entry Revisions.
 - Fixed an issue with Step Condition on Form Submission Step. The entry meta of child form was fetched to process the condition, instead of parent form.
 - Fixed an issue with reassignment when the assignee policy has changed.
+- Fix Assignee Email merge tag to display alongside the container.

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -17,7 +17,7 @@
 .gravityflow-tab-field span[class^="mt-_gform_setting_"] {
     float: right;
     position: relative;
-    right: 15px;
+    right: -20px;
     top: 90px;
     z-index: 1;
 }


### PR DESCRIPTION
## Description
[Issue# 58](https://github.com/gravityflow/backlog/issues/58)

## Testing instructions
1. Enable Assignee Email "Send an email to the assignee" on a workflow step.
2. With Gravity Forms 2.4, the merge tag dropdown on the Message body does appear fine. It doesn't on Gravity Forms 2.5.
3. Update to this branch and check with both Gravity Forms 2.4 and Gravity Forms 2.5. Gravity Forms 2.4 should display the same. Gravity Forms 2.5 should now be fixed.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes?
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->