### PR TITLE
Add gravityflow_step_start action

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,1 +1,2 @@
+- Added action gravityflow_step_start for custom logic to perform when any step starts.
 - Fixed an issue that prevented use of gravityflow_status_filter with an 'any' mode selection from being applied correctly.

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -610,7 +610,7 @@ abstract class Gravity_Flow_Step extends stdClass {
 			 * @param int               $step_id    The ID of the step.
 			 * @param int               $entry_id   The entry of the step.
 			 * @param int               $form_id    The form of the step.
-			 * @param string            $status     The status when the step.
+			 * @param string            $status     The status when the step starts.
 			 * @param Gravity_Flow_Step $step       The step.
 			 */
 			do_action( 'gravityflow_step_start', $step_id, $entry_id, $this->get_form_id(), $this->get_status(), $this );

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -607,11 +607,11 @@ abstract class Gravity_Flow_Step extends stdClass {
 			 *
 			 * @since 2.7.1
 			 *
-			 * @param int               $step_id    The ID of the completed step.
-			 * @param int               $entry_id   The entry of the completed step.
-			 * @param int               $form_id    The form of the completed step.
-			 * @param string            $status     The status when the step completed.
-			 * @param Gravity_Flow_Step $step       The completed step.
+			 * @param int               $step_id    The ID of the step.
+			 * @param int               $entry_id   The entry of the step.
+			 * @param int               $form_id    The form of the step.
+			 * @param string            $status     The status when the step.
+			 * @param Gravity_Flow_Step $step       The step.
 			 */
 			do_action( 'gravityflow_step_start', $step_id, $entry_id, $this->get_form_id(), $this->get_status(), $this );
 

--- a/includes/steps/class-step.php
+++ b/includes/steps/class-step.php
@@ -602,6 +602,19 @@ abstract class Gravity_Flow_Step extends stdClass {
 
 			$this->log_event( 'started' );
 
+			/**
+			 * Allows custom logic to be added when the step is started.
+			 *
+			 * @since 2.7.1
+			 *
+			 * @param int               $step_id    The ID of the completed step.
+			 * @param int               $entry_id   The entry of the completed step.
+			 * @param int               $form_id    The form of the completed step.
+			 * @param string            $status     The status when the step completed.
+			 * @param Gravity_Flow_Step $step       The completed step.
+			 */
+			do_action( 'gravityflow_step_start', $step_id, $entry_id, $this->get_form_id(), $this->get_status(), $this );
+
 			$complete = $this->process();
 
 			$log_is_complete = $complete ? 'yes' : 'no';
@@ -1900,6 +1913,17 @@ abstract class Gravity_Flow_Step extends stdClass {
 			gform_update_meta( $entry_id, 'workflow_current_status_timestamp', time() );
 		}
 
+		/**
+		 * Allows custom logic to be added when the step is started.
+		 *
+		 * @since 1.3.0.10
+		 *
+		 * @param int               $step_id    The ID of the completed step.
+		 * @param int               $entry_id   The entry of the completed step.
+		 * @param int               $form_id    The form of the completed step.
+		 * @param string            $status     The status when the step completed.
+		 * @param Gravity_Flow_Step $step       The completed step.
+		 */
 		do_action( 'gravityflow_step_complete', $step_id, $entry_id, $this->get_form_id(), $status, $this );
 		$this->log_debug( __METHOD__ . '() - ending step ' . $step_id );
 		$this->log_event( 'ended', $status, $duration );


### PR DESCRIPTION
## Description
Providing a parallel action to gravityflow_step_complete for custom processing.

## Testing instructions
- Ensure that steps continue to start as normal
- Ensure that use of the new action is possible
```
add_action( 'gravityflow_step_start', 'custom_step_start_step_due_date', 10, 5 );
function custom_step_start_step_due_date( $step_id, $entry_id, $form_id, $status, $step ) {
	error_log('The gravityflow_step_start action works');
}
```
 
## Documentation Changes
- Create new developer page based on docblock.
```
/**
* Allows custom logic to be added when the step is started.
*
* @since 2.7.1
*
* @param int               $step_id    The ID of the completed step.
* @param int               $entry_id   The entry of the completed step.
* @param int               $form_id    The form of the completed step.
* @param string            $status     The status when the step completed.
* @param Gravity_Flow_Step $step       The completed step.
*/
```

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->