### PR TITLE
Fix entry filter setting

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,0 +1,1 @@
+- Fixed an issue with the entry filter setting where the settings are not saved for the Update Fields step.

--- a/class-gravity-flow.php
+++ b/class-gravity-flow.php
@@ -3710,7 +3710,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
             	    v = $(this).find('.gform-filter-value').val();
                 filters.push({field : f, operator: o, value: v });
             });
-            var input = filterSetting.find('input.gaddon-hidden'),
+            var input = filterSetting.find('input[type=hidden]'),
                 mode = filterSetting.find('select[name=mode]').val(),
                 val = {
                     mode : mode,
@@ -3721,6 +3721,7 @@ jQuery('#setting-entry-filter-{$name}').gfFilterUI({$filter_settings_json}, {$va
         $('#setting-entry-filter-{$name}').on('change', 'select[name=mode]', setFilterValue);
 	    $('#setting-entry-filter-{$name}').on('change', '.gform-filter-operator', setFilterValue);
 	    $('#setting-entry-filter-{$name}').on('change blur', '.gform-filter-value', setFilterValue);
+	    $('#setting-entry-filter-{$name}').on('DOMSubtreeModified', setFilterValue);
     });
 })(jQuery);
 </script>";

--- a/css/form-settings.css
+++ b/css/form-settings.css
@@ -256,6 +256,11 @@ select.gform-filter-field, select.gform-filter-operator, input.gform-filter-valu
     position: relative;
 }
 
+#gform-no-filters{
+    align-items: flex-start!important;
+    height:40px;
+}
+
 .gform-settings-panel__content select[name="mode"] {
     width: 10%;
 }


### PR DESCRIPTION
## Description
This PR fixes an issue with the entry filter setting where the settings are not saved on Gravity Forms 2.5 and another issue where conditions cannot be removed on either 2.4 or 2.5. It also adjusts the space available for the no conditions message to prevent the icon from being cut off on 2.5.

Fixes https://github.com/gravityflow/backlog/issues/121

## Testing instructions
1. Add an Update Fields step
2. Select a form
3. Select "Conditional logic" for the entry lookup setting.
4. Add conditions.
5. Save & notice the settings are not saved on 2.5
6. Add more conditions and save while on this branch to check that the settings are saved.
7. Remove conditions and save to check that the conditions are removed after saving.

Double-check that there are no related regressions for the functionality of this setting on both 2.4 and 2.5.

## Checklist:
- [X] I've tested the code.
- [X] My code follows the WordPress code style. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code follows the inline documentation standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/ -->