### PR TITLE
Fix 'gravityflow_form_ids_status' not fetching correct Status page counts with 'gravityflow_status_filter'

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue when the filter gravityflow_form_ids_status in use with the filter gravityflow_status_filter fetches invalid counters for the Status Page.

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1459,6 +1459,8 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$form_ids = $this->get_workflow_form_ids();
 		}
 
+		$form_ids = apply_filters( 'gravityflow_form_ids_status', $form_ids, $this->get_search_criteria() );
+
 		$results            = new stdClass();
 		$results->total     = 0;
 		$results->pending   = 0;

--- a/includes/pages/class-status.php
+++ b/includes/pages/class-status.php
@@ -1459,6 +1459,16 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 			$form_ids = $this->get_workflow_form_ids();
 		}
 
+		/**
+		* Allows form id(s) to be adjusted to define which forms' entries are displayed in status table.
+		*
+		* Return an array of form ids for use with GFAPI.
+		*
+		* @since 2.2.3
+		*
+		* @param array   $form_ids        The form ids
+		* @param array   $search_criteria The search criteria
+		*/
 		$form_ids = apply_filters( 'gravityflow_form_ids_status', $form_ids, $this->get_search_criteria() );
 
 		$results            = new stdClass();
@@ -1765,7 +1775,7 @@ class Gravity_Flow_Status_Table extends WP_List_Table {
 		 * 
 		 * Return an array of form ids for use with GFAPI.
 		 *
-		 * @since 2.2.2-dev
+		 * @since 2.2.3
 		 * 
 		 * @param array   $form_ids       The form ids
 		 * @param array   $search_criteria The search criteria


### PR DESCRIPTION
## Description
Despite filtering form ids with `gravityflow_form_ids_status`, the Gravity Flow Status page does not fetch correct counts (All, Pending, Complete, Cancelled) when used with `gravityflow_status_filter`

## Testing instructions
1. Add snippet with `gravityflow_form_ids_status` to restrict the display of forms on the Status page:
```
add_filter( 'gravityflow_form_ids_status', 'sh_status_form_ids_explicit', 10, 2 );
function sh_status_form_ids_explicit( $form_ids, $search_criteria ) {
	//Adjust array to your desired form IDs.
	$form_ids = array(13,16);
	return $form_ids;
}
```
2. Add snippet with `gravityflow_status_filter` to the Status page to display entries on a particular step, or with a particular final status.
```
add_filter( 'gravityflow_status_filter', 'sh_gravityflow_status_field_filter' );
function sh_gravityflow_status_field_filter( $filter_constraints ) {
	$search_criteria = array(
		'status'        => 'active',
		'field_filters' => array(
			'mode' => 'any',
			array(
				'key'   => 'workflow_step',
				'operator' => 'in',
				'value' => array('6','9','13','17','21'),
			),
			array(
				'key'   => 'workflow_final_status',
				'operator' => 'is',
				'value' => 'Approved',
			),
		),
	);
	return $search_criteria;
}
```
3.  Check the Status page, it should display entries as targeted with the snippets on steps 1 and 2. However, the count values (All, Pending, Complete, Cancelled) would be displayed for the entire Workflow Status and not for the current filtered entries.
4. Switch to this branch, and check the Status page again. The counts should be displaying correctly.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->