### PR TITLE
Update the EDD SL updater to v1.8.0

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Allows plugins to use their own update API.
  *
  * @author Easy Digital Downloads
- * @version 1.7.1
+ * @version 1.8.0
  */
 class Gravity_Flow_EDD_SL_Plugin_Updater {
 
@@ -106,47 +106,50 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			return $_transient_data;
 		}
 
+		$current = $this->get_repo_api_data();
+		if ( false !== $current && is_object( $current ) && isset( $current->new_version ) ) {
+			if ( version_compare( $this->version, $current->new_version, '<' ) ) {
+				$_transient_data->response[ $this->name ] = $current;
+			} else {
+				// Populating the no_update information is required to support auto-updates in WordPress 5.5.
+				$_transient_data->no_update[ $this->name ] = $current;
+			}
+		}
+		$_transient_data->last_checked           = time();
+		$_transient_data->checked[ $this->name ] = $this->version;
+
+		return $_transient_data;
+	}
+
+	/**
+	 * Get repo API data from store.
+	 * Save to cache.
+	 *
+	 * @return \stdClass
+	 */
+	public function get_repo_api_data() {
 		$version_info = $this->get_cached_version_info();
 
 		if ( false === $version_info ) {
-			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug, 'beta' => $this->beta ) );
+			$version_info = $this->api_request(
+				'plugin_latest_version',
+				array(
+					'slug' => $this->slug,
+					'beta' => $this->beta,
+				)
+			);
+			if ( ! $version_info ) {
+				return false;
+			}
+
+			// This is required for your plugin to support auto-updates in WordPress 5.5.
+			$version_info->plugin = $this->name;
+			$version_info->id     = $this->name;
 
 			$this->set_version_info_cache( $version_info );
-
 		}
 
-		if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
-
-			$no_update = false;
-			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
-
-				$_transient_data->response[ $this->name ] = $version_info;
-
-				// Make sure the plugin property is set to the plugin's name/location. See issue 1463 on Software Licensing's GitHub repo.
-				$_transient_data->response[ $this->name ]->plugin = $this->name;
-
-			} else {
-				$no_update              = new stdClass();
-				$no_update->id          = '';
-				$no_update->slug        = $this->slug;
-				$no_update->plugin      = $this->name;
-				$no_update->new_version = $version_info->new_version;
-				$no_update->url         = $version_info->homepage;
-				$no_update->package     = $version_info->package;
-				$no_update->icons       = $version_info->icons;
-				$no_update->banners     = $version_info->banners;
-				$no_update->banners_rtl = array();
-			}
-
-			$_transient_data->last_checked           = time();
-			$_transient_data->checked[ $this->name ] = $this->version;
-
-			if ( $no_update ) {
-				$_transient_data->no_update[ $this->name ] = $no_update;
-			}
-		}
-
-		return $_transient_data;
+		return $version_info;
 	}
 
 	/**
@@ -182,7 +185,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 
 		if ( empty( $update_cache->response ) || empty( $update_cache->response[ $this->name ] ) ) {
 
-			$version_info = $this->get_cached_version_info();
+			$version_info = $this->get_repo_api_data();
 
 			if ( false === $version_info ) {
 				$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug, 'beta' => $this->beta ) );
@@ -211,29 +214,14 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 				return;
 			}
 
-			$no_update = false;
 			if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
-
 				$update_cache->response[ $this->name ] = $version_info;
-
 			} else {
-				$no_update              = new stdClass();
-				$no_update->id          = '';
-				$no_update->slug        = $this->slug;
-				$no_update->plugin      = $this->name;
-				$no_update->new_version = $version_info->new_version;
-				$no_update->url         = $version_info->homepage;
-				$no_update->package     = $version_info->package;
-				$no_update->icons       = $version_info->icons;
-				$no_update->banners     = $version_info->banners;
-				$no_update->banners_rtl = array();
+				$update_cache->no_update[ $this->name ] = $version_info;
 			}
 
 			$update_cache->last_checked           = time();
 			$update_cache->checked[ $this->name ] = $this->version;
-			if ( $no_update ) {
-				$update_cache->no_update[ $this->name ] = $no_update;
-			}
 
 			set_site_transient( 'update_plugins', $update_cache );
 
@@ -437,16 +425,16 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 		}
 
 		if ( false === $edd_plugin_url_available[ $store_hash ] ) {
-			return;
+			return false;
 		}
 
 		$data = array_merge( $this->api_data, $_data );
 
 		if ( $data['slug'] != $this->slug ) {
-			return;
+			return false;
 		}
 
-		if( $this->api_url == trailingslashit ( home_url() ) ) {
+		if ( $this->api_url == trailingslashit ( home_url() ) ) {
 			return false; // Don't allow a plugin to ping itself
 		}
 
@@ -482,7 +470,7 @@ class Gravity_Flow_EDD_SL_Plugin_Updater {
 			$request->icons = maybe_unserialize( $request->icons );
 		}
 
-		if( ! empty( $request->sections ) ) {
+		if ( ! empty( $request->sections ) ) {
 			foreach( $request->sections as $key => $section ) {
 				$request->$key = (array) $section;
 			}


### PR DESCRIPTION
## Description
Closes gravityflow/backlog/issues/54

This updates `Gravity_Flow_EDD_SL_Plugin_Updater` with the changes from `EDD_SL_Plugin_Updater` v1.8.0.

## Testing instructions
- Change the version in gravityflow.php and an extension to older versions
- Go to the installed plugins page to find updates are available
- Click the view details links to confirm the changelog modal is displayed

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->