### PR TITLE
Remove exclamation mark from license nag

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -9443,7 +9443,7 @@ AND m.meta_value='queued'";
 
 				$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings' );
 
-				$message = sprintf( '<img src="%s" style="vertical-align:text-bottom;margin-right:5px;"/>', GFCommon::get_base_url() . '/images/exclamation.png' );
+				$message = '';
 
 				switch ( $license_status ) {
 					case 'expired':

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -492,7 +492,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 
 			$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings&view=' . $this->get_slug() );
 
-			$message = sprintf( '<img src="%s" style="vertical-align:text-bottom;margin-right:5px;"/>', GFCommon::get_base_url() . '/images/exclamation.png' );
+			$message = '';
 
 			switch ( $license_status ) {
 				case 'expired':

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -500,7 +500,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 
 			$primary_button_link = admin_url( 'admin.php?page=gravityflow_settings&view=' . $this->get_slug() );
 
-			$message = sprintf( '<img src="%s" style="vertical-align:text-bottom;margin-right:5px;"/>', GFCommon::get_base_url() . '/images/exclamation.png' );
+			$message = '';
 
 			switch ( $license_status ) {
 				case 'expired':


### PR DESCRIPTION
## Description
Closes https://github.com/gravityflow/backlog/issues/88

Remove the redundant exclamation mark from the license nag ready for Gravity Forms 2.5.

## Testing instructions
Check the exclamation mark has been removed from the license nags for Gravity Flow plus the two types of extensions on both Gravity Forms 2.4 and 2.5.

## Automated Test Enhancements
N/A
 
## Screenshots
Before

<img width="1148" alt="nag" src="https://user-images.githubusercontent.com/368815/114275265-28dbef80-9a22-11eb-89e1-adf5b777fec3.png">
After

<img width="1138" alt="Screen Shot on 2021-04-10 at 17-30-22" src="https://user-images.githubusercontent.com/368815/114275334-76585c80-9a22-11eb-8512-08e5f3f72d01.png">


## Documentation Changes
N/A

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->