### PR TITLE
Fix Display of Icons in Timeline View

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,3 +2,4 @@
 - Fixed an issue that prevented use of gravityflow_status_filter with an 'any' mode selection from being applied correctly.
 - Updated the Status Page to use a CSS Loading Spinner to replace the deprecated Spinner Gif from Gravity Forms Core.
 - Updated the Assignee Email Message Textarea to improve support for the TinyMCE Editor from Gravity Forms 2.5
+- Fixed an issue that causes Icons in the Timeline View to display at the wrong size in Gravity Forms 2.5.

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -290,7 +290,7 @@
     }
 }
 
-.gravityflow-note-avatar span > i {
+.gravityflow-note-avatar span > i.fa {
 	width:65px;
 	height:65px;
 	display:inline-block;


### PR DESCRIPTION
## Description
Changes to GF in 2.5-rc1 updated the specificity of our font-awesome styles. This caused the Timeline icons to display much smaller, since their font-size property was being reset/overridden. This fix simply makes that selector more-specific, retaining its properties. 

Addresses issue 80: https://github.com/gravityflow/backlog/issues/80

## Testing instructions
1. Add a form with an Approval step. 
2. Submit the form, and Approve the step as an anonymous user so that the "Approval" icon displays instead of the user avatar.
3. Ensure the icon is the correct size, and no longer tiny.

 
## Screenshots

**Correct Display**
![image](https://user-images.githubusercontent.com/6209061/110220254-e4d95600-7e89-11eb-8606-5ced4839a9b9.png)

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->