### PR TITLE
Fix UI on 'Update Fields' Workflow Step

### DIFF
--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -250,7 +250,7 @@ div.gform-field-filter {
     max-width: auto;
 }
 
-select.gform-filter-field, select.gform-filter-operator, input.gform-filter-value {
+select.gform-filter-field, select.gform-filter-operator, input.gform-filter-value, select.gform-filter-value {
     height: auto;
     min-height: 100%;
     position: relative;

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -274,14 +274,6 @@ button.gform-add, button.gform-remove {
     padding: 1px 7px;
 }
 
-button.gform-add.add_field_choice {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02IDBhMSAxIDAgMDAtMSAxdjRIMWExIDEgMCAwMDAgMmg0djRhMSAxIDAgMTAyIDBWN2g0YTEgMSAwIDEwMC0ySDdWMWExIDEgMCAwMC0xLTF6IiBmaWxsPSIjRjE1QTI5Ii8+PC9zdmc+);
-}
-
-button.gform-remove.delete_field_choice {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMCAxYTEgMSAwIDAxMS0xaDEwYTEgMSAwIDExMCAySDFhMSAxIDAgMDEtMS0xeiIgZmlsbD0iI0YxNUEyOSIvPjwvc3ZnPg==);
-}
-
 .gform-settings-panel__content select[name="_gform_setting_entry_filtersort_key"], .gform-settings-panel__content select[name="_gform_setting_entry_filtersort_direction"] {
     width: auto;
 }


### PR DESCRIPTION
## Description
This PR fixes CSS rules on the `form-settings.css` to fix some UI issues on Form Connector's 'Update Field' step. The SVGs that were overridden before to fix the add-remove icons are no longer needed. The `gform-filter-value` CSS rule was only indicated for `input` previously, it should also be identified for `select`.

This resolves [gravityflow/backlog#105](https://github.com/gravityflow/backlog/issues/105).

## Testing instructions
1. Install and Enable the 'Form Connector' extension.
2. Create a Workflow 'Update Fields' step.
3. Select 'Entry Lookup' -> 'Conditional Logic'.
4. Notice the Add-Remove icons displayed under the rules.
5. Select a field on the rule which will display a select on the value, for instance 'Status of a step'.
6. Notice the select field's size isn't aligned.
7. Switch to this branch, and repeats steps 2-6. Confirm steps 4 and 6 now display fine.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->