### PR TITLE
Fix save settings for 2.4

### DIFF
--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3427,8 +3427,18 @@ PRIMARY KEY  (id)
 		 * @param array $settings The settings to be potentially saved.
 		 */
 		public function validate_highlight_settings( $field, $settings ) {
-			$field = $this->prepare_settings_step_highlight( $field );
 
+			if ( ! $this->is_gravityforms_supported( '2.5-beta-1' ) ) {
+				$field = $this->prepare_settings_step_highlight( $field );
+				$checkbox_field = $field['settings']['step_highlight'];
+				$this->validate_checkbox_settings( $checkbox_field, $settings );
+				$color_field = $field['settings']['step_highlight_color'];
+				$this->validate_text_settings( $color_field, $settings );
+				$this->validate_step_highlight_color_settings( $color_field, $settings );
+				return;
+			}
+
+			$field = $this->prepare_settings_step_highlight( $field );
 			$checkbox_field = $field['settings']['step_highlight'];
 			$renderer  = $this->get_settings_renderer();
 			$cb_field     = new \Gravity_Forms\Gravity_Forms\Settings\Fields\Checkbox( $checkbox_field, $renderer );
@@ -3437,9 +3447,7 @@ PRIMARY KEY  (id)
 			$color_field = $field['settings']['step_highlight_color'];
 			$text_field     = new \Gravity_Forms\Gravity_Forms\Settings\Fields\Text( $color_field, $renderer );
 			$text_field->do_validation( $settings[ 'step_highlight_color'] );
-
 			$this->validate_step_highlight_color_settings( $color_field, $settings );
-
 		}
 
 		/**


### PR DESCRIPTION
## Description
This PR fixes an issue introduced in https://github.com/gravityflow/gravityflow/pull/400 where the settings can't be saved on Gravity Forms 2.4.

## Testing instructions
Check that settings can be saved on Gravity Forms 2.4 and 2.5.

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->