### PR TITLE
Fix extensions uninstall on Gravity Forms uninstall page

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,3 +1,3 @@
 - Fixed an issue where a blank note could be submitted with whitespaces, even if it is required.
 - Added the gravityflow_note_valid filter to customize note validity for Approval and User Input steps.
-- Fixed an issue where uninstall for extensions on Gravity Forms Settings was not loading the correct page.
+- Fixed an issue where uninstall for extensions on Gravity Forms Settings is not loading the correct page.

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,2 +1,3 @@
 - Fixed an issue where a blank note could be submitted with whitespaces, even if it is required.
 - Added the gravityflow_note_valid filter to customize note validity for Approval and User Input steps.
+- Fixed an issue where uninstall for extensions on Gravity Forms Settings was not loading the correct page.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -317,7 +317,8 @@ if ( class_exists( 'GFForms' ) ) {
 		 * @return string
 		 */
 		public function get_short_title() {
-			return $this->translate_navigation_label( 'workflow' );
+			$is_gravityforms_uninstall = rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall';
+			return $is_gravityforms_uninstall ? $this->_title : $this->translate_navigation_label( 'workflow' );
 		}
 
 		/**

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -233,6 +233,12 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		if ( ! $this->current_user_can_uninstall() ) {
 			return;
 		}
+
+		if ( rgget('page') == 'gf_settings' ) {
+			GFAddOn::render_uninstall();
+			return;
+		}
+
 		$icon        = array( 'icon' => $this->get_menu_icon() );
 		$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
 		$url         = add_query_arg( array( 'view' => $this->get_slug() ), admin_url( 'admin.php?page=gravityflow_settings' ) );

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -90,6 +90,9 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	/**
 	 * Returns the extension short title.
 	 *
+	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
+	 * @since unknown
+	 * 
 	 * @return string
 	 */
 	public function get_short_title() {

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -87,6 +87,11 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
+	public function get_short_title() {
+		$is_gravityforms_uninstall = rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall';
+		return $is_gravityforms_uninstall ? 'Gravity Flow ' . $this->_short_title : $this->_short_title;
+	}
+		
 	/**
 	 * Add the extension capabilities to the Gravity Flow group in Members.
 	 *

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -229,7 +229,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	}
 
 	/**
-	 * Override the settings button on Gravity Forms uninstall to point to Gravity Flow settings page
+	 * Render the uninstall button on Gravity Forms uninstall page to correctly point for Gravity Flow Extensions
 	 *
 	 * @since 2.7.3
 	 */

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -224,6 +224,39 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	}
 
 	/**
+	 * Override the settings button on Gravity Forms uninstall to point to Gravity Flow settings page
+	 *
+	 * @since 2.7.3
+	 */
+	public function render_settings_button() {
+
+		if ( ! $this->current_user_can_uninstall() ) {
+			return;
+		}
+		$icon        = array( 'icon' => $this->get_menu_icon() );
+		$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
+		$url         = add_query_arg( array( 'view' => $this->get_slug() ), admin_url( 'admin.php?page=gravityflow_settings' ) );
+		?>
+		<form action="" method="post" class="gform-settings-panel gform-settings-panel__addon-uninstall">
+			<?php wp_nonce_field( 'uninstall', 'gf_addon_uninstall' ); ?>
+			<div class="gform-settings-panel__content">
+				<div class="addon-logo dashicons"><?php echo $icon_markup; ?></div>
+				<div class="addon-uninstall-text">
+					<h4 class="gform-settings-panel__title"><?php printf( esc_html__( '%s', 'gravityforms' ), $this->get_short_title() ) ?></h4>
+					<div><?php esc_attr_e( 'To continue uninstalling this add-on click the settings button.', 'gravityforms' ) ?></div>
+				</div>
+				<div class="addon-uninstall-button">
+					<a href="<?php echo esc_url( $url ); ?>" aria-label="<?php echo 'Visit ' . $this->get_short_title() . ' Settings page'; ?>" class="button addon-settings">
+						<i class="dashicons dashicons-admin-generic"></i>
+						<?php esc_attr_e( 'Settings', 'gravityforms' ); ?>
+					</a>
+				</div>
+			</div>
+		</form>
+		<?php
+	}
+	
+	/**
 	 * Get the settings for the app settings tab.
 	 *
 	 * @return array

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -90,8 +90,8 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	/**
 	 * Returns the extension short title.
 	 *
-	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
 	 * @since unknown
+	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
 	 * 
 	 * @return string
 	 */

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -87,6 +87,11 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
+	/**
+	 * Returns the extension short title.
+	 *
+	 * @return string
+	 */
 	public function get_short_title() {
 		$is_gravityforms_uninstall = rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall';
 		return $is_gravityforms_uninstall ? 'Gravity Flow ' . $this->_short_title : $this->_short_title;

--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -234,7 +234,7 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 			return;
 		}
 
-		if ( rgget('page') == 'gf_settings' ) {
+		if ( rgget( 'page' ) == 'gf_settings' ) {
 			GFAddOn::render_uninstall();
 			return;
 		}

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -90,6 +90,9 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	/**
 	 * Returns the feed extension short title.
 	 *
+	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
+	 * @since unknown
+	 *  
 	 * @return string
 	 */	
 	public function get_short_title() {

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -87,6 +87,11 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
+	public function get_short_title() {
+		$is_gravityforms_uninstall = rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall';
+		return $is_gravityforms_uninstall ? 'Gravity Flow ' . $this->_short_title : $this->_short_title;
+	}
+
 	/**
 	 * Add the extension capabilities to the Gravity Flow group in Members.
 	 *

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -236,6 +236,12 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		if ( ! $this->current_user_can_uninstall() ) {
 			return;
 		}
+
+		if ( rgget('page') == 'gf_settings' ) {
+			GFAddOn::render_uninstall();
+			return;
+		}
+
 		$icon        = array( 'icon' => $this->get_menu_icon() );
 		$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
 		$url         = add_query_arg( array( 'view' => $this->get_slug() ), admin_url( 'admin.php?page=gravityflow_settings' ) );

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -237,7 +237,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 			return;
 		}
 
-		if ( rgget('page') == 'gf_settings' ) {
+		if ( rgget( 'page' ) == 'gf_settings' ) {
 			GFAddOn::render_uninstall();
 			return;
 		}

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -90,8 +90,8 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	/**
 	 * Returns the feed extension short title.
 	 *
-	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
 	 * @since unknown
+	 * @since 2.7.3 Updated to return Gravity Flow appended with the short title for Uninstall Page
 	 *  
 	 * @return string
 	 */	

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -87,6 +87,11 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 		add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 	}
 
+	/**
+	 * Returns the feed extension short title.
+	 *
+	 * @return string
+	 */	
 	public function get_short_title() {
 		$is_gravityforms_uninstall = rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall';
 		return $is_gravityforms_uninstall ? 'Gravity Flow ' . $this->_short_title : $this->_short_title;

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -227,6 +227,39 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	}
 
 	/**
+	 * Override the settings button on Gravity Forms uninstall to point to Gravity Flow settings page
+	 *
+	 * @since 2.7.3
+	 */
+	public function render_settings_button() {
+
+		if ( ! $this->current_user_can_uninstall() ) {
+			return;
+		}
+		$icon        = array( 'icon' => $this->get_menu_icon() );
+		$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
+		$url         = add_query_arg( array( 'view' => $this->get_slug() ), admin_url( 'admin.php?page=gravityflow_settings' ) );
+		?>
+		<form action="" method="post" class="gform-settings-panel gform-settings-panel__addon-uninstall">
+			<?php wp_nonce_field( 'uninstall', 'gf_addon_uninstall' ); ?>
+			<div class="gform-settings-panel__content">
+				<div class="addon-logo dashicons"><?php echo $icon_markup; ?></div>
+				<div class="addon-uninstall-text">
+					<h4 class="gform-settings-panel__title"><?php printf( esc_html__( '%s', 'gravityforms' ), $this->get_short_title() ) ?></h4>
+					<div><?php esc_attr_e( 'To continue uninstalling this add-on click the settings button.', 'gravityforms' ) ?></div>
+				</div>
+				<div class="addon-uninstall-button">
+					<a href="<?php echo esc_url( $url ); ?>" aria-label="<?php echo 'Visit ' . $this->get_short_title() . ' Settings page'; ?>" class="button addon-settings">
+						<i class="dashicons dashicons-admin-generic"></i>
+						<?php esc_attr_e( 'Settings', 'gravityforms' ); ?>
+					</a>
+				</div>
+			</div>
+		</form>
+		<?php
+	}
+
+	/**
 	 * Get the settings for the app settings tab.
 	 *
 	 * @return array

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -232,7 +232,7 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	}
 
 	/**
-	 * Override the settings button on Gravity Forms uninstall to point to Gravity Flow settings page
+	 * Render the uninstall button on Gravity Forms uninstall page to correctly point for Gravity Flow Feed Extensions
 	 *
 	 * @since 2.7.3
 	 */


### PR DESCRIPTION
## Description
This PR fixes the Gravity Forms Uninstall Page for Gravity Flow extensions. Currently, the uninstall page does not display Uninstall buttons for Gravity Flow Extensions. Also, the names of the extensions aren't listed with the 'Gravity Flow' prefix.

This resolves [Issue#102](https://github.com/gravityflow/backlog/issues/102).

## Testing instructions
1. Check the Gravity Forms Uninstall page to see the display of Gravity Flow Extensions with `master`.
2. Switch to this branch and confirm the uninstall buttons for all extensions display and work fine.
3. Confirm the names of all the extensions are displayed with the 'Gravity Flow' prefix.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->