### PR TITLE
Fix display of main admin nav with Gravity Forms 2.5

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -5698,7 +5698,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 					$entry = GFAPI::get_entry( $entry_id ); // Refresh entry.
 
 					$feedback = GFCommon::replace_variables( $feedback, $form, $entry, false, true, true, 'html' );
-					
+
 					if ( substr( $feedback, 0, 3 ) !== '<p>' ) {
 						$feedback = sprintf( '<p>%s</p>', $feedback );
 					}
@@ -5892,8 +5892,14 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 			?>
 
-			<div id="<?php echo $legacy ? 'gf_form_toolbar': 'gform-form-toolbar'; ?>">
-				<ul id="<?php echo $legacy ? 'gf_form_toolbar_links': 'gform-form-toolbar__menu'; ?>">
+			<div
+				id="<?php echo $legacy ? 'gf_form_toolbar': 'gform-form-toolbar'; ?>"
+				class="gform-form-toolbar"
+			>
+				<ul
+					id="<?php echo $legacy ? 'gf_form_toolbar_links': 'gform-form-toolbar__menu'; ?>"
+					class="gform-form-toolbar__menu"
+				>
 
 					<?php
 
@@ -6242,9 +6248,9 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 		 * Add inbox notification count to Workflow Menu.
 		 *
 		 * @since 2.5.12
-		 * 
+		 *
 		 * @param array $menu The current WP Dashboard Menu.
-		 */		
+		 */
 		public function show_inbox_count( $menu ) {
 
 			$app_settings = $this->get_app_settings();
@@ -6257,7 +6263,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 			$custom_navigation_labels = rgar( $custom_labels, 'navigation' );
 			$custom_workflow_label = rgar( $custom_navigation_labels, 'workflow' );
 			$workflow_label = $custom_workflow_label ? $custom_workflow_label : 'Workflow';
-	
+
 			$workflow_menu_pos = -1;
 			foreach ( $menu as $menuitem ) {
 				if ( $menuitem[0] == $workflow_label ) {
@@ -6822,11 +6828,11 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
 
 		/**
 		 * Return the inbox entries count from transient.
-		 * 
+		 *
 		 * @since 2.5.12
-		 * 
+		 *
 		 * @return int
-		 */		
+		 */
 		public function get_inbox_count() {
 			$count_value = get_transient( 'gflow_inbox_count_' . get_current_user_id()  );
 			if ( $count_value === false ) {
@@ -7429,7 +7435,7 @@ AND m.meta_value='queued'";
 										 * Return zero to deactivate the repeat reminder.
 										 *
 										 * @deprecated 2.5.3 - Fix typo of gravityflow_assignee_eamil_reminder_repeat_days (email)
-										 * 
+										 *
 										 * @param int                   $repeat_days The number of days between each reminder.
 										 * @param array                 $form        The current form.
 										 * @param array                 $entry       The current entry.
@@ -8595,7 +8601,7 @@ AND m.meta_value='queued'";
 		 * @since 2.6.1     Added parameters for form_id and step_id.
 		 *
 		 * @param int $form_id The form ID.
-		 * @param int $step_id The step ID.		 
+		 * @param int $step_id The step ID.
 		 *
 		 * @return array
 		 */
@@ -8754,7 +8760,7 @@ AND m.meta_value='queued'";
 				return true;
 			}
 
-			$form_id         = $form['id'];			
+			$form_id         = $form['id'];
 			$entry_meta      = array_merge( $this->get_feed_condition_entry_meta( $form_id ), $this->get_feed_condition_entry_properties() );
 			$entry_meta_keys = array_keys( $entry_meta );
 			$match_count     = 0;
@@ -8763,7 +8769,7 @@ AND m.meta_value='queued'";
 				foreach ( $logic['rules'] as $rule ) {
 
 					$rule['value'] = GFCommon::replace_variables( $rule['value'], $form, $entry, false, false, false, 'text' );
-					
+
 					if ( in_array( $rule['fieldId'], $entry_meta_keys ) ) {
 						$is_value_match = GFFormsModel::is_value_match( rgar( $entry, $rule['fieldId'] ), $rule['value'], $rule['operator'], null, $rule, $form );
 					} else {

--- a/css/inbox.css
+++ b/css/inbox.css
@@ -63,7 +63,7 @@ table#gravityflow-inbox td a {
     transform: translateY(-50%);
 }
 
-i.gravityflow-inbox-check {
+.gf_entry_wrap i.gravityflow-inbox-check {
     font-size: 5em;
 }
 


### PR DESCRIPTION
## Description

Gravity Forms 2.5 moved to using classes to style the nav toolbar. We need to add those same classes to Gravity Flow's instances of the toolbar to get the styles working again in that version.

## Testing instructions

* Load up the admin and go to any main Flow screen (inbox, checklist, folders etc)
* Confirm the nav displays correctly as in the screenshot below
 
## Screenshots

![image](https://user-images.githubusercontent.com/1568589/111078560-567d5980-84b3-11eb-959a-5831131100f1.png)

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->