### PR TITLE
Fix font awesome not loading for shortcodes

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
+- Fixed Font Awesome not loading for shortcodes which causes the quick actions for inbox to not be visible.
 - Fixed an issue where a blank note could be submitted with whitespaces, even if it is required.
 - Added the gravityflow_note_valid filter to customize note validity for Approval and User Input steps.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -841,7 +841,7 @@ PRIMARY KEY  (id)
 					wp_enqueue_script( 'gravityflow_inbox', $this->get_base_url() . "/js/inbox{$this->min()}.js",  array(), $this->_version );
 
 					wp_enqueue_style( 'gform_admin',  GFCommon::get_base_url() . "/css/admin{$this->min()}.css", null, $this->_version );
-					wp_enqueue_style( 'gform_fontawesome',  GFCommon::get_base_url() . "/css/font-awesome{$this->min()}.css", null, $this->_version );
+					wp_enqueue_style( 'gform_font_awesome',  GFCommon::get_base_url() . "/css/font-awesome{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_entry_detail',  $this->get_base_url() . "/css/entry-detail{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_frontend_css', $this->get_base_url() . "/css/frontend{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_status', $this->get_base_url() . "/css/status{$this->min()}.css", null, $this->_version );

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -841,6 +841,7 @@ PRIMARY KEY  (id)
 					wp_enqueue_script( 'gravityflow_inbox', $this->get_base_url() . "/js/inbox{$this->min()}.js",  array(), $this->_version );
 
 					wp_enqueue_style( 'gform_admin',  GFCommon::get_base_url() . "/css/admin{$this->min()}.css", null, $this->_version );
+					wp_enqueue_style( 'gform_fontawesome',  GFCommon::get_base_url() . "/css/font-awesome{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_entry_detail',  $this->get_base_url() . "/css/entry-detail{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_frontend_css', $this->get_base_url() . "/css/frontend{$this->min()}.css", null, $this->_version );
 					wp_enqueue_style( 'gravityflow_status', $this->get_base_url() . "/css/status{$this->min()}.css", null, $this->_version );


### PR DESCRIPTION
## Description
The Font Awesome libraries were not being loaded for shortcodes, so our quick actions would not display. This pr patches that! 

## Testing instructions
* Create a page and embed your inbox with quick actions enabled `[gravityflow page="inbox" actions_column="true"]`
* Confirm the quick actions icons are visible on the front end
 
## Screenshots
![image](https://user-images.githubusercontent.com/1568589/117553662-aab23f00-b007-11eb-96b8-4cd0c276dafa.png)

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->