### PR TITLE
Fix Gravity Forms namespaces

### DIFF
--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -169,7 +169,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 				$sections = $this->prepare_settings_sections( $sections, 'app_settings' );
 
 				// Initialize new settings renderer.
-				$renderer = new Gravity_Forms\Gravity_Forms\Settings(
+				$renderer = new Gravity_Forms\Gravity_Forms\Settings\Settings(
 					array(
 						'capability'     => $this->_capabilities_app_settings,
 						'fields'         => $sections,

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -170,7 +170,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 				$sections = $this->prepare_settings_sections( $sections, 'app_settings' );
 
 				// Initialize new settings renderer.
-				$renderer = new Gravity_Forms\Gravity_Forms\Settings(
+				$renderer = new Gravity_Forms\Gravity_Forms\Settings\Settings(
 					array(
 						'capability'     => $this->_capabilities_app_settings,
 						'fields'         => $sections,

--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -169,7 +169,7 @@ class Gravity_Flow_Fields {
 
 			if ( ! gravity_flow()->get_settings_renderer() ) {
 				// Set a dummy renderer.
-				$renderer = new Gravity_Forms\Gravity_Forms\Settings();
+				$renderer = new Gravity_Forms\Gravity_Forms\Settings\Settings();
 				gravity_flow()->set_settings_renderer( $renderer );
 			}
 


### PR DESCRIPTION
## Description
Addresses https://github.com/gravityflow/backlog/issues/59

## Testing instructions
Test the Workflow settings for both types of extensions and the form editor on Gravity Forms both 2.4 and 2.5. 

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->