### PR TITLE
Fix Green Triangle not displaying for Editable Fields on User Input Step

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with Gravity Forms 2.5 not displaying the green triangle next to the Editable fields on User Input Workflow Step.

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -337,9 +337,9 @@ table.entry-detail-view td.detail-view{
 }
 
 .gfield.gravityflow-display-field .gfield_label,
-.gfield.gravityflow-display-field legend.gfield_label,
+.gfield.gravityflow-display-field .gfield_label,
 .gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) .gfield_label,
-.gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) legend.gfield_label{
+.gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) .gfield_label{
     background-color: #EAF2FA;
     border-top: 1px solid #DFDFDF;
     border-bottom: 1px solid #FFF;
@@ -349,13 +349,13 @@ table.entry-detail-view td.detail-view{
     margin:0;
 }
 
-.gfield.gravityflow-editable-field legend.gfield_label {
+.gfield.gravityflow-editable-field .gfield_label {
     float:left;
     margin-bottom: .5em;
     width:100%;
 }
 
-.gfield.gravityflow-editable-field legend.gfield_label + div {
+.gfield.gravityflow-editable-field .gfield_label + div {
     clear:both;
 }
 

--- a/css/entry-detail.css
+++ b/css/entry-detail.css
@@ -10,13 +10,13 @@
 }
 
 /* The little triangle indicator */
-.gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label {
+.gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label {
     width:100%;
     position: relative;
 }
 
-.gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::before,
-.gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::after {
+.gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::before,
+.gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::after {
     content: '';
     position: absolute;
     top: 0;
@@ -25,31 +25,31 @@
     border-style: solid;
 }
 
-.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::before,
-.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::after {
+.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::before,
+.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::after {
     left: auto;
     right: 0;
 }
 
-.gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::before {
+.gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::before {
     border-width: 0.4em;
     border-left-color: #ccc;
     border-top-color: #ccc;
 }
 
-.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::before {
+.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::before {
     border-left-color: transparent;
     border-right-color: #ccc;
 }
 
-.gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::after {
+.gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::after {
     border-radius: 0.1em;
     border-width: 0.4em;
     border-left-color: #0c0;
     border-top-color: #0c0;
 }
 
-.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) label.gfield_label::after {
+.rtl .gravityflow-editable-field.green-triangle:not(.gfield_error) .gfield_label::after {
     border-left-color: transparent;
     border-right-color: #0c0;
 }
@@ -336,9 +336,9 @@ table.entry-detail-view td.detail-view{
     list-style-type: disc;
 }
 
-.gfield.gravityflow-display-field label.gfield_label,
+.gfield.gravityflow-display-field .gfield_label,
 .gfield.gravityflow-display-field legend.gfield_label,
-.gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) label.gfield_label,
+.gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) .gfield_label,
 .gfield.gravityflow-editable-field:not(.green-background):not(.gfield_error) legend.gfield_label{
     background-color: #EAF2FA;
     border-top: 1px solid #DFDFDF;
@@ -359,7 +359,7 @@ table.entry-detail-view td.detail-view{
     clear:both;
 }
 
-.gravityflow-editable-field.gfield.green-background label.gfield_label{
+.gravityflow-editable-field.gfield.green-background .gfield_label{
     border: 0;
     margin: 0;
     padding: 0;

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -250,7 +250,7 @@ div.gform-field-filter {
     max-width: auto;
 }
 
-select.gform-filter-field, select.gform-filter-operator, input.gform-filter-value {
+select.gform-filter-field, select.gform-filter-operator, input.gform-filter-value, select.gform-filter-value {
     height: auto;
     min-height: 100%;
     position: relative;
@@ -272,14 +272,6 @@ button.gform-add, button.gform-remove {
     vertical-align: middle;
     top: .3rem;
     padding: 1px 7px;
-}
-
-button.gform-add.add_field_choice {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02IDBhMSAxIDAgMDAtMSAxdjRIMWExIDEgMCAwMDAgMmg0djRhMSAxIDAgMTAyIDBWN2g0YTEgMSAwIDEwMC0ySDdWMWExIDEgMCAwMC0xLTF6IiBmaWxsPSIjRjE1QTI5Ii8+PC9zdmc+);
-}
-
-button.gform-remove.delete_field_choice {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMCAxYTEgMSAwIDAxMS0xaDEwYTEgMSAwIDExMCAySDFhMSAxIDAgMDEtMS0xeiIgZmlsbD0iI0YxNUEyOSIvPjwvc3ZnPg==);
 }
 
 .gform-settings-panel__content select[name="_gform_setting_entry_filtersort_key"], .gform-settings-panel__content select[name="_gform_setting_entry_filtersort_direction"] {


### PR DESCRIPTION
## Description
With Gravity Forms 2.5, the Workflow Entry Inbox displays fields with `legend` instead of `label`. The CSS rules for `green-triangle` are defined to work only with `label.gfield_label`, so the green triangle only displays on legacy forms.

This fix removes the specific `label.gfield_label` CSS rule to a generic `.gfield_label`. Thus it works for both label and legend tags.

This resolves [gravityflow/backlog#122](https://github.com/gravityflow/backlog/issues/122).

## Testing instructions
1. Create a form, ensure 'Enable legacy markup' is not enabled.
2. Create a User Input step, and select editable fields. Enable highlight editable fields with the 'Green Triangle' setting.
3. Run the form and create an entry.
4. Open the Workflow Inbox for the entry created. The green triangle would not display for the editable field.
5. Switch to this branch, and repeat step 4. The Green Triangle now displays fine.
6. Now enable legacy markup on form settings, and repeat step 4. Confirm the green triangle still displays fine.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
N/A

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->