### PR TITLE
Master fix 67 update assignee email message to use 2.5 editor

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,4 @@
 - Added action gravityflow_step_start for custom logic to perform when any step starts.
 - Fixed an issue that prevented use of gravityflow_status_filter with an 'any' mode selection from being applied correctly.
 - Updated the Status Page to use a CSS Loading Spinner to replace the deprecated Spinner Gif from Gravity Forms Core.
-- Updated the Assignee Email Message Textarea to use an updated version of the TinyMCE Editor from Gravity Forms 2.5
+- Updated the Assignee Email Message Textarea to improve support for the TinyMCE Editor from Gravity Forms 2.5

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Added action gravityflow_step_start for custom logic to perform when any step starts.
 - Fixed an issue that prevented use of gravityflow_status_filter with an 'any' mode selection from being applied correctly.
+- Updated the Assignee Email Message Textarea to use an updated version of the TinyMCE Editor from Gravity Forms 2.5

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3167,7 +3167,7 @@ PRIMARY KEY  (id)
 							$tooltip_class = isset( $field['tooltip_class'] ) ? $field['tooltip_class'] : '';
 							$tooltip       = gform_tooltip( $field['tooltip'], $tooltip_class, true );
 						}
-						printf( '<div id="%s-setting-tab-field-%s" class="gravityflow-tab-field"><div class="gravityflow-tab-field-label">%s %s</div>', $settings_prefix, $id, $field['label'], $tooltip );
+						printf( '<div id="%s-setting-tab-field-%s" class="gform-settings-field gform-settings-field__%s gravityflow-tab-field"><div class="gravityflow-tab-field-label">%s %s</div>', $settings_prefix, $id, $field['type'], $field['label'], $tooltip );
 						call_user_func( $func, $field );
 						echo '</div>';
 					}

--- a/includes/steps/class-common-step-settings.php
+++ b/includes/steps/class-common-step-settings.php
@@ -212,7 +212,8 @@ class Gravity_Flow_Common_Step_Settings {
 			array(
 				'name'          => $prefix . '_notification_message',
 				'label'         => __( 'Message', 'gravityflow' ),
-				'type'          => 'visual_editor',
+				'type'          => 'textarea',
+				'use_editor'    => true,
 				'default_value' => rgar( $config, 'default_message' ),
 			),
 			array(


### PR DESCRIPTION
## Description
The Message textarea for the Assignee Email in a Step was using the soon-to-be-deprecated 2.4 version of the editor. In Gravity Forms 2.5, the process for defining Settings Fields updated to move away from `visual_editor` and to a standardized `textarea` type. 

This fix simply updates the properties we send to the Settings API to use the `textarea` type along with `use_editor` to ensure it remains a WYSIWYG field. 

Additionally, Gravity Forms is expecting each field to be wrapped with a `div` with a combination of classes (`gform-settings-field gform-settings-field__{input type}` in order to inherit the correct styles. In this case, since this was a "tabbed" field in our UI, we were only setting the `gravityflow-tab-field` class on the field wrapper in our custom logic. This fix updates things to also add the additional `gform-settings-field` classes to our markup so that the correct style inheritance applies. 

Resolves issue 67: https://github.com/gravityflow/backlog/issues/67

## Testing instructions
1. Set up a form and add some Workflow Steps
2. Edit a Step, and scroll down to the Message field for the Assignee
3. Ensure that in Gravity Forms 2.5, the display matches the screenshot below. 
4. Switch to Gravity Forms 2.4, and ensure that the display remains as it was before this change (these changes should only fundamentally impact 2.5+). 

 
## Screenshots

**The correct display in GF 2.5**
![correct-layout](https://user-images.githubusercontent.com/6209061/107885782-d66ad080-6ec1-11eb-9c01-596e29d4f8c0.png)

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->