### PR TITLE
Fix conflict with Feed Add-On Framework feed ordering functionality

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -2077,6 +2077,10 @@ PRIMARY KEY  (id)
 		 * Ajax handler for the request to save the custom feed order.
 		 */
 		public function ajax_save_feed_order() {
+			if ( rgpost( 'action' ) !== 'gravityflow_save_feed_order' ) {
+				return;
+			}
+
 			$feed_ids = rgpost( 'feed_ids' );
 			$form_id  = absint( rgpost( 'form_id' ) );
 			foreach ( $feed_ids as &$feed_id ) {

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -736,6 +736,7 @@ PRIMARY KEY  (id)
 						'hasStartStep'    => $has_start_step,
 						'hasCompleteStep' => $has_complete_step,
 						'formId'          => $form_id,
+						'nonce'           => wp_create_nonce( 'gravityflow_feed_list' ),
 					),
 				),
 				array(
@@ -2080,6 +2081,8 @@ PRIMARY KEY  (id)
 			if ( rgpost( 'action' ) !== 'gravityflow_save_feed_order' ) {
 				return;
 			}
+
+			check_ajax_referer( 'gravityflow_feed_list', 'nonce' );
 
 			$feed_ids = rgpost( 'feed_ids' );
 			$form_id  = absint( rgpost( 'form_id' ) );

--- a/js/feed-list.js
+++ b/js/feed-list.js
@@ -10,7 +10,8 @@
 
         var hasStartStep = gravityflow_feed_list_strings.hasStartStep,
             hasCompleteStep = gravityflow_feed_list_strings.hasCompleteStep,
-            formId = gravityflow_feed_list_strings.formId;
+            formId = gravityflow_feed_list_strings.formId,
+            nonce = gravityflow_feed_list_strings.nonce;
 
         $.each( $('.wp-list-table tbody tr'), function() { 
             $( this ).css( 'border-left', '5px solid ' + $(this).find('.step_highlight_color').css( 'background-color' ) );
@@ -56,7 +57,8 @@
                     var data = {
                         action: 'gravityflow_save_feed_order',
                         feed_ids: feedIds,
-                        form_id: formId
+                        form_id: formId,
+                        nonce: nonce
                     };
 
                     $.post( ajaxurl, data)


### PR DESCRIPTION
## Description
This PR fixes a conflict that occurs due to how Gravity Flow forks the feed ordering method implemented in the Feed Add-On Framework.

Since Gravity Flow uses a custom action name but the same Feed Add-On Framework method name, I've updated the method to confirm the action is for Gravity Flow feed ordering before continuing processing.

I also added a nonce check for added security.

## Testing instructions
1. Create a form with at least two workflow steps.
2. On the Workflow Steps page, re-order the feeds.
   - The AJAX response should be `[["ok"],200]`.
   - When you reload the page, the order should match the new feed order.

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->