### PR TITLE
Add Form setting to Zapier step

### DIFF
--- a/includes/steps/class-step-feed-add-on.php
+++ b/includes/steps/class-step-feed-add-on.php
@@ -78,52 +78,53 @@ abstract class Gravity_Flow_Step_Feed_Add_On extends Gravity_Flow_Step {
 	 * @return array
 	 */
 	public function get_settings() {
-		$fields = array();
-
 		if ( ! $this->is_supported() ) {
-			return $fields;
+			return array();
 		}
 
-		$feeds = $this->get_feeds();
+		return array(
+			'title'  => $this->get_label(),
+			'fields' => array( $this->get_feeds_setting() ),
+		);
+	}
 
-		$feed_choices = array();
+	/**
+	 * Returns the feeds setting.
+	 *
+	 * @since 2.7.3
+	 *
+	 * @return array
+	 */
+	protected function get_feeds_setting() {
+		$feeds   = $this->get_feeds();
+		$choices = array();
+
 		foreach ( $feeds as $feed ) {
 			if ( $feed['is_active'] ) {
-				$label = $this->get_feed_label( $feed );
-
-				$feed_choices[] = array(
-					'label' => $label,
+				$choices[] = array(
+					'label' => $this->get_feed_label( $feed ),
 					'name'  => 'feed_' . $feed['id'],
 				);
 			}
 		}
 
-		if ( ! empty( $feed_choices ) ) {
-			$fields[] = array(
-				'name'     => 'feeds',
-				'required' => true,
-				'label'    => esc_html__( 'Feeds', 'gravityflow' ),
-				'type'     => 'checkbox',
-				'choices'  => $feed_choices,
-			);
-		}
-
-		if ( empty( $fields ) ) {
-			$html     = esc_html__( "You don't have any feeds set up.", 'gravityflow' );
-			$fields[] = array(
+		if ( empty( $choices ) ) {
+			return array(
 				'name'  => 'no_feeds',
 				'label' => esc_html__( 'Feeds', 'gravityflow' ),
 				'type'  => 'html',
-				'html'  => $html,
+				'html'  => esc_html__( "You don't have any feeds set up.", 'gravityflow' ),
 			);
 		}
 
 		return array(
-			'title'  => $this->get_label(),
-			'fields' => $fields,
+			'name'     => 'feeds',
+			'required' => true,
+			'label'    => esc_html__( 'Feeds', 'gravityflow' ),
+			'type'     => 'checkbox',
+			'choices'  => $choices,
 		);
 	}
-
 
 	/**
 	 * Processes this step.

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -69,19 +69,131 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 	}
 
 	/**
+	 * Returns the settings for this step.
+	 *
+	 * @since 2.7.3
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+		$settings = parent::get_settings();
+
+		if ( empty( $settings ) ) {
+			return $settings;
+		}
+
+		$form_setting = array(
+			'name'          => 'zapier_form',
+			'label'         => esc_html__( 'Form', 'gravityflow' ),
+			'type'          => 'select',
+			'tooltip'       => esc_html__( 'Select the form which has the Zapier feed(s) to be processed by this step.', 'gravityflow' ),
+			'default_value' => '',
+			'choices'       => array(
+				array(
+					'label' => esc_html__( 'This Form', 'gravityflow' ),
+					'value' => '',
+				),
+			),
+			'onchange'      => "jQuery(this).closest('form').submit();",
+		);
+
+		$forms = GFFormsModel::get_forms( true );
+
+		foreach ( $forms as $form ) {
+			if ( $this->get_form_id() == $form->id ) {
+				continue;
+			}
+
+			$form_setting['choices'][] = array(
+				'label' => esc_html( $form->title ),
+				'value' => absint( $form->id ),
+			);
+		}
+
+		array_unshift( $settings['fields'], $form_setting );
+
+		return $settings;
+	}
+
+	/**
+	 * Customizes the feeds setting.
+	 *
+	 * @since 2.7.3
+	 *
+	 * @return array
+	 */
+	protected function get_feeds_setting() {
+		$feeds   = $this->get_feeds();
+		$choices = array();
+
+		foreach ( $feeds as $feed ) {
+			if ( empty( $feed['is_active'] ) ) {
+				continue;
+			}
+
+			$choice = array(
+				'label' => $this->get_feed_label( $feed ),
+				'name'  => 'feed_' . $feed['id'],
+			);
+
+			$zap_id = absint( rgar( $feed['meta'], 'zapID' ) );
+
+			if ( ! empty( $zap_id ) ) {
+				$choice['tooltip'] = sprintf(
+					esc_html__( '%1$sView zap (%2$s)%3$s on zapier.com', 'gravityflow' ),
+					'<a href="' . esc_url( 'https://zapier.com/app/editor/' . $zap_id ) . '" target="_blank">',
+					$zap_id,
+					'</a>'
+				);
+			}
+
+			$choices[] = $choice;
+		}
+
+		if ( empty( $choices ) ) {
+			return array(
+				'name'  => 'no_feeds',
+				'label' => esc_html__( 'Feeds', 'gravityflow' ),
+				'type'  => 'html',
+				'html'  => sprintf(
+					esc_html__( 'The selected form doesn\'t have any feeds. %1$sCreate a zap%2$s on zapier.com or select a different form.', 'gravityflow' ),
+					'<a href="' . esc_url( 'https://zapier.com/apps/gravity-forms/integrations' ) . '" target="_blank">',
+					'</a>'
+				),
+			);
+		}
+
+		return array(
+			'name'     => 'feeds',
+			'required' => true,
+			'label'    => esc_html__( 'Feeds', 'gravityflow' ),
+			'type'     => 'checkbox',
+			'choices'  => $choices,
+		);
+	}
+
+	/**
 	 * Returns the feeds for the add-on.
 	 *
 	 * @since 1.0.0
 	 * @since 2.5.10 Updated to support Zapier v4.0
+	 * @since 2.7.3  Updated to support processing feeds from other forms.
 	 *
 	 * @return array
 	 */
 	public function get_feeds() {
-		if ( class_exists( 'GFZapierData' ) ) {
-			return GFZapierData::get_feed_by_form( $this->get_form_id() );
+		$form_id = $this->get_setting( 'zapier_form' );
+		if ( empty( $form_id ) ) {
+			$form_id = $this->get_form_id();
 		}
 
-		return parent::get_feeds();
+		if ( class_exists( 'GFZapierData' ) ) {
+			return GFZapierData::get_feed_by_form( $form_id );
+		} elseif ( function_exists( 'gf_zapier' ) ) {
+			return gf_zapier()->get_feeds( $form_id );
+		}
+
+		return array();
 	}
 
 	/**
@@ -181,24 +293,6 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 		}
 
 		return parent::get_feed_add_on_class_name();
-	}
-
-	/**
-	 * Determines if this step type is supported.
-	 *
-	 * @since 2.5.10
-	 *
-	 * @return bool
-	 */
-	public function is_supported() {
-		$is_supported = parent::is_supported();
-
-		if ( $is_supported && class_exists( 'GF_Zapier' ) && gravity_flow()->is_form_settings() ) {
-			// Zapier v4.0 feed config is only available if a feed already exists for the form.
-			$is_supported = gf_zapier()->has_feed( $this->get_form_id() );
-		}
-
-		return $is_supported;
 	}
 
 	/**

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -140,10 +140,12 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 
 			if ( ! empty( $zap_id ) ) {
 				$choice['tooltip'] = sprintf(
-					esc_html__( '%1$sView zap (%2$s)%3$s on zapier.com', 'gravityflow' ),
+					// Translators: 1. Opening <a> tag for link to zap overview, 2. Closing <a> tag, 3. Opening <a> tag for link to zap editor, 4. The zap ID.
+					esc_html__( '%1$sView%2$s or %3$sedit%2$s zap (%4$s) on zapier.com', 'gravityflow' ),
+					'<a href="' . esc_url( 'https://zapier.com/app/zap/' . $zap_id ) . '" target="_blank">',
+					'</a>',
 					'<a href="' . esc_url( 'https://zapier.com/app/editor/' . $zap_id ) . '" target="_blank">',
-					$zap_id,
-					'</a>'
+					$zap_id
 				);
 			}
 

--- a/includes/steps/class-step-feed-zapier.php
+++ b/includes/steps/class-step-feed-zapier.php
@@ -158,6 +158,7 @@ class Gravity_Flow_Step_Feed_Zapier extends Gravity_Flow_Step_Feed_Add_On {
 				'label' => esc_html__( 'Feeds', 'gravityflow' ),
 				'type'  => 'html',
 				'html'  => sprintf(
+					// Translators: 1. Opening <a> tag for link to Zapier, 2. Closing <a> tag.
 					esc_html__( 'The selected form doesn\'t have any feeds. %1$sCreate a zap%2$s on zapier.com or select a different form.', 'gravityflow' ),
 					'<a href="' . esc_url( 'https://zapier.com/apps/gravity-forms/integrations' ) . '" target="_blank">',
 					'</a>'


### PR DESCRIPTION
## Description
This restores the ability to use the Zapier step with forms which don’t have Zapier feeds. It also adds a Form setting to the Zapier step settings so the user can select a different form as the source of the feeds to be processed by the step.

Zapier Add-On 4.1 will add support for Zapier storing the zap ID in the feed when created or updated. If the feed meta contains the `zapID` a link to view the zap on zapier.com will be included in a tooltip next to the feed name.

![Screenshot 2021-05-05 at 18 44 22](https://user-images.githubusercontent.com/1872371/117190131-efa35f00-add6-11eb-8ad6-bd77d973372a.png)


## Testing instructions
- Enable logging for the Zapier add-on
- Create a form with a text field
- Duplicate the form
- Enable display of feeds on the Forms > Settings > Zapier page, if not already enabled
- Using an API client such as Postman or Paw create a `POST` request for the `/wp-json/gf/v2/feeds` endpoint of your site. Use basic auth credentials created via the Forms > Settings > REST API page. Use JSON for the request body with the following config, replacing 180 with the ID of the first form:
```
{
  "form_id": "180",
  "addon_slug": "gravityformszapier",
  "meta": {
    "feedName": "rest api test",
    "zapURL": "https://testing.test",
    "adminLabels": true,
    "zapID": "123"
  }
}
```
![Screenshot 2021-04-28 at 14 08 46](https://user-images.githubusercontent.com/1872371/116408954-4931e980-a82b-11eb-8f7c-33a0370781f3.png)

- Send the request
- Create a Zapier step for the second form
- Select the first form in the Form setting
- Select the "rest api test" feed.
- Confirm the tooltip contains a link to view the zap on zapier.com. Note: while the link will open zapier in a new tab it won't display the zap editor since we are testing with an invalid id.
- Save the feed
- Preview the second form
- Add a value to the field and submit
- View the logs to find the Zapier feed from the first form was used to process the second form
- Create a Zapier feed for the second form, use a different feed name 
- Edit the Zapier step, change the Form setting to the "This Form" choice, and select the new feed
- Submit the form again
- Check the logs to confirm the correct Zapier feed was used

## Automated Test Enhancements
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->