### PR TITLE
Add custom uninstall message functionality for extensions

### DIFF
--- a/includes/class-extension.php
+++ b/includes/class-extension.php
@@ -237,6 +237,17 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	}
 
 	/**
+	 * Returns the uninstall message for Gravity Flow Extension on Gravity Forms Uninstall Page. Override this function on extension classes for custom uninstall message.
+	 * 
+	 * @since 2.7.4
+	 * 
+	 * @return string
+	 */
+	public function extension_uninstall_message() {
+		return esc_html__( 'This operation deletes ALL %s settings.', 'gravityforms' );
+	}
+
+	/**
 	 * Render the uninstall button on Gravity Forms uninstall page to correctly point for Gravity Flow Extensions
 	 *
 	 * @since 2.7.3
@@ -244,6 +255,33 @@ abstract class Gravity_Flow_Extension extends GFAddOn {
 	public function render_settings_button() {
 
 		if ( ! $this->current_user_can_uninstall() ) {
+			return;
+		}
+
+		if ( rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall' ) {
+			$icon        = array( 'icon' => $this->get_menu_icon() );
+			$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
+
+			?>
+			<form action="" method="post" class="gform-settings-panel gform-settings-panel__addon-uninstall">
+				<?php wp_nonce_field( 'uninstall', 'gf_addon_uninstall' ); ?>
+				<div class="gform-settings-panel__content">
+					<div class="addon-logo dashicons"><?php echo $icon_markup; ?></div>
+					<div class="addon-uninstall-text">
+						<h4 class="gform-settings-panel__title"><?php printf( esc_html__( '%s', 'gravityforms' ), $this->get_short_title() ) ?></h4>
+						<div><?php printf( $this->extension_uninstall_message(), $this->get_short_title() ) ?></div>
+					</div>
+					<div class="addon-uninstall-button">
+						<input id="addon" name="addon" type="hidden" value="<?php echo $this->get_short_title(); ?>">
+						<button type="submit" aria-label="<?php printf( esc_html__( 'Uninstall %s', 'gravityforms'), $this->get_short_title() ); ?>" name="uninstall_addon" value="uninstall" class="button uninstall-addon red" onclick="return confirm('<?php echo esc_js( $this->uninstall_confirm_message() ); ?>');" onkeypress="return confirm('<?php echo esc_js( $this->uninstall_confirm_message() ); ?>');">
+							<i class="dashicons dashicons-trash"></i>
+							<?php esc_attr_e( 'Uninstall', 'gravityforms' ); ?>
+						</button>
+					</div>
+				</div>
+			</form>
+			<?php
+
 			return;
 		}
 

--- a/includes/class-feed-extension.php
+++ b/includes/class-feed-extension.php
@@ -240,6 +240,17 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	}
 
 	/**
+	 * Returns the uninstall message for Gravity Flow Feed Extension on Gravity Forms Uninstall Page. Override this function on feed extension classes for custom uninstall message.
+	 * 
+	 * @since 2.7.4
+	 * 
+	 * @return string
+	 */
+	public function extension_uninstall_message() {
+		return esc_html__( 'This operation deletes ALL %s settings.', 'gravityforms' );
+	}
+
+	/**
 	 * Render the uninstall button on Gravity Forms uninstall page to correctly point for Gravity Flow Feed Extensions
 	 *
 	 * @since 2.7.3
@@ -247,6 +258,33 @@ abstract class Gravity_Flow_Feed_Extension extends GFFeedAddOn {
 	public function render_settings_button() {
 
 		if ( ! $this->current_user_can_uninstall() ) {
+			return;
+		}
+
+		if ( rgget( 'page' ) == 'gf_settings' && rgget( 'subview' ) == 'uninstall' ) {
+			$icon        = array( 'icon' => $this->get_menu_icon() );
+			$icon_markup = GFCommon::get_icon_markup( $icon, 'dashicon-admin-generic' );
+
+			?>
+			<form action="" method="post" class="gform-settings-panel gform-settings-panel__addon-uninstall">
+				<?php wp_nonce_field( 'uninstall', 'gf_addon_uninstall' ); ?>
+				<div class="gform-settings-panel__content">
+					<div class="addon-logo dashicons"><?php echo $icon_markup; ?></div>
+					<div class="addon-uninstall-text">
+						<h4 class="gform-settings-panel__title"><?php printf( esc_html__( '%s', 'gravityforms' ), $this->get_short_title() ) ?></h4>
+						<div><?php printf( $this->extension_uninstall_message(), $this->get_short_title() ) ?></div>
+					</div>
+					<div class="addon-uninstall-button">
+						<input id="addon" name="addon" type="hidden" value="<?php echo $this->get_short_title(); ?>">
+						<button type="submit" aria-label="<?php printf( esc_html__( 'Uninstall %s', 'gravityforms'), $this->get_short_title() ); ?>" name="uninstall_addon" value="uninstall" class="button uninstall-addon red" onclick="return confirm('<?php echo esc_js( $this->uninstall_confirm_message() ); ?>');" onkeypress="return confirm('<?php echo esc_js( $this->uninstall_confirm_message() ); ?>');">
+							<i class="dashicons dashicons-trash"></i>
+							<?php esc_attr_e( 'Uninstall', 'gravityforms' ); ?>
+						</button>
+					</div>
+				</div>
+			</form>
+			<?php
+
 			return;
 		}
 


### PR DESCRIPTION
## Description
Uninstall messages appearing on Gravity Forms Uninstall Page for Gravity Flow Extensions aren't entirely accurate. For instance, uninstalling the Gravity Flow PDF extension does not remove all PDF extension settings. Only templates are removed.

This PR adds methods that can be overridden in extension (and feed extension) classes to provide custom messages on the uninstall page.

This resolves [gravityflow/backlog#112](https://github.com/gravityflow/backlog/issues/112)

## Testing instructions
1. Pick a Gravity Flow extension that extends the `Gravity_Flow_Extension` base class, say Gravity Flow Form Connector.
2. On the class `Gravity_Flow_Form_Connector`, add a method as follows: 
```
public function extension_uninstall_message() {
	return esc_html__( 'This is a custom uninstall message for %s appearing on uninstall page.', 'gravityforms' );
}
```
3. Go to Gravity Forms Uninstall Page (Settings > Uninstall). (`?page=gf_settings&subview=uninstall`)
4. Confirm the customized uninstall message for the Form Connector extension appears.
5. Pick a Gravity Flow Feed extension that extends the `Gravity_Flow_Feed_Extension` base class, say Gravity Flow Incoming Webhook.
6. Repeats steps 2-4, this time for Gravity Flow Incoming Webhook and confirm the custom uninstall message appears for it as well.

## Automated Test Enhancements
N/A
 
## Screenshots
N/A

## Documentation Changes
<!-- Are any documentation updates needed to co-incide with release? -->
<!-- Are any new documentation pages required to co-incide with the release? -->

## Checklist:
- [x] I've tested the code.
- [x] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->